### PR TITLE
[Feat] User 도메인 모델링 및 인터페이스 설계

### DIFF
--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/BusinessException.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/BusinessException.java
@@ -1,0 +1,11 @@
+package com.assetmind.server_auth.global.error;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/ErrorCode.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/ErrorCode.java
@@ -1,0 +1,23 @@
+package com.assetmind.server_auth.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common 에러
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "서버 내부 오류가 발생했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C002", "잘못된 입력값입니다."),
+
+
+    // User Domain 에러
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 회원입니다."),
+    ALREADY_GET_USER_PERMISSION(HttpStatus.BAD_REQUEST, "U002", "이미 정식 회원입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/User.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/User.java
@@ -1,5 +1,7 @@
 package com.assetmind.server_auth.user.domain;
 
+import com.assetmind.server_auth.global.error.BusinessException;
+import com.assetmind.server_auth.global.error.ErrorCode;
 import com.assetmind.server_auth.user.domain.port.UserIdGenerator;
 import com.assetmind.server_auth.user.domain.vo.SocialID;
 import com.assetmind.server_auth.user.domain.vo.UserInfo;
@@ -65,7 +67,7 @@ public class User {
      */
     public void upgradeToRoleUser() {
         if (this.userRole == UserRole.USER) {
-            throw new IllegalStateException("이미 정식 회원입니다.");
+            throw new BusinessException(ErrorCode.ALREADY_GET_USER_PERMISSION);
         }
         this.userRole = UserRole.USER;
     }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/User.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/User.java
@@ -1,0 +1,72 @@
+package com.assetmind.server_auth.user.domain;
+
+import com.assetmind.server_auth.user.domain.port.UserIdGenerator;
+import com.assetmind.server_auth.user.domain.vo.SocialID;
+import com.assetmind.server_auth.user.domain.vo.UserInfo;
+import com.assetmind.server_auth.user.domain.type.UserRole;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+
+/**
+ * 우리 서비스의 루트 도메인 유저 객체
+ * 모든 유저와 관련된 VO 객체를 조합하여 비즈니스 로직을 수행
+ */
+@Getter
+public class User {
+    private final UUID id; // 도메인 객체 식별자
+
+    private final UserInfo userInfo; // 유저 정보
+    private final SocialID socialID; // 소셜 로그인 정보
+
+    // 상태 변경이 가능한 필드
+    private UserRole userRole;
+
+    /**
+     * 생성자는 private로 제한하여 팩토리 메서드를 통해서만 객체가 생성되도록 강제
+     */
+    private User(UUID id, UserInfo userInfo, SocialID socialID, UserRole userRole) {
+        this.id = id;
+        this.userInfo = userInfo;
+        this.socialID = socialID;
+        this.userRole = userRole;
+    }
+
+    /**
+     * DB에서 유저 복원시 사용되는 메서드
+     * DB의 id과 도메인 객체의 id가 같아야함
+     * @param id - DB에 저장된 UUID
+     * @param userInfo - DB에 저장된 유저 정보
+     * @param socialID - DB에 저장된 소셜 정보
+     * @param userRole - DB에 저장된 유저 권한
+     * @return DB에 존재하는 User 객체
+     */
+    public static User withId(UUID id, UserInfo userInfo, SocialID socialID, UserRole userRole) {
+        return new User(id, userInfo, socialID, userRole);
+    }
+
+    /**
+     * 초기 유저 생성시 GUEST(게스트) 역할로 유저를 생성
+     * @param userInfo - 유저 정보
+     * @param socialID - 소셜 정보
+     * @param idGenerator - ID 생성자 인터페이스(ID 생성 방식 정의)
+     * @return 유저 객체
+     */
+    public static User createGuest(UserInfo userInfo, SocialID socialID, UserIdGenerator idGenerator) {
+        // 유저 정보 및 소셜 정보가 Null 값인지 한번 더 검증
+        Objects.requireNonNull(userInfo);
+        Objects.requireNonNull(socialID);
+
+        return new User(idGenerator.generate(), userInfo, socialID, UserRole.GUEST);
+    }
+
+    /**
+     * 유저를 USER(정회원) 역할로 변경
+     */
+    public void upgradeToRoleUser() {
+        if (this.userRole == UserRole.USER) {
+            throw new IllegalStateException("이미 정식 회원입니다.");
+        }
+        this.userRole = UserRole.USER;
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/UserRole.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/UserRole.java
@@ -1,0 +1,15 @@
+package com.assetmind.server_auth.user.domain;
+
+public enum UserRole {
+    /**
+     * GUEST: OAuth2 최초 가입 시 부여되는 권한, 본인 인증 X
+     * 본인 인증 전이므로 제한된 기능만 접근 가능
+     */
+    GUEST,
+
+    /**
+     * USER: 본인 인증을 완료한 정식 사용자
+     * 모든 일반적인 서비스 접근 가능
+     */
+    USER
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/port/UserIdGenerator.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/port/UserIdGenerator.java
@@ -1,0 +1,22 @@
+package com.assetmind.server_auth.user.domain.port;
+
+import java.util.UUID;
+
+/**
+ * 도메인의 식별자 생성 전략을 정의하는 인터페이스
+ * 도메인 계층은 어떤 기술을 사용하여 자신의 ID가 생성되는지 알 필요없이
+ * 해당 인터페이스를 통 식별자를 주입받아 사용
+ * 이를 통해
+ * 도메인이 외부 기술을 몰라도 되는 도메인의 순수성을 충족시킬 수 있고,
+ * DIP(의존성 역전 원칙)을 달성하게 되고
+ * 도메인이 구체적인 기술에 의존하지 않으므로 확장성 있는 설계가 가능하다.
+ */
+public interface UserIdGenerator {
+
+    /**
+     * 새로운 User ID를 생성
+     * @return 생성된 UUID
+     */
+    UUID generate();
+
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/port/UserRepository.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/port/UserRepository.java
@@ -1,0 +1,37 @@
+package com.assetmind.server_auth.user.domain.port;
+
+import com.assetmind.server_auth.user.domain.User;
+import com.assetmind.server_auth.user.domain.vo.SocialID;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * User 도메인 객체 저장소의 행동을 정의
+ * 해당 인터페이스를 통해 User 도메인 객체의 데이터를 저장하고 조회
+ * 구체적인 구현은 Infrastructure 계층에서 담당
+ */
+public interface UserRepository {
+
+    /**
+     * User를 저장하거나 수정
+     * @param user - 저장할 User 도메인 객체
+     * @return 저장 및 수정된 User 도메인 객체
+     */
+    User save(User user);
+
+    /**
+     * User 도메인 객체를 DB에서 UUID로 조회
+     * @param id - User 도메인 객체의 식별자
+     * @return User 도메인 객체
+     */
+    Optional<User> findById(UUID id);
+
+    /**
+     * User 도메인 객체를 DB에서 소셜 정보로 조회
+     * 추후의 Provider(카카오/구글 ..) 이메일이 변경되어도 ProviderID는 변하지 않으므로
+     * Provider와 ProviderID의 조합으로 User 도메인 객체를 조회
+     * @param socialId - User 도메인 객체의 소셜 정보(Provider + ProviderID)
+     * @return User 도메인 객체
+     */
+    Optional<User> findBySocialId(SocialID socialId);
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/type/Provider.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/type/Provider.java
@@ -1,0 +1,9 @@
+package com.assetmind.server_auth.user.domain.type;
+
+/**
+ * OAuth2 방식의 소셜로그인 제공하는 곳
+ */
+public enum Provider {
+    GOOGLE, // 구글
+    KAKAO   // 카카오
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/type/UserRole.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/type/UserRole.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_auth.user.domain;
+package com.assetmind.server_auth.user.domain.type;
 
 public enum UserRole {
     /**

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/Email.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/Email.java
@@ -1,0 +1,32 @@
+package com.assetmind.server_auth.user.domain.vo;
+
+/**
+ * User의 이메일 VO 객체
+ * @param value - 서비스에 사용될 유저 이메일 값
+ */
+public record Email(
+        String value
+) {
+
+    /**
+     * email의 값 유효성 검증
+     * @param value
+     */
+    public Email {
+        if(value == null || !checkValidation(value)) {
+            throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다.");
+        }
+    }
+
+    /**
+     * 이메일의 정규 형식 검사
+     * [\w-\.]+ : 영어, 숫자, 언더바, 하이픈(-), 점(.)으로 이루어진 문자가 1가지 이상 존재 그리고 해당 문자 덩어리가 반복 가능 (이메일 아이디 부분)
+     * @ : 반드시 필요
+     * ([\w-]+\.)+ : 영어, 숫자, 언더바, 하이픈이 포함된 덩어리에 점이 추가된 덩어리가 반복 가능 (도메인 부분, 예) wotjr.co.)
+     * [/w-]{2,} : 영어, 숫자, 언더바, 하이픈으로 이루어졌으면서 2글자 이상 문자 (도메인의 마지막 부분, 예) kr)
+     */
+    private boolean checkValidation(String value) {
+        return value.matches("^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,}$");
+    }
+
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/SocialID.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/SocialID.java
@@ -1,0 +1,28 @@
+package com.assetmind.server_auth.user.domain.vo;
+
+import com.assetmind.server_auth.user.domain.type.Provider;
+
+/**
+ * 소셜 로그인 식별자 정보
+ * @param provider - 소셜 로그인 제공하는 곳
+ * @param providerID - 식별 ID
+ */
+public record SocialID(
+        Provider provider,
+        String providerID
+) {
+    public SocialID {
+        if (provider == null) {
+            throw new IllegalArgumentException("소셜 로그인 제공자는 필수 입니다.");
+        }
+
+        if (providerID == null || providerID.isBlank()) {
+            throw new IllegalArgumentException("소셜 로그인 식별값은 필수 입니다.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return provider.toString() + " : " + providerID;
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/UserInfo.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/UserInfo.java
@@ -21,18 +21,4 @@ public record UserInfo(
         Objects.requireNonNull(email);
         Objects.requireNonNull(username);
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof UserInfo userInfo)) {
-            return false;
-        }
-        return Objects.equals(email, userInfo.email) && Objects.equals(username,
-                userInfo.username);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(email, username);
-    }
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/UserInfo.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/UserInfo.java
@@ -1,0 +1,38 @@
+package com.assetmind.server_auth.user.domain.vo;
+
+import java.util.Objects;
+
+/**
+ * 유저의 정보를 담은 VO 객체
+ * @param email - 유저 이름
+ * @param username - 유저 이메일
+ */
+public record UserInfo(
+        Email email,
+        Username username
+) {
+
+    /**
+     * 유저를 생성할 때 들어온 유저의 정보 값이 null인지 확인
+     * @param email
+     * @param username
+     */
+    public UserInfo {
+        Objects.requireNonNull(email);
+        Objects.requireNonNull(username);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof UserInfo userInfo)) {
+            return false;
+        }
+        return Objects.equals(email, userInfo.email) && Objects.equals(username,
+                userInfo.username);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(email, username);
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/Username.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/Username.java
@@ -1,0 +1,24 @@
+package com.assetmind.server_auth.user.domain.vo;
+
+/**
+ * User의 유저 이름 VO 객체
+ * @param value - 서비스에 사용될 유저 이름 값
+ */
+public record Username(
+        String value
+) {
+
+    /**
+     * username의 값 유효성 검증
+     * @param value
+     */
+    public Username {
+        if(value == null || checkLength(value)) {
+            throw new IllegalArgumentException("유저 이름은 2자 이상 15자 이하여야 합니다.");
+        }
+    }
+
+    private boolean checkLength(String value) {
+        return value.length() < 2 || value.length() > 15;
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/UserTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/UserTest.java
@@ -1,0 +1,118 @@
+package com.assetmind.server_auth.user.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.assetmind.server_auth.global.error.BusinessException;
+import com.assetmind.server_auth.global.error.ErrorCode;
+import com.assetmind.server_auth.user.domain.port.UserIdGenerator;
+import com.assetmind.server_auth.user.domain.type.Provider;
+import com.assetmind.server_auth.user.domain.type.UserRole;
+import com.assetmind.server_auth.user.domain.vo.Email;
+import com.assetmind.server_auth.user.domain.vo.SocialID;
+import com.assetmind.server_auth.user.domain.vo.UserInfo;
+import com.assetmind.server_auth.user.domain.vo.Username;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * User domain 단위 테스트 작성
+ * 입력값 유효성 검증 로직 확인
+ * 비즈니스 로직 확인
+ */
+class UserTest {
+
+    // 테스트용 더미 데이터 준비
+    private final Email validEmail = new Email("test@email.com");
+    private final Username validUsername = new Username("이재석동동동");
+    private final UserInfo validUserInfo = new UserInfo(new Email("test@email.com"), new Username("이재석동동동"));
+    private final SocialID validSocialID = new SocialID(Provider.KAKAO, "testID1234");
+
+    // ID 생성기 Stub (고정된 UUID 반환)
+    private final UUID FIXED_UUID = UUID.fromString("dea7b2fb-e7ac-4c45-86cb-9e0e5cd81e93");
+    private final UserIdGenerator idGenerator = () -> FIXED_UUID;
+
+    @Nested
+    @DisplayName("신규 유저 생성 (createGuest)")
+    class CreateGuest {
+
+        @Test
+        @DisplayName("성공: 유효한 정보로 GUEST 유저를 생성한다.")
+        void givenValidInfo_whenCreateGuest_thenCreated() {
+            // when
+            User user = User.createGuest(validUserInfo, validSocialID, idGenerator);
+
+            // then
+            assertThat(user.getId()).isEqualTo(FIXED_UUID);
+            assertThat(user.getUserRole()).isEqualTo(UserRole.GUEST);
+            assertThat(user.getSocialID()).isEqualTo(validSocialID);
+            assertThat(user.getUserInfo().email()).isEqualTo(validEmail);
+            assertThat(user.getUserInfo().username()).isEqualTo(validUsername);
+        }
+
+        @Test
+        @DisplayName("실패: 필수 정보(UserInfo)가 없으면 생성할 수 없다.")
+        void givenNullUserInfo_whenCreateGuest_thenThrowException() {
+            // when & then
+            assertThatThrownBy(() -> User.createGuest(null, validSocialID, idGenerator))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 필수 정보(SocialID)가 없으면 생성할 수 없다.")
+        void givenNullSocialID_whenCreateGuest_thenThrowException() {
+            // when & then
+            assertThatThrownBy(() -> User.createGuest(validUserInfo, null, idGenerator))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 등급 업그레이드 (upgradeToRoleUser)")
+    class UpgradeRole {
+
+        @Test
+        @DisplayName("성공: GUEST 상태인 유저가 USER로 승격된다.")
+        void givenGuestRoleUser_whenUpgradeRole_thenUpgradeToUser() {
+            // given
+            User guestUser = User.createGuest(validUserInfo, validSocialID, idGenerator);
+
+            // when
+            guestUser.upgradeToRoleUser();
+
+            // then
+            assertThat(guestUser.getUserRole()).isEqualTo(UserRole.USER);
+        }
+
+        @Test
+        @DisplayName("실패: 이미 USER인 경우 BusinessException이 발생한다.")
+        void givenUserRoleUser_whenUpgradeRole_thenThrowException() {
+            // given
+            User user = User.createGuest(validUserInfo, validSocialID, idGenerator);
+            user.upgradeToRoleUser(); // 먼저 USER(정회원)으로 상태 변경
+
+            // when & then
+            assertThatThrownBy(user::upgradeToRoleUser)
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.ALREADY_GET_USER_PERMISSION);
+        }
+    }
+
+    @Test
+    @DisplayName("성공: DB에 저장된 ID와 상태를 그대로 복원한다.")
+    void givenStoredUserId_whenWithId_thenGetValidUser() {
+        // given
+        // db에 해당 dbId로 저장되었다고 가정
+        UUID dbId = UUID.randomUUID();
+        UserRole dbRole = UserRole.USER;
+
+        // when
+        User restoredUser = User.withId(dbId, validUserInfo, validSocialID, dbRole);
+
+        // then
+        assertThat(restoredUser.getId()).isEqualTo(dbId); // ID가 새로 생성되지 않고 유지됨
+        assertThat(restoredUser.getUserRole()).isEqualTo(UserRole.USER);
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/vo/EmailTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/vo/EmailTest.java
@@ -1,0 +1,41 @@
+package com.assetmind.server_auth.user.domain.vo;
+
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Email VO 객체 단위 테스트
+ * 입력값 유효성 검증 로직 확인
+ */
+@DisplayName("Email VO 객체 단위 테스트")
+class EmailTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"test@naver.com", "user.name@gmail.co.kr", "123@kakao.com"})
+    @DisplayName("성공: 올바른 이메일 형식이면 생성된다.")
+    void givenValidEmail_whenNewEmail_thenCreated(String value) {
+        // given = @ValueSource
+
+        // when
+        Email email = new Email(value);
+
+        // then
+        assertThat(email.value()).isEqualTo(value);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid-email", "test@", "@gmail.com", "test@.com"})
+    @DisplayName("실패: 이메일 형식이 올바르지 않으면 예외가 발생한다.")
+    void givenInvalidEmail_whenNewEmail_thenThrowException(String value) {
+        // given = @ValueSource
+
+        // when & then
+        assertThatThrownBy(() -> new Email(value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("유효하지 않은 이메일 형식입니다.");
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/vo/SocialIDTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/vo/SocialIDTest.java
@@ -1,0 +1,70 @@
+package com.assetmind.server_auth.user.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.assetmind.server_auth.user.domain.type.Provider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+/**
+ * SocailID VO 객체 단위 테스트
+ * 입력값 유효성 검증 로직 확인
+ */
+class SocialIDTest {
+
+    @Test
+    @DisplayName("성공: 올바른 Provider와 ProviderID가 주어지면 정상적으로 객체를 생성한다.")
+    void givenValidSocialInfo_whenNewSocialID_thenCreated() {
+        // given
+        Provider provider = Provider.GOOGLE;
+        String providerId = "testID1234";
+
+        // when
+        SocialID socialID = new SocialID(provider, providerId);
+
+        // then
+        assertThat(socialID.provider()).isEqualTo(provider);
+        assertThat(socialID.providerID()).isEqualTo(providerId);
+    }
+
+    @Test
+    @DisplayName("실패: Provider가 null이면 예외가 발생한다.")
+    void givenInvalidProvider_whenNewSocialID_thenThrowException() {
+        // given
+        Provider provider = null;
+        String providerId = "testID1234";
+
+        // when & then
+        assertThatThrownBy(() -> new SocialID(provider, providerId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("소셜 로그인 제공자는 필수 입니다.");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("실패: ProviderId가 null이거나 공백이면 예외가 발생한다.")
+    void givenInvalidProviderId_whenNewSocialID_thenThrowException(String providerId) {
+        // given = @NullAndEmptySource
+
+        // when & then
+        assertThatThrownBy(() -> new SocialID(Provider.GOOGLE, providerId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("소셜 로그인 식별값은 필수 입니다.");
+    }
+
+    @Test
+    @DisplayName("성공: toString()이 지정된 포맷(Provider : ProviderId)로 출력된다.")
+    void givenSocialID_whenToString_thenValidFormat() {
+        // given
+        SocialID socialID = new SocialID(Provider.GOOGLE, "testID1234");
+
+        // when
+        String format = socialID.toString();
+
+        // then
+        assertThat(format).isEqualTo("GOOGLE : testID1234");
+    }
+
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/vo/UserInfoTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/vo/UserInfoTest.java
@@ -1,0 +1,37 @@
+package com.assetmind.server_auth.user.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * UserInfo VO 객체 단위 테스트
+ * 입력값 유효성 검증 로직 테스트
+ */
+@DisplayName("UserInfo VO 객체 단위 테스트")
+class UserInfoTest {
+
+    @Test
+    @DisplayName("성공: 유효한 Email, Username이 주어지면 객체가 생성된다.")
+    void givenValidEmailAndUsername_whenNewUserInfo_thenCreated() {
+        // given
+        Email email = new Email("test@kakao.com");
+        Username username = new Username("이재석동동동");
+
+        // when
+        UserInfo userInfo = new UserInfo(email, username);
+
+        // then
+        assertThat(userInfo.email()).isEqualTo(email);
+        assertThat(userInfo.username()).isEqualTo(username);
+    }
+
+    @Test
+    @DisplayName("실패: Email, Username이 null이면 예외가 발생한다.")
+    void givenInValidEmailAndUsername_whenNewUserInfo_thenThrowException() {
+        // given & when & then
+        assertThatThrownBy(() -> new UserInfo(null, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/vo/UsernameTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/vo/UsernameTest.java
@@ -1,0 +1,42 @@
+package com.assetmind.server_auth.user.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Username VO 객체 단위 테스트
+ * 입력값 유효성 검증 로직 확인
+ */
+@DisplayName("Username VO 객체 단위 테스트")
+class UsernameTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"테슽", "테스트123", "이글자는15글자허용테스트입니"})
+    @DisplayName("성공: 올바른 유저 이름 형식이면 생성된다.")
+    void givenValidUsername_whenNewUsername_thenCreated(String value) {
+        // given = @ValueSource
+
+        // when
+        Username username = new Username(value);
+
+        // then
+        assertThat(username.value()).isEqualTo(value);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "테", "이글자는16글자실패테스트입니다"})
+    @DisplayName("실패: 2글자 미만 15글자 초과 유저 이름은 예외가 발생한다.")
+    void givenInvalidUsername_whenNewUsername_thenThrowException(String value) {
+        // given = @ValueSource
+
+        // when & then
+        assertThatThrownBy(() -> new Username(value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("유저 이름은 2자 이상 15자 이하여야 합니다.");
+    }
+}

--- a/docs/TCS/TCS-USR-001.md
+++ b/docs/TCS/TCS-USR-001.md
@@ -1,0 +1,48 @@
+# [TCS] 사용자(User) 도메인 모듈 테스트 명세서
+
+| 문서 ID | **TCS-USR-001**                |
+| :--- |:-------------------------------|
+| **문서 버전** | 1.0                            |
+| **프로젝트** | AssetMind                      |
+| **작성자** | 이재석                            |
+| **작성일** | 2026년 01월 15일                  |
+| **관련 모듈** | `apps/server-auth/user/domain` |
+
+## 1. 개요 (Overview)
+
+본 문서는 AssetMind 인증 서버의 핵심 애그리거트 루트인 **`User`** 객체의 비즈니스 로직 및 팩토리 메서드를 검증하기 위한 단위 테스트(Unit Test) 명세이다.
+모든 테스트는 외부 의존성(DB, Network)을 배제한 상태에서 수행되며, **BDD(Given-When-Then)** 스타일을 따른다.
+
+### 1.1. 테스트 환경
+- **Framework:** JUnit 5, AssertJ
+- **Target Class:** `UserTest`
+- **Key Verification:**
+    - **Creation:** 신규 가입 시 ID 주입 및 초기 상태(GUEST) 검증
+    - **Validation:** 필수 정보 누락 시 방어 로직(Null Check) 검증
+    - **State Transition:** 권한 승격 로직 및 중복 승격 방지 검증
+    - **Reconstitution:** DB 데이터 기반 객체 복원 검증
+
+---
+
+## 2. Domain Entity 테스트 명세
+> **대상 클래스:** `UserTest`
+> **검증 목표:** 애그리거트 루트(`User`)의 무결성 및 비즈니스 규칙 준수 보장
+
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **ENT-001** | `givenValidInfo_whenCreateGuest_`<br>`thenCreated`<br>👉 **유효한 정보로 GUEST 유저를 생성한다.** | **Stub Generator**<br>(고정된 UUID 반환)<br>**Valid VOs**<br>(UserInfo, SocialID) | **`User.createGuest()`** | 1. `id`가 Stubbing된 UUID와 일치한다.<br>2. `userRole`이 **GUEST**이다.<br>3. `socialID`, `userInfo` 필드가 정상 매핑된다. |
+| **ENT-002** | `givenNullUserInfo_whenCreateGuest_`<br>`thenThrowException`<br>👉 **필수 정보(UserInfo)가 없으면 생성할 수 없다.** | **UserInfo 누락**<br>(`null` 주입) | **`User.createGuest()`** | 1. `NullPointerException` 발생. |
+| **ENT-003** | `givenNullSocialID_whenCreateGuest_`<br>`thenThrowException`<br>👉 **필수 정보(SocialID)가 없으면 생성할 수 없다.** | **SocialID 누락**<br>(`null` 주입) | **`User.createGuest()`** | 1. `NullPointerException` 발생. |
+| **ENT-004** | `givenGuestRoleUser_whenUpgradeRole_`<br>`thenUpgradeToUser`<br>👉 **GUEST 상태인 유저가 USER로 승격된다.** | **GUEST 유저**<br>(`createGuest`로 생성됨) | **`upgradeToRoleUser()`** | 1. `userRole` 상태가 **USER**로 변경된다. |
+| **ENT-005** | `givenUserRoleUser_whenUpgradeRole_`<br>`thenThrowException`<br>👉 **이미 USER인 경우 중복 승격 시 예외가 발생한다.** | **USER 유저**<br>(이미 승격 완료된 상태) | **`upgradeToRoleUser()`** | 1. `BusinessException` 발생.<br>2. ErrorCode: `ALREADY_GET_USER_PERMISSION` 확인. |
+| **ENT-006** | `givenStoredUserId_whenWithId_`<br>`thenGetValidUser`<br>👉 **DB 데이터 복원 시 ID와 상태를 그대로 유지한다.** | **DB 데이터 가정**<br>(Random UUID, Role=USER) | **`User.withId()`** | 1. ID가 새로 생성되지 않고 **입력값(DB ID)**과 일치한다.<br>2. Role 상태가 **USER**로 유지된다. |
+
+---
+
+## 3. 테스트 결과 요약
+
+### 3.1. 수행 결과
+| 구분 | 전체 케이스 | Pass | Fail | 비고 |
+| :--- | :---: | :---: | :---: | :--- |
+| **User Entity** | 6 | 6 | 0 | 팩토리 메서드, Null 방어, 상태 변경 로직 검증 완료 |
+| **합계** | **6** | **6** | **0** | **Pass** ✅ |


### PR DESCRIPTION
## 📌 작업 내용
- **DDD(Domain-Driven Design) 원칙에 기반한 User 도메인 모델과 테스트 환경을 구축했습니다.**
- 외부 의존성(DB, Web) 없이 순수 자바 코드로 동작하는 도메인 계층(`domain`)을 구현하여 비즈니스 로직의 응집도를 높였습니다.
- 도메인 객체의 무결성을 검증하기 위한 **단위 테스트(Unit Test)** 코드를 작성하고, 이를 문서화한 `테스트 명세서(TCS)`를 산출했습니다.

## 🏗 기술적 의사결정 (핵심 변경 사유)

**1. 팩토리 메서드 패턴과 생성자 캡슐화**
> `User` 객체의 무분별한 생성을 막고, 생성 의도를 명확히 하기 위해 생성자를 `private`으로 닫았습니다.
- **객체 생성의 이원화:**
    - `createGuest`: 신규 가입 시 사용되며, `UserIdGenerator`를 통해 **새로운 UUID**를 발급받습니다.
    - `withId`: DB에서 조회 시 사용되며, 기존에 저장된 **ID와 상태를 그대로 복원(Reconstitution)**합니다.
- **이유:** '신규 생성'과 'DB 로드'는 엄연히 다른 라이프사이클을 가지므로, 이를 메서드 레벨에서 명확히 분리하여 데이터 오염을 방지했습니다.

**2. 불변 식별자 `SocialID` 도입 (OAuth2 특성 반영)**
> 고객의 소셜 이메일은 변경될 수 있는 값이므로, 변하지 않는 식별자인 `Provider` + `TargetID` 조합을 사용했습니다.
- **문제점:** 소셜 로그인 제공자(Kakao, Google)의 이메일은 사용자가 변경하거나 비공개 처리할 수 있어 고유 식별자(Key)로 부적합합니다.
- **해결책:** `SocialID`라는 Value Object(VO)를 만들어 `Provider`와 `TargetID`(고유번호)를 묶어서 관리함으로써, 이메일이 바뀌어도 동일 사용자로 식별할 수 있게 설계했습니다.

**3. 예외 처리 전략의 분리 (Validation vs Business)**
> '잘못된 입력'과 '비즈니스 규칙 위반'을 명확히 구분하여 예외를 던지도록 설계했습니다.
- **VO (Validation):** 객체 생성 시점의 값 검증 실패는 `IllegalArgumentException`(표준 예외)을 사용하여, 시스템 외적인 입력 오류임을 명시했습니다.
- **Entity (Business):** '권한 중복 승격'과 같은 상태 오류는 `BusinessException` + `ErrorCode`를 사용하여, 클라이언트에게 구체적인 에러 사유를 전달할 수 있도록 했습니다.

## ✅ 주요 변경점
- **`domain` 패키지 구현:**
    - **Aggregate Root:** `User` (핵심 비즈니스 로직 포함)
    - **Value Objects:** `UserInfo`, `Email`, `SocialID`, `Username` (`record` 기반 불변 객체)
    - **Ports:** `UserIdGenerator`, `UserRepository` (인프라스트럭처와의 연결 고리)
- **테스트 구현:**
    - `UserTest`: BDD 스타일의 애그리거트 단위 테스트.
    - `TCS-USR-001.md`: 테스트 시나리오와 결과를 정리한 명세서 파일 추가.

## 📝 리뷰 포인트
- **VO 검증 로직:** `UserInfo`, `SocialID` 등 각 VO 내부의 `Validation` 로직이 비즈니스 요구사항(길이 제한, 포맷 등)을 잘 반영하고 있는지 검토 바랍니다.