### PR TITLE
[Feat] 인프라스트럭처 구현 - DB 어댑터

### DIFF
--- a/apps/server-auth/build.gradle
+++ b/apps/server-auth/build.gradle
@@ -6,10 +6,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'
 }
 

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/config/JpaConfig.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/config/JpaConfig.java
@@ -1,0 +1,13 @@
+package com.assetmind.server_auth.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+/**
+ * Jpa 관련 설정
+ */
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/config/SecurityConfig.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.assetmind.server_auth.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.socket.EnableWebSocketSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/**
+ * 보안 관련 설정
+ */
+@Configuration
+@EnableWebSocketSecurity
+public class SecurityConfig {
+
+    /**
+     * 비밀번호 암호화 모듈
+     */
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/User.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/User.java
@@ -80,4 +80,16 @@ public class User {
         this.socialID = socialID;
         this.userRole = UserRole.USER;
     }
+
+    public String getEmailValue() {
+        return this.userInfo.email().value();
+    }
+
+    public String getUsernameValue() {
+        return this.userInfo.username().value();
+    }
+
+    public String getPasswordValue() {
+        return this.password.value();
+    }
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/SocialID.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/SocialID.java
@@ -11,15 +11,6 @@ public record SocialID(
         Provider provider,
         String providerID
 ) {
-    public SocialID {
-        if (provider == null) {
-            throw new IllegalArgumentException("소셜 로그인 제공자는 필수 입니다.");
-        }
-
-        if (providerID == null || providerID.isBlank()) {
-            throw new IllegalArgumentException("소셜 로그인 식별값은 필수 입니다.");
-        }
-    }
 
     @Override
     public String toString() {

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserEntity.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserEntity.java
@@ -8,10 +8,13 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 /**
  * User 도메인의 영속성 정보를 DB에 저장하는 도메인의 엔티티
@@ -45,6 +48,14 @@ public class UserEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserRole role;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
 
     public UserEntity(UUID id, String email, String username, String password,
             Provider socialProvider, String socialProviderId, UserRole role)

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserEntity.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserEntity.java
@@ -39,22 +39,22 @@ public class UserEntity {
     @Column(name = "social_provider", nullable = true)
     private Provider socialProvider;
 
-    @Column(name = "social_id", nullable = true)
-    private String socialId;
+    @Column(name = "social_provider_id", nullable = true)
+    private String socialProviderId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserRole role;
 
     public UserEntity(UUID id, String email, String username, String password,
-            Provider socialProvider, String socialId, UserRole role)
+            Provider socialProvider, String socialProviderId, UserRole role)
     {
         this.id = id;
         this.email = email;
         this.username = username;
         this.password = password;
         this.socialProvider = socialProvider;
-        this.socialId = socialId;
+        this.socialProviderId = socialProviderId;
         this.role = role;
     }
 

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserEntity.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserEntity.java
@@ -1,0 +1,61 @@
+package com.assetmind.server_auth.user.infrastructure.persistence;
+
+import com.assetmind.server_auth.user.domain.type.Provider;
+import com.assetmind.server_auth.user.domain.type.UserRole;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * User 도메인의 영속성 정보를 DB에 저장하는 도메인의 엔티티
+ */
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserEntity {
+
+    @Id
+    @Column(columnDefinition = "uuid")
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_provider", nullable = true)
+    private Provider socialProvider;
+
+    @Column(name = "social_id", nullable = true)
+    private String socialId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    public UserEntity(UUID id, String email, String username, String password,
+            Provider socialProvider, String socialId, UserRole role)
+    {
+        this.id = id;
+        this.email = email;
+        this.username = username;
+        this.password = password;
+        this.socialProvider = socialProvider;
+        this.socialId = socialId;
+        this.role = role;
+    }
+
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserEntity.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserEntity.java
@@ -4,10 +4,12 @@ import com.assetmind.server_auth.user.domain.type.Provider;
 import com.assetmind.server_auth.user.domain.type.UserRole;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -15,14 +17,21 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * User 도메인의 영속성 정보를 DB에 저장하는 도메인의 엔티티
  */
 @Entity
-@Table(name = "users")
+@Table(name = "users", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_users_social",
+                columnNames = {"social_provider", "social_provider_id"}
+        )
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class UserEntity {
 
     @Id

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserEntityMapper.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserEntityMapper.java
@@ -1,0 +1,52 @@
+package com.assetmind.server_auth.user.infrastructure.persistence;
+
+import com.assetmind.server_auth.user.domain.User;
+import com.assetmind.server_auth.user.domain.type.Provider;
+import com.assetmind.server_auth.user.domain.vo.Email;
+import com.assetmind.server_auth.user.domain.vo.Password;
+import com.assetmind.server_auth.user.domain.vo.SocialID;
+import com.assetmind.server_auth.user.domain.vo.UserInfo;
+import com.assetmind.server_auth.user.domain.vo.Username;
+import org.springframework.stereotype.Component;
+
+/**
+ * Domain(User) <-> Entity(UserEntity) 변환 매퍼
+ */
+@Component
+public class UserEntityMapper {
+
+    public UserEntity toEntity(User user) {
+        Provider provider = (user.getSocialID().provider() != null) ? user.getSocialID().provider() : null;
+        String socialId = (user.getSocialID().providerID() != null) ? user.getSocialID().providerID() : null;
+
+        return new UserEntity(
+                user.getId(),
+                user.getEmailValue(),
+                user.getUsernameValue(),
+                user.getPasswordValue(),
+                provider,
+                socialId,
+                user.getUserRole()
+        );
+    }
+
+    public User toDomain(UserEntity userEntity) {
+        UserInfo userInfo = new UserInfo(new Email(userEntity.getEmail()),
+                new Username(userEntity.getUsername()));
+
+        Password password = new Password(userEntity.getPassword());
+
+        SocialID socialID = null;
+        if (userEntity.getSocialProvider() != null && userEntity.getSocialProviderId() != null) {
+            socialID = new SocialID(userEntity.getSocialProvider(), userEntity.getSocialProviderId());
+        }
+
+        return User.withId(
+                userEntity.getId(),
+                userInfo,
+                password,
+                socialID,
+                userEntity.getRole()
+        );
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserJpaRepository.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserJpaRepository.java
@@ -1,0 +1,22 @@
+package com.assetmind.server_auth.user.infrastructure.persistence;
+
+import com.assetmind.server_auth.user.domain.type.Provider;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Spring Data JPA를 Repository 구현체에서 사용하기 위한 인터페이스 정의
+ */
+public interface UserJpaRepository extends JpaRepository<UserEntity, UUID> {
+
+    @Query("SELECT u "
+            + "FROM UserEntity u "
+            + "WHERE u.socialProvider = :provider AND u.socialProviderId = :provider_id")
+    Optional<UserEntity> findBySocialId(
+            @Param("provider") Provider provider,
+            @Param("provider_id") String providerId
+    );
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.assetmind.server_auth.user.infrastructure.persistence;
+
+import com.assetmind.server_auth.user.domain.User;
+import com.assetmind.server_auth.user.domain.port.UserRepository;
+import com.assetmind.server_auth.user.domain.vo.SocialID;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Spring Data JPA를 사용하여 Domain 영역에서 정의한 UserRepository 구현체
+ */
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository jpaRepository;
+    private final UserEntityMapper mapper;
+
+    @Override
+    public User save(User user) {
+        UserEntity entity = mapper.toEntity(user);
+        UserEntity savedEntity = jpaRepository.save(entity);
+
+        return mapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public Optional<User> findById(UUID id) {
+        return jpaRepository.findById(id)
+                .map(mapper::toDomain);
+    }
+
+    @Override
+    public Optional<User> findBySocialId(SocialID socialId) {
+        return jpaRepository.findBySocialId(socialId.provider(), socialId.providerID())
+                .map(mapper::toDomain);
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/security/SecurityPasswordEncoder.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/security/SecurityPasswordEncoder.java
@@ -1,0 +1,23 @@
+package com.assetmind.server_auth.user.infrastructure.security;
+
+import com.assetmind.server_auth.user.domain.port.PasswordEncoder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityPasswordEncoder implements PasswordEncoder {
+
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Override
+    public String encode(String rawPassword) {
+        return bCryptPasswordEncoder.encode(rawPassword);
+    }
+
+    @Override
+    public boolean matches(String rawPassword, String encodedPassword) {
+        return bCryptPasswordEncoder.matches(rawPassword, encodedPassword);
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/infrastructure/persistence/UserRepositoryImplTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/infrastructure/persistence/UserRepositoryImplTest.java
@@ -1,0 +1,206 @@
+package com.assetmind.server_auth.user.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+import com.assetmind.server_auth.global.config.JpaConfig;
+import com.assetmind.server_auth.user.domain.User;
+import com.assetmind.server_auth.user.domain.type.Provider;
+import com.assetmind.server_auth.user.domain.type.UserRole;
+import com.assetmind.server_auth.user.domain.vo.Email;
+import com.assetmind.server_auth.user.domain.vo.Password;
+import com.assetmind.server_auth.user.domain.vo.SocialID;
+import com.assetmind.server_auth.user.domain.vo.UserInfo;
+import com.assetmind.server_auth.user.domain.vo.Username;
+import java.util.Optional;
+import java.util.UUID;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/**
+ * JPA를 이용한 UserRepository의 구현체가
+ * 잘 저장하고 잘 조회되는지 검증
+ */
+@DataJpaTest
+@Import({UserRepositoryImpl.class, UserEntityMapper.class, JpaConfig.class}) // 컴포넌트 스캔대상에 해당 모듈들을 포함
+class UserRepositoryImplTest {
+
+    @Autowired
+    private UserRepositoryImpl userRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private User createTestUser(UUID id, String email, String username, String rawPassword, Provider provider, String providerId, UserRole role) {
+        return User.withId(
+                id,
+                new UserInfo(new Email(email), new Username(username)),
+                new Password(rawPassword),
+                new SocialID(provider, providerId),
+                role
+        );
+    }
+
+    @Nested
+    @DisplayName("User 저장 (save)")
+    class Save {
+        @Test
+        @DisplayName("성공: 소셜 정보가 없는 User를 저장할 때 Nullable가 정상 작동하고, Domain의 정보가 Entity로 매핑된 후 저장된다.")
+        void givenGuestRoleUser_whenSave_thenSaved() {
+            // given
+            UUID uuid = UUID.randomUUID();
+            User testUser = createTestUser(uuid, "test@test.com", "테스트001", "test1234",
+                    null, null, UserRole.GUEST);
+
+            // when
+            User result = userRepository.save(testUser);
+
+            // then
+            assertThat(result.getId()).isEqualTo(testUser.getId());
+            assertThat(result.getSocialID()).isNull();
+        }
+
+        @Test
+        @DisplayName("성공: 소셜 정보가 있는 User를 저장할 때 모든 Domain의 정보가 Entity로 매핑된 후 저장된다.")
+        void givenUserRoleUser_whenSave_thenSaved() {
+            // given
+            UUID uuid = UUID.randomUUID();
+            User testUser = createTestUser(uuid, "test@test.com", "테스트001", "test1234",
+                    Provider.GOOGLE, "google-123", UserRole.USER);
+
+            // when
+            User result = userRepository.save(testUser);
+
+            // then
+            assertThat(result.getId()).isEqualTo(testUser.getId());
+            assertThat(result.getSocialID()).isNotNull();
+            assertThat(result.getUserRole()).isEqualTo(UserRole.USER);
+        }
+
+        @Test
+        @DisplayName("실패: User를 저장할 때 중복된 이메일이면 저장 실패한다.")
+        void givenDuplicatedEmailUser_whenSave_thenThrowException() {
+            // given
+            String email = "dup@test.com";
+            User savedUser = createTestUser(UUID.randomUUID(), email, "테스트001", "test1234", null,
+                    null, UserRole.GUEST);
+            userRepository.save(savedUser);
+            em.flush();
+            em.clear();
+
+            User duplicatedUser = createTestUser(UUID.randomUUID(), email, "테스트001", "test1234", null,
+                    null, UserRole.GUEST);
+
+            // when & then
+            assertThatThrownBy(() -> {
+                userRepository.save(duplicatedUser);
+                em.flush();
+            })
+                    .isInstanceOf(ConstraintViolationException.class);
+        }
+
+        @Test
+        @DisplayName("실패: User를 저장할 때 이미 존재하는 소셜 계정(Provider + ID)이면 저장 실패한다.")
+        void givenAlreadySocialUser_whenSave_thenThrowException() {
+            // given
+            SocialID alreadySocialId = new SocialID(Provider.KAKAO, "kakao-1234");
+            User savedUser = createTestUser(UUID.randomUUID(), "test01@test.com", "테스트001", "test1234",
+                    alreadySocialId.provider(), alreadySocialId.providerID(), UserRole.USER);
+            userRepository.save(savedUser);
+            em.flush();
+            em.clear();
+
+            User duplicatedUser = createTestUser(UUID.randomUUID(), "test02@test.com", "테스트002", "test1234",
+                    alreadySocialId.provider(), alreadySocialId.providerID(), UserRole.USER);
+
+            // when & then
+            assertThatThrownBy(() -> {
+                userRepository.save(duplicatedUser);
+                em.flush();
+            })
+                    .isInstanceOf(ConstraintViolationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("UUID를 통해 User 조회 (findById)")
+    class FindById {
+        @Test
+        @DisplayName("성공: 저장된 User를 ID(UUID)로 성공적으로 조회한다.")
+        void givenValidUserId_whenFindById_thenReturnSavedUser() {
+            // given
+            UUID uuid = UUID.randomUUID();
+            User testUser = createTestUser(uuid, "test@test.com", "테스트001", "test1234",
+                    Provider.GOOGLE, "google-123", UserRole.USER);
+            userRepository.save(testUser);
+
+            // when
+            Optional<User> found = userRepository.findById(uuid);
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getId()).isEqualTo(testUser.getId());
+            assertThat(found.get().getUsernameValue()).isEqualTo(testUser.getUsernameValue());
+        }
+
+        @Test
+        @DisplayName("실패: 저장된 User를 잘못된 ID(UUID)로 조회하면 빈 객체를 반환한다.")
+        void givenInvalidUserId_whenFindById_thenReturnEmpty() {
+            // given
+            UUID invalidUuid = UUID.randomUUID();
+
+            // when
+            Optional<User> found = userRepository.findById(invalidUuid);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("SocialId(provider + providerId)를 통해 User 조회 (findBySocialId)")
+    class FindBySocialId {
+        @Test
+        @DisplayName("성공: 저장된 User를 Social 정보로 성공적으로 조회한다.")
+        void givenValidSocialId_whenFindBySocialId_thenReturnSavedUser() {
+            // given
+            UUID uuid = UUID.randomUUID();
+            SocialID socialId = new SocialID(Provider.KAKAO, "kakao-1234");
+            User testUser = createTestUser(uuid, "test@test.com", "테스트001", "test1234",
+                    socialId.provider(), socialId.providerID(), UserRole.USER);
+            userRepository.save(testUser);
+
+            // when
+            Optional<User> found = userRepository.findBySocialId(socialId);
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getId()).isEqualTo(testUser.getId());
+            assertThat(found.get().getUsernameValue()).isEqualTo(testUser.getUsernameValue());
+            assertThat(found.get().getSocialID()).isEqualTo(socialId);
+        }
+
+        @Test
+        @DisplayName("실패: 저장된 User를 잘못된 Social 정보로 조화하면 빈 객체를 반환한다.")
+        void givenInvalidSocialId_whenFindBySocialId_thenReturnEmpty() {
+            // given
+            SocialID invalidSocialId = new SocialID(Provider.KAKAO, "kakao-1234");
+            User testUser = createTestUser(UUID.randomUUID(), "test@test.com", "테스트001", "test1234",
+                    Provider.GOOGLE, "google-123", UserRole.USER);
+            userRepository.save(testUser);
+
+            // when
+            Optional<User> found = userRepository.findBySocialId(invalidSocialId);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+}

--- a/docs/TCS/TCS-USR-002.md
+++ b/docs/TCS/TCS-USR-002.md
@@ -1,0 +1,58 @@
+# [TCS] 사용자(User) 영속성 어댑터 테스트 명세서
+
+| 문서 ID | **TCS-INFRA-USR-001** |
+| :--- | :--- |
+| **문서 버전** | 1.0 |
+| **프로젝트** | AssetMind |
+| **작성자** | 이재석 |
+| **작성일** | 2026년 01월 17일 |
+| **관련 모듈** | `apps/server-auth/user/infrastructure/persistence` |
+
+## 1. 개요 (Overview)
+
+본 문서는 AssetMind 인증 서버의 도메인 객체를 영속화하는 **`UserRepositoryImpl`** (Adapter)의 동작을 검증하기 위한 슬라이스 테스트(Slice Test) 명세이다.
+`@DataJpaTest`를 사용하여 H2 인메모리 DB 환경에서 수행되며, 도메인 객체와 JPA 엔티티 간의 매핑 및 DB 제약조건 동작을 중점적으로 검증한다.
+
+### 1.1. 테스트 환경
+- **Framework:** JUnit 5, AssertJ, Spring Data JPA
+- **Target Class:** `UserRepositoryImplTest`
+- **Key Verification:**
+    - **Mapping:** Domain(User) ↔ Entity(UserEntity) 간 필드 매핑 및 변환 검증
+    - **Nullable:** GUEST(소셜 정보 없음)와 USER(소셜 정보 있음) 간의 저장 로직 분기 검증
+    - **Constraints:** 이메일 및 소셜 계정의 유니크(Unique) 제약조건 위반 시 예외 발생 여부 검증
+    - **Reconstitution:** 저장된 데이터를 조회하여 도메인 객체로 완벽하게 재구성되는지 검증
+
+---
+
+## 2. Infrastructure Adapter 테스트 명세
+> **대상 클래스:** `UserRepositoryImplTest`
+> **검증 목표:** 도메인 객체가 DB에 올바르게 저장되고, 제약조건을 준수하며, 조회 시 원본 상태로 복원됨을 보장
+
+### 2.1. 저장 (Save) 검증
+
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **INF-001** | `givenGuestRoleUser_`<br>`whenSave_thenSaved`<br>👉 **소셜 정보가 없는 1차 가입자(GUEST)를 저장한다.** | **User(GUEST)**<br>(SocialID 필드 `null`) | **`userRepository.save()`** | 1. 저장된 객체의 ID가 반환된다.<br>2. **`socialID` 필드는 `null`로 저장된다.**<br>3. `userRole`은 **GUEST**이다. |
+| **INF-002** | `givenUserRoleUser_`<br>`whenSave_thenSaved`<br>👉 **소셜 정보가 있는 정회원(USER)을 저장한다.** | **User(USER)**<br>(Valid SocialID 포함) | **`userRepository.save()`** | 1. 저장된 객체의 ID가 반환된다.<br>2. **`socialID` 정보가 DB에 정상 매핑된다.**<br>3. `userRole`은 **USER**이다. |
+| **INF-003** | `givenDuplicatedEmailUser_`<br>`whenSave_thenThrowException`<br>👉 **이미 존재하는 이메일로 저장 시 예외가 발생한다.** | **기존 유저 저장됨**<br>(이메일: A)<br>**신규 유저 생성**<br>(이메일: A, 동일) | **`userRepository.save()`**<br>+ `em.flush()` (DB 반영) | 1. `ConstraintViolationException` 발생.<br>(DB Unique Key 제약조건 위반) |
+| **INF-004** | `givenAlreadySocialUser_`<br>`whenSave_thenThrowException`<br>👉 **이미 연동된 소셜 계정으로 저장 시 예외가 발생한다.** | **기존 유저 저장됨**<br>(Provider: P, ID: 1)<br>**신규 유저 생성**<br>(Provider: P, ID: 1, 동일) | **`userRepository.save()`**<br>+ `em.flush()` (DB 반영) | 1. `ConstraintViolationException` 발생.<br>(DB Unique Key 제약조건 위반) |
+
+### 2.2. 조회 (Find) 검증
+
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **INF-005** | `givenValidUserId_`<br>`whenFindById_thenReturnSavedUser`<br>👉 **저장된 ID(UUID)로 유저를 조회한다.** | **유저 저장 완료**<br>(UUID: id_A) | **`userRepository.findById(id_A)`** | 1. `Optional`이 비어있지 않다(`isPresent`).<br>2. 조회된 유저의 ID 및 필드 값이 일치한다. |
+| **INF-006** | `givenInvalidUserId_`<br>`whenFindById_thenReturnEmpty`<br>👉 **존재하지 않는 ID로 조회 시 빈 결과를 반환한다.** | **랜덤 UUID 생성**<br>(DB에 없음) | **`userRepository.findById(randomId)`** | 1. `Optional`이 비어있다(`isEmpty`). |
+| **INF-007** | `givenValidSocialId_`<br>`whenFindBySocialId_thenReturnSavedUser`<br>👉 **일치하는 소셜 정보(Provider+ID)로 유저를 조회한다.** | **유저 저장 완료**<br>(KAKAO, id_123) | **`userRepository.findBySocialId`**<br>`(KAKAO, id_123)` | 1. `Optional`이 비어있지 않다.<br>2. 조회된 유저의 `socialID` 값이 일치한다. |
+| **INF-008** | `givenInvalidSocialId_`<br>`whenFindBySocialId_thenReturnEmpty`<br>👉 **소셜 정보가 일치하지 않으면 빈 결과를 반환한다.** | **유저 저장 완료**<br>(GOOGLE, id_999) | **`userRepository.findBySocialId`**<br>`(KAKAO, id_999)` | 1. `Optional`이 비어있다(`isEmpty`).<br>(Provider 불일치 케이스 등) |
+
+---
+
+## 3. 테스트 결과 요약
+
+### 3.1. 수행 결과
+| 구분 | 전체 케이스 | Pass | Fail | 비고 |
+| :--- | :---: | :---: | :---: | :--- |
+| **Save (저장)** | 4 | 4 | 0 | Nullable 처리 및 Unique 제약조건 검증 완료 |
+| **Find (조회)** | 4 | 4 | 0 | PK 및 복합 인덱스 조회 검증 완료 |
+| **합계** | **8** | **8** | **0** | **Pass** ✅ |


### PR DESCRIPTION
## 📌 작업 내용
- **User 도메인을 지원하는 인프라스트럭처(Adapter) 계층을 구현했습니다.**
- 도메인 포트(`UserRepository`, `PasswordEncoder`)를 구현하여, 순수 도메인 객체가 실제 DB(PostgreSQL/H2) 및 Spring Security와 상호작용할 수 있도록 연결했습니다.
- DB 매핑 및 제약조건 동작을 검증하기 위한 **슬라이스 테스트(Slice Test)** 코드를 작성하고, 이를 문서화한 `테스트 명세서(TCS)`를 산출했습니다.

## 🏗 기술적 의사결정 (핵심 변경 사유)

**1. Flattening 전략을 통한 도메인 순수성 보장**
> JPA의 `@Embedded`를 사용하는 대신, 엔티티 레벨에서 필드를 풀어서 매핑하는 **Flattening** 방식을 채택했습니다.
- **문제점:** `@Embeddable`을 사용하려면 도메인 VO 객체에 JPA 어노테이션을 붙여야 하므로, 도메인 계층이 특정 기술(JPA)에 오염되는 문제가 발생합니다.
- **해결책:** 도메인 객체는 POJO 상태를 유지하고, `UserEntityMapper`가 중간에서 VO의 값을 추출하여 `UserEntity`의 평문 필드를 원시타입으로 매핑하도록 설계했습니다. 이를 통해 도메인과 인프라의 결합도를 낮췄습니다.

**2. Audit 정보의 인프라 위임 (Separation of Concerns)**
> `createdAt`, `updatedAt`과 같은 데이터 감사(Audit) 정보는 비즈니스 로직이 아닌 인프라의 영역으로 판단했습니다.
- **결정:** `User` 도메인 모델에서 날짜 필드를 굳이 추가하지 않고, `UserEntity`에 `JPA Auditing`(`@EntityListeners`)을 적용하여 관리 주체를 분리했습니다.
- **이점:** 도메인 모델이 비즈니스 행위에만 집중할 수 있게 경량화되었으며, 날짜 갱신 누락과 같은 실수를 시스템 레벨에서 방지했습니다. 추후에 비즈니스 로직에도 `생성 시점`, `수정 시점`이 필요하다면 그때 도메인 모델에 추가하면 됩니다.

## ✅ 주요 변경점
- **`infrastructure/persistence` 패키지 구현:**
    - **Entity:** `UserEntity` (Flattening 적용, Unique 제약조건 설정)
    - **Mapper:** `UserEntityMapper` (Domain ↔ Entity 변환 및 재구성 로직)
    - **Adapter:** `UserRepositoryImpl` (JPA Repository 연동)
- **`infrastructure/security` 패키지 구현:**
    - **Adapter:** `SecurityPasswordEncoder` (BCrypt 알고리즘 적용)
- **Configuration:**
    - `JpaConfig` (Auditing 활성화)
    - `SecurityConfig` (PasswordEncoder Bean 등록)
- **테스트 구현:**
    - `UserRepositoryImplTest`: `@DataJpaTest` 기반의 슬라이스 테스트.
    - `TCS-USR-002.md`: 인프라 계층 테스트 명세서 추가.

## 📝 리뷰 포인트
- **매핑 로직의 정확성:** `UserEntityMapper`에서 `SocialID`가 없는(GUEST) 경우와 있는(USER) 경우를 분기하여 `null` 처리를 올바르게 수행하는지 확인 부탁드립니다.
- **제약조건 설정:** `UserEntity`의 `@Table` 설정에서 이메일 및 소셜 계정(`Provider` + `ID`)에 대한 Unique Constraint가 누락 없이 설정되었는지 검토 바랍니다.