### PR TITLE
[DOCS] 실시간 주식 데이터 명세(ETL) 및 아키텍처(ARC) 설계

### DIFF
--- a/docs/ARC/ARC-KIS-001.md
+++ b/docs/ARC/ARC-KIS-001.md
@@ -18,13 +18,13 @@
 
 ## 3. 데이터 흐름도 (Data Flow Sequence Diagram)
 
-![실시간 아키텍처 다이어그램](https://github.com/user-attachments/assets/5b131a4d-298e-4e9f-86bd-e2bb455f0422)
+![실시간 아키텍처 다이어그램](https://github.com/user-attachments/assets/f92b7f78-19d5-4abd-bf6f-18b793a15d37)
 
 ### 3.1 흐름 상세 설명 (Flow Description)
 위 시퀀스 다이어그램은 `초기 진입(Initial Load)`부터 `실시간 데이터 서빙(Serving)`까지의 전체 생명주기를 나타낸다.
 
 1.  **메타데이터 조회 (Initialization):**
-    * 사용자가 메인 페이지에 접속하면, Server는 **PostgreSQL**에서 관리 중인 '관심 종목 리스트(25개)'의 종목 코드를 조회한다.
+    * 사용자가 메인 페이지에 접속하면, Server는 **PostgreSQL**에서 관리 중인 '종목 리스트(100개)'의 종목 코드를 조회한다.
     * 이 단계에서는 종목명, 로고 등 변하지 않는 **정적 데이터**만 확보한다.
 
 2.  **실시간 스트림 연결 (Ingestion):**

--- a/docs/ARC/ARC-KIS-001.md
+++ b/docs/ARC/ARC-KIS-001.md
@@ -1,0 +1,41 @@
+# 실시간 주식 데이터 처리 아키텍처
+
+| 문서 ID | ARC-KIS-001   |
+| :--- |:--------------|
+| **문서 버전** | 1.0           |
+| **프로젝트** | AssetMind     |
+| **작성자** | 이재석           |
+| **작성일** | 2026년 01월 08일 |
+
+## 1. 개요
+본 문서는 한국투자증권(KIS) API를 활용하여 실시간 주가 정보를 처리하고 사용자에게 전달하는 **Real-time Data Pipeline**의 아키텍처를 정의한다.
+시스템은 `정적 데이터(DB)`와 `동적 데이터(Memory DB)`의 역할을 명확히 분리하여 성능과 데이터 무결성을 동시에 확보한다.
+
+## 2. 핵심 설계 원칙 (Design Principles)
+1.  **역할 분리 (Separation of Concerns):** DB는 '구독 대상' 메타데이터 관리, Redis는 '실시간 상태' 캐싱에 집중한다.
+2.  **고성능 캐싱 (High Performance Caching):** 고빈도(High-frequency) 체결 데이터는 Redis에 저장하여 DB 부하를 원천 차단한다.
+3.  **중앙화된 상태 관리:** 백엔드 서버가 다중 인스턴스로 확장되어도 Redis를 통해 실시간 데이터의 일관성(Consistency)을 유지한다.
+
+## 3. 데이터 흐름도 (Data Flow Sequence Diagram)
+
+![실시간 아키텍처 다이어그램](https://github.com/user-attachments/assets/5b131a4d-298e-4e9f-86bd-e2bb455f0422)
+
+### 3.1 흐름 상세 설명 (Flow Description)
+위 시퀀스 다이어그램은 `초기 진입(Initial Load)`부터 `실시간 데이터 서빙(Serving)`까지의 전체 생명주기를 나타낸다.
+
+1.  **메타데이터 조회 (Initialization):**
+    * 사용자가 메인 페이지에 접속하면, Server는 **PostgreSQL**에서 관리 중인 '관심 종목 리스트(25개)'의 종목 코드를 조회한다.
+    * 이 단계에서는 종목명, 로고 등 변하지 않는 **정적 데이터**만 확보한다.
+
+2.  **실시간 스트림 연결 (Ingestion):**
+    * 확보된 종목 코드를 이용해 **KIS Real-time Server**에 WebSocket 구독(Subscribe)을 요청한다.
+    * KIS 서버로부터 체결 데이터(Raw String)가 실시간으로 Push 된다.
+
+3.  **데이터 가공 및 캐싱 (Processing & Caching):**
+    * **Parsing:** 수신된 Raw Data를 `StockTickDto` 객체로 변환한다.
+    * **Caching:** 변환된 데이터를 **Redis**에 `Key-Value` 형태로 즉시 갱신(Update)한다. 이 과정은 DB 트랜잭션 없이 인메모리에서 고속으로 수행된다.
+
+4.  **데이터 서빙 (Serving):**
+    * Server는 **Redis**에 저장된 최신 상태의 데이터들을 조회(Get)한다.
+    * 거래대금 등 비즈니스 로직에 따라 `정렬(Sorting)`을 수행하여 `StockSummaryDto` 리스트를 생성한다.
+    * 최종적으로 Frontend에 완성된 리스트를 반환하여 화면을 렌더링한다.

--- a/docs/DTO/DTO-KIS-001.md
+++ b/docs/DTO/DTO-KIS-001.md
@@ -1,5 +1,12 @@
 # StockTickDto 클래스 구조 설계
 
+| 문서 ID | DTO-KIS-001   |
+| :--- |:--------------|
+| **문서 버전** | 1.0           |
+| **프로젝트** | AssetMind     |
+| **작성자** | 이재석           |
+| **작성일** | 2026년 01월 08일 |
+
 ## 1. 개요
 `StockTickDto`는 **실시간 주식 체결 원천 데이터 DTO** 로써, 파서(Parser)를 통해 Raw String을 시스템 내부에서 사용 가능한 형태(Object)로 변환한 불변 객체(Immutable Record)이다. 
 `List<StockTickDto>` 형식으로 프론트로 응답할 객체이다.

--- a/docs/DTO/DTO-KIS-001.md
+++ b/docs/DTO/DTO-KIS-001.md
@@ -1,0 +1,46 @@
+# StockTickDto 클래스 구조 설계
+
+## 1. 개요
+`StockTickDto`는 **실시간 주식 체결 원천 데이터 DTO** 로써, 파서(Parser)를 통해 Raw String을 시스템 내부에서 사용 가능한 형태(Object)로 변환한 불변 객체(Immutable Record)이다. 
+`List<StockTickDto>` 형식으로 프론트로 응답할 객체이다.
+
+## 2. 클래스 명세
+* **Package**: `com.assetmind.server_stokc.stock.dto` (상황에 따라 약간의 변경 가능성 있음)
+* **Type**: Java `record`
+* **Dependency**: Lombok (`@Builder`)
+
+## 3. 구현 코드 (초안)
+
+```java
+import java.math.BigDecimal;
+import lombok.Builder;
+
+/**
+ * 실시간 주식 체결 원천 데이터 DTO
+ * 한국투자증권 WebSocket 데이터를 파싱하여 저장
+ * record 타입으로 인한 불변성(Immutable) 보장
+ */
+@Builder
+public record StockTickDto(
+    String symbol,                   // 종목코드 (MKSC_SHRN_ISCD)
+    BigDecimal currentPrice,         // 현재가 (STCK_PRPR)
+    BigDecimal changeRate,           // 등락률 (PRDY_CTRT)
+    BigDecimal accumulatedVolume,    // 누적 거래량 (ACML_VOL)
+    BigDecimal accumulatedTradeValue // 누적 거래대금 (ACML_TR_PBMN)
+) {
+
+    /**
+     * 거래대금 조회 유틸리티 메서드 (Null-Safe)
+     * API 원본 데이터에 거래대금이 누락된 경우, [현재가 * 거래량]으로 대체 계산하여 반환
+     * 랭킹 정렬 및 화면 표시 시 이 메서드를 호출하여 사용
+     */
+    public BigDecimal getTradeValue() {
+        // + 원본 데이터가 유효하면 우선 사용 로직
+        ...
+        // + 방어 로직: 필수 값이 누락된 경우 0 반환
+        ...
+        
+        // + 계산된 거래대금 반환로직
+        return currentPrice.multiply(accumulatedVolume);
+    }
+}

--- a/docs/ETL/ETL-KIS-001.md
+++ b/docs/ETL/ETL-KIS-001.md
@@ -1,0 +1,36 @@
+# 실시간 주식 데이터 수집 명세서
+
+| 문서 ID     | ETL-KIS-001   |
+|:----------|:--------------|
+| **문서 버전** | 1.0           |
+| **프로젝트**  | AssetMind     |
+| **작성자**   | 이재석           |
+| **작성일**   | 2026년 01월 08일 |
+
+## 1. 개요
+본 문서는 한국투자증권(KIS) 실시간 웹소켓 API(`H0NXCNT0`)를 통해 수신되는 주식 체결 데이터 중, 서비스 구현에 필수적인 필드와 처리 규칙을 정의한다.
+
+## 2. 수집 대상 필드 (Raw Data Specification)
+> KIS API (국내주식 실시간체결가) 참조: https://apiportal.koreainvestment.com/apiservice-apiservice?/tryitout/H0NXCNT0
+* **Source**: 한국투자증권 WebSocket (Realtime)
+* **TR ID**: `H0NXCNT0` (주식체결가)
+* **Format**: `|` 구분자 문자열
+
+| Index | 필드 ID | 필드명 (Logical) | 타입 (Raw) | 설명                        | 비고 |
+| :--- | :--- | :--- | :--- |:--------------------------| :--- |
+| **0** | `MKSC_SHRN_ISCD` | **종목코드** | String | 종목 식별자 (예: 005930 [삼성전자]) | PK 역할 |
+| **2** | `STCK_PRPR` | **현재가** | String | 실시간 체결 가격                 | `BigDecimal` 변환 필수 |
+| **5** | `PRDY_CTRT` | **등락률** | String | 전일 대비 등락률 (%)             | 화면 색상 결정 (Red/Blue) |
+| **12** | `ACML_VOL` | **누적거래량** | String | 당일 장 시작 후 총 거래량           | 거래대금 산출 보조 |
+| **14** | `ACML_TR_PBMN` | **누적거래대금** | String | 당일 장 시작 후 총 거래 금액         | **정렬(Ranking) 기준 데이터** |
+
+## 3. 데이터 처리 규칙 (Business Rules)
+
+### 3.1 거래대금(Trade Value) 산출 로직
+일부 데이터 패킷에서 **누적거래대금(Index 14)** 필드가 null이거나 `0`으로 수신될 수 있다. 데이터의 정합성을 위해 아래 우선순위에 따라 값을 결정한다.
+* **1순위:** `누적거래대금(Index 14)` 값이 존재하면 해당 값을 사용.
+* **2순위:** 값이 없을 경우, **`현재가(Index 2) * 누적거래랑(Index 12)`** 공식을 사용하여 근사치 계산.
+
+### 3.2 데이터 타입 및 예외 처리
+* **정밀도 보장:** 모든 금액 및 비율 데이터는 부동소수점 오차 방지를 위해 Java `BicDecimal` 타입을 사용한다.
+* **Null Safety:** 파싱 중 `null`, `Empty String`, `NumberFormatError` 발생 시 시스템 중단 없이 해당 필드를 `0`(default)으로 처리한다.

--- a/docs/ETL/ETL-KIS-001.md
+++ b/docs/ETL/ETL-KIS-001.md
@@ -2,18 +2,18 @@
 
 | 문서 ID     | ETL-KIS-001   |
 |:----------|:--------------|
-| **문서 버전** | 1.0           |
+| **문서 버전** | 1.1           |
 | **프로젝트**  | AssetMind     |
 | **작성자**   | 이재석           |
 | **작성일**   | 2026년 01월 08일 |
 
 ## 1. 개요
-본 문서는 한국투자증권(KIS) 실시간 웹소켓 API(`H0NXCNT0`)를 통해 수신되는 주식 체결 데이터 중, 서비스 구현에 필수적인 필드와 처리 규칙을 정의한다.
+본 문서는 한국투자증권(KIS) 실시간 웹소켓 API(`H0UNCNT0`)를 통해 수신되는 주식 체결 데이터 중, 서비스 구현에 필수적인 필드와 처리 규칙을 정의한다.
 
 ## 2. 수집 대상 필드 (Raw Data Specification)
-> KIS API (국내주식 실시간체결가) 참조: https://apiportal.koreainvestment.com/apiservice-apiservice?/tryitout/H0NXCNT0
+> KIS API (국내주식 실시간체결가) 참조: https://apiportal.koreainvestment.com/apiservice-apiservice?/tryitout/H0UNCNT0
 * **Source**: 한국투자증권 WebSocket (Realtime)
-* **TR ID**: `H0NXCNT0` (주식체결가)
+* **TR ID**: `H0UNCNT0` (주식체결가)
 * **Format**: `|` 구분자 문자열
 
 | Index | 필드 ID | 필드명 (Logical) | 타입 (Raw) | 설명                        | 비고 |


### PR DESCRIPTION
## 📌 작업 내용
- **실시간 주식 데이터 파이프라인 구축을 위한 데이터 명세(ETL) 및 시스템 아키텍처(ARC) 설계를 완료했습니다.**
- 한국투자증권(KIS) WebSocket 데이터의 수집부터 가공, 저장(`Redis`), 서빙까지의 전 과정을 문서화했습니다.
- 데이터 정합성을 위한 `DTO` 구조를 정의하고, 예외 상황(Null Data)에 대한 비즈니스 처리 규칙을 수립했습니다.

## 🏗 기술적 의사결정 (핵심 변경 사유)

**1. 하이브리드 데이터 관리 전략 (DB + Redis)**
> 정적 데이터는 `PostgreSQL`, 동적 데이터는 `Redis`로 이원화하여 관리합니다.
- **부하 분산 및 성능 최적화:** 초당 수십 건 이상 발생하는 체결 데이터(`High-frequency Data`)를 RDB에 직접 갱신할 경우 발생할 트랜잭션 부하를 방지하기 위해, 실시간 시세 정보는 인메모리 저장소인 **Redis**에서 전담하도록 설계했습니다.
- **역할의 분리:** DB는 '구독 대상 관리(Metadata)'에, Redis는 '실시간 상태 서빙(State Serving)'에 집중하여 시스템 확장성을 확보했습니다.

**2. 금융 데이터 정합성을 위한 `BigDecimal` 전면 도입**
> `StockTickDto`의 모든 가격 및 등락률 필드에 `double` 대신 `BigDecimal`을 적용했습니다.
- **부동소수점 오차 방지:** 금전 데이터 처리 시 발생할 수 있는 미세한 연산 오차를 원천 차단했습니다.
- **포맷팅 일관성:** 프론트엔드 전달 시 소수점 처리가 일관되게 유지되도록 설계 단계에서 타입을 강제했습니다.

**3. 데이터 결측 시 Fallback 로직 수립 (ETL 명세)**
> API에서 `누적 거래대금` 필드가 비어있거나 0으로 내려오는 경우를 대비한 방어 로직을 정의했습니다.
- **데이터 가용성 확보:** 거래대금은 랭킹 산정의 핵심 지표이므로, 원천 데이터 누락 시 **`현재가 × 누적거래량`** 공식을 통해 근사치를 계산하여 시스템이 중단되지 않고 랭킹을 산출할 수 있도록 `Fail-safe` 전략을 명세서(`ETL-KIS-001`)에 포함했습니다.

## ✅ 주요 변경점
- **문서 추가 (`docs/`):**
    - `ETL-KIS-001.md`: 실시간 데이터 수집 필드 정의 및 변환 로직 명세.
    - `DTO-KIS-001.md`: 내부 시스템용 `StockTickDto` 클래스 구조 및 타입 정의.
    - `ARC-KIS-001.md`: 전체 시스템 아키텍처 다이어그램(Sequence Diagram 포함) 및 요약 기술
- **시각화 자료:**
    - `ARC-KIS-001` 내에 아키텍처 흐름도 및 시퀀스 다이어그램 추가 (Github Issue Image Link 활용).

## 📝 리뷰 포인트
- **아키텍처 적절성:** `ARC-KIS-001`에서 정의한 **[KIS -> Backend -> Redis -> Client]** 흐름이 실시간성을 보장하기에 적절한지 검토 부탁드립니다.
- **문서 ID 규칙:** `GUIDE-DOCS-001`에 따라 `ETL`(수집/변환), `DD`(데이터구조), `ARC`(아키텍처)로 분류 코드를 적용했습니다. 분류가 적절한지 확인해 주세요.