### PR TITLE
[Feat] 회원가입 비즈니스 로직 구현 준비 - 보안/유틸 인프라

### DIFF
--- a/apps/server-auth/build.gradle
+++ b/apps/server-auth/build.gradle
@@ -7,14 +7,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	testImplementation 'org.springframework.security:spring-security-test'
 
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'
-}
-
-dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
 }

--- a/apps/server-auth/build.gradle
+++ b/apps/server-auth/build.gradle
@@ -9,6 +9,12 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
+
 	testImplementation 'org.springframework.security:spring-security-test'
 
 	runtimeOnly 'com.h2database:h2'

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/ServerAuthApplication.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/ServerAuthApplication.java
@@ -1,9 +1,12 @@
 package com.assetmind.server_auth;
 
+import com.assetmind.server_auth.global.config.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(JwtProperties.class)
 public class ServerAuthApplication {
 
 	public static void main(String[] args) {

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/common/JwtProcessor.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/common/JwtProcessor.java
@@ -1,0 +1,61 @@
+package com.assetmind.server_auth.global.common;
+
+import com.assetmind.server_auth.global.config.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import org.springframework.stereotype.Component;
+
+/**
+ * 비즈니스 로직은 전혀 모르는
+ * 토큰 생성과 토큰을 파싱하는 공통 유틸 모듈
+ */
+@Component
+public class JwtProcessor {
+
+    private final SecretKey key;
+
+    public JwtProcessor(JwtProperties properties) {
+        this.key = Keys.hmacShaKeyFor(
+                properties.secret().getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    /**
+     * 토큰 생성
+     * @param subject - 토큰의 주인 (email or userId)
+     * @param claims - 토큰에 담을 정보들 (Map을 이용)
+     * @param expireMs - 유효기간
+     * @return 생성된 Jwt 문자열
+     */
+    public String generate(String subject, Map<String, Object> claims, long expireMs) {
+        return Jwts.builder()
+                .subject(subject)       // sub: 누구의 토큰인가
+                .claims(claims)         // payload: 커스텀 데이터
+                .issuedAt(new Date())   // issueAt: 만든 날짜
+                .expiration(new Date(System.currentTimeMillis() + expireMs)) // 만료기간
+                .signWith(key, SIG.HS256) // 서명
+                .compact();
+    }
+
+    /**
+     * 토큰 검증이 포함된 토큰 파싱
+     * 만료되거나 위조된 토큰이면 jjwt 라이브러리가 알아서 예외를 던짐
+     * @param token - jwt 토큰
+     * @return 토큰 생성시 넣었던 데이터
+     */
+    public Claims parse(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/config/JwtProperties.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/config/JwtProperties.java
@@ -1,0 +1,10 @@
+package com.assetmind.server_auth.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret
+) {
+
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/config/SecurityConfig.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/config/SecurityConfig.java
@@ -2,14 +2,14 @@ package com.assetmind.server_auth.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.socket.EnableWebSocketSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 /**
  * 보안 관련 설정
  */
 @Configuration
-@EnableWebSocketSecurity
+@EnableWebSecurity
 public class SecurityConfig {
 
     /**

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/ErrorCode.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/ErrorCode.java
@@ -15,7 +15,10 @@ public enum ErrorCode {
 
     // User Domain 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 회원입니다."),
-    ALREADY_GET_USER_PERMISSION(HttpStatus.BAD_REQUEST, "U002", "이미 정식 회원입니다.");
+    ALREADY_GET_USER_PERMISSION(HttpStatus.BAD_REQUEST, "U002", "이미 정식 회원입니다."),
+
+    // Jwt 토큰 에러
+    INVALID_SIGN_UP_TOKEN(HttpStatus.BAD_REQUEST, "U003", "유효하지 않거나 용도가 잘못된 회원가입 토큰입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/SignUpTokenProvider.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/SignUpTokenProvider.java
@@ -1,0 +1,61 @@
+package com.assetmind.server_auth.user.application;
+
+import com.assetmind.server_auth.global.common.JwtProcessor;
+import com.assetmind.server_auth.user.exception.InvalidSignUpTokenException;
+import io.jsonwebtoken.Claims;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SignUpTokenProvider {
+
+    private final JwtProcessor jwtProcessor;
+
+    // 토큰 Claims의 payload - "type": "SIGN_UP"
+    private static final String TYPE_CLAIM = "type";
+    private static final String TYPE_SIGN_UP = "SIGN_UP";
+
+    // 가입 토큰 유효기간: 30분 - 사용자가 정보 입력 시간 고려
+    private static final long EXPIRATION_MS = 30 * 60 * 1000L;
+
+    /**
+     * 회원 가입용 토큰 생성
+     * 인증 번호 검증 성공 시 사용
+     * @param email - 토큰의 주인 (subject)
+     * @return Jwt 문자열
+     */
+    public String createToken(String email) {
+        return jwtProcessor.generate(
+                email,
+                Map.of(TYPE_CLAIM, TYPE_SIGN_UP),
+                EXPIRATION_MS
+        );
+    }
+
+    /**
+     * 토큰 검증 및 이메일 추출
+     * @param token
+     * @return
+     */
+    public String getEmailFromToken(String token) {
+        Claims claims = jwtProcessor.parse(token);
+
+        validateTokenType(claims);
+
+        return claims.getSubject();
+    }
+
+    /**
+     * 토큰의 용도가 회원가입용 토큰인지 검증
+     * @param claims
+     */
+    public void validateTokenType(Claims claims) {
+        String type = claims.get(TYPE_CLAIM, String.class);
+
+        if (type == null || !type.equals(TYPE_SIGN_UP)) {
+            throw new InvalidSignUpTokenException();
+        }
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserRegisterUseCase.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserRegisterUseCase.java
@@ -1,0 +1,41 @@
+package com.assetmind.server_auth.user.application;
+
+import com.assetmind.server_auth.user.application.dto.UserRegisterCommand;
+
+public interface UserRegisterUseCase {
+
+    /**
+     * 이메일 중복 검사
+     * @param email - 중복 검사할 이메일
+     * @return true: 중복됨(가입불가 X), false: 사용가능한 이메일
+     */
+    boolean checkEmailDuplicate(String email);
+
+    /**
+     * 인증 코드 발송
+     * 이메일 중복 체크 포함
+     * 인증 코드 생성 및 저장, 메일 발송
+     * @param email
+     */
+    void sendVerificationCode(String email);
+
+    /**
+     * 인증 코드 검증
+     * 코드가 일치하지 않으면 예외 발생
+     * 코드가 일치하면 Redis에서 코드를 삭제,
+     * 가입 권한이 담긴 SignUp Token을 발급하여 반환
+     * @param email - 인증 코드를 전달한 email
+     * @param code - 유저가 입력한 인증 코드
+     * @return signUpToken (회원 가입용 임시 토큰)
+     */
+    String verifyCode(String email, String code);
+
+    /**
+     * 최종 회원 가입
+     * SignUp Token의 유효성 및 서명을 검증
+     * 도메인 생성 및 저장
+     * @param cmd - 회원가입 유저 데이터 DTO
+     * @return 가입된 유저 ID
+     */
+    Long register(UserRegisterCommand cmd);
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/dto/UserRegisterCommand.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/dto/UserRegisterCommand.java
@@ -1,0 +1,10 @@
+package com.assetmind.server_auth.user.application.dto;
+
+public record UserRegisterCommand(
+        String email,
+        String password,
+        String username,
+        String signUpToken
+) {
+
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/EmailSendPort.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/EmailSendPort.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_auth.user.domain.port;
+package com.assetmind.server_auth.user.application.port;
 
 /**
  * 이메일 전송을 정의하는 인터페이스

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/PasswordEncoder.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/PasswordEncoder.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_auth.user.domain.port;
+package com.assetmind.server_auth.user.application.port;
 
 /**
  * 비밀번호 암호화 인터페이스 정의

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/UserIdGenerator.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/UserIdGenerator.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_auth.user.domain.port;
+package com.assetmind.server_auth.user.application.port;
 
 import java.util.UUID;
 

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/UserRepository.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/UserRepository.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_auth.user.domain.port;
+package com.assetmind.server_auth.user.application.port;
 
 import com.assetmind.server_auth.user.domain.User;
 import com.assetmind.server_auth.user.domain.vo.SocialID;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/VerificationCodePort.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/VerificationCodePort.java
@@ -1,0 +1,28 @@
+package com.assetmind.server_auth.user.application.port;
+
+/**
+ * 이메일 검증시 사용되는 인증번호 저장소 인터페이스
+ */
+public interface VerificationCodePort {
+
+    /**
+     * 인증 코드 저장 (TTL 포함)
+     * @param email - 인증 코드의 키 값, 이메일
+     * @param code - 인증 코드
+     * @param ttlSeconds - 유효 시간
+     */
+    void save(String email, String code, long ttlSeconds);
+
+    /**
+     * 인증 코드 조회
+     * @param email - 인증 코드 값의 키 값
+     * @return 인증 코드 값
+     */
+    String getCode(String email);
+
+    /**
+     * 인증 코드 삭제
+     * @param email - 인증 코드 값의 키 값
+     */
+    void remove(String email);
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/User.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/User.java
@@ -2,7 +2,6 @@ package com.assetmind.server_auth.user.domain;
 
 import com.assetmind.server_auth.global.error.BusinessException;
 import com.assetmind.server_auth.global.error.ErrorCode;
-import com.assetmind.server_auth.user.domain.port.UserIdGenerator;
 import com.assetmind.server_auth.user.domain.vo.Password;
 import com.assetmind.server_auth.user.domain.vo.SocialID;
 import com.assetmind.server_auth.user.domain.vo.UserInfo;
@@ -53,17 +52,18 @@ public class User {
 
     /**
      * 초기 유저 생성시 GUEST(게스트) 역할로 유저를 생성 - 이메일 인증
+     * @param id - 유저 ID(UUID)
      * @param userInfo - 유저 정보
      * @param password - 유저 비밀번호
-     * @param idGenerator - ID 생성자 인터페이스(ID 생성 방식 정의)
      * @return 유저 객체
      */
-    public static User createGuest(UserInfo userInfo, Password password, UserIdGenerator idGenerator) {
+    public static User createGuest(UUID id, UserInfo userInfo, Password password) {
         // 유저 정보 및 소셜 정보가 Null 값인지 한번 더 검증
+        Objects.requireNonNull(id);
         Objects.requireNonNull(userInfo);
         Objects.requireNonNull(password);
 
-        return new User(idGenerator.generate(), userInfo, password, null, UserRole.GUEST);
+        return new User(id, userInfo, password, null, UserRole.GUEST);
     }
 
     /**

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/Password.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/domain/vo/Password.java
@@ -1,6 +1,6 @@
 package com.assetmind.server_auth.user.domain.vo;
 
-import com.assetmind.server_auth.user.domain.port.PasswordEncoder;
+import com.assetmind.server_auth.user.application.port.PasswordEncoder;
 
 /**
  * User의 비밀번호 VO 객체
@@ -21,28 +21,11 @@ public record Password(
     }
 
     /**
-     * 길이를 검증하고 암호화를 수행하는 정적 팩토리 메서드
-     * @param rawPassword - 비밀번호 평문
-     * @param encoder - 평문을 암호화할 encoder
-     * @return 암호화된 새 비밀번호
+     * 비밀번호 VO객체를 생성하는 정적 팩토리 메서드
+     * @param encodedPassword - 암호화된 비밀번호
+     * @return 비밀번호 VO 객체
      */
-    public static Password create(String rawPassword, PasswordEncoder encoder) {
-        if (rawPassword == null || rawPassword.length() < 8 || rawPassword.length() > 20) {
-            throw new IllegalArgumentException("비밀번호는 8자 이상 20자 이하여야 합니다.");
-        }
-
-        return new Password(encoder.encode(rawPassword));
+    public static Password from(String encodedPassword) {
+        return new Password(encodedPassword);
     }
-
-    /**
-     * 입력값인 비밀번호 평문과 현재 암호화된 비밀번호와 동일한지 검증
-     * @param rawPassword - 평문 비밀번호
-     * @param encoder - 평문을 암호화한 encoder
-     * @return T/F
-     */
-    public boolean match(String rawPassword, PasswordEncoder encoder) {
-        return encoder.matches(rawPassword, this.value);
-    }
-
-
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/exception/InvalidSignUpTokenException.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/exception/InvalidSignUpTokenException.java
@@ -1,0 +1,11 @@
+package com.assetmind.server_auth.user.exception;
+
+import com.assetmind.server_auth.global.error.BusinessException;
+import com.assetmind.server_auth.global.error.ErrorCode;
+
+public class InvalidSignUpTokenException extends BusinessException {
+
+    public InvalidSignUpTokenException() {
+        super(ErrorCode.INVALID_SIGN_UP_TOKEN);
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/mail/EmailSenderAdapter.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/mail/EmailSenderAdapter.java
@@ -1,7 +1,6 @@
 package com.assetmind.server_auth.user.infrastructure.mail;
 
-import com.assetmind.server_auth.user.domain.port.EmailSendPort;
-import jakarta.mail.MessagingException;
+import com.assetmind.server_auth.user.application.port.EmailSendPort;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.assetmind.server_auth.user.infrastructure.persistence;
 
 import com.assetmind.server_auth.user.domain.User;
-import com.assetmind.server_auth.user.domain.port.UserRepository;
+import com.assetmind.server_auth.user.application.port.UserRepository;
 import com.assetmind.server_auth.user.domain.vo.SocialID;
 import java.util.Optional;
 import java.util.UUID;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/security/SecurityPasswordEncoder.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/security/SecurityPasswordEncoder.java
@@ -1,6 +1,6 @@
 package com.assetmind.server_auth.user.infrastructure.security;
 
-import com.assetmind.server_auth.user.domain.port.PasswordEncoder;
+import com.assetmind.server_auth.user.application.port.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;

--- a/apps/server-auth/src/main/resources/application.yaml
+++ b/apps/server-auth/src/main/resources/application.yaml
@@ -34,3 +34,6 @@ spring:
         connectiontimeout: 5000   # 5초안에 연결 안되면 포기
         timeout: 5000             # 5초 동안 응답 없으면 포기
         writetimeout: 5000        # 5초 동안 전송 안되면 포기
+
+jwt:
+  secret: ${JWT_SECRET_KEY}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/global/common/JwtProcessorTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/global/common/JwtProcessorTest.java
@@ -1,0 +1,75 @@
+package com.assetmind.server_auth.global.common;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.assetmind.server_auth.global.config.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * JwtProcessor 단위 테스트
+ * 토큰 생성 및 파싱 로직 검증
+ * 토큰 검증시 예외 검증
+ */
+class JwtProcessorTest {
+
+    private JwtProcessor jwtProcessor;
+
+    @BeforeEach
+    void setUp() {
+        String testSecret = "sh2yA+V0RXqGXgOMAE+uieIMEOrDXHJwlb3Pt5X8qlQ=";
+        JwtProperties properties = new JwtProperties(testSecret);
+
+        jwtProcessor = new JwtProcessor(properties);
+    }
+
+    @Test
+    @DisplayName("성공: 토큰 생성 후 파싱을 했을 때, 넣은 데이터가 그대로 반환되어야 한다.")
+    void givenTokenMetaData_whenGenerateAndParse_thenReturnCorrectMetaData() {
+        // given
+        String email = "subject@test.com";
+        Map<String, Object> claims = Map.of("role", "USER", "type", "test", "int", 1);
+        long expireMs = 60000;
+
+        // when
+        String token = jwtProcessor.generate(email, claims, expireMs);
+        Claims parsingResult = jwtProcessor.parse(token);
+
+        // then
+        assertThat(parsingResult.getSubject()).isEqualTo(email);
+        assertThat(parsingResult.get("role")).isEqualTo("USER");
+        assertThat(parsingResult.get("int")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("실패: 토큰 파싱하면서 검증 시, 만료된 토큰인 경우 ExpiredJwtException 예외가 발생해야한다.")
+    void givenExpiredToken_whenParse_thenThrowException() throws InterruptedException {
+        // given
+        // 유효기간을 아주 짧게 설정
+        String token = jwtProcessor.generate("test", Map.of(), 10);
+
+        Thread.sleep(20);
+
+        // when & then
+        assertThatThrownBy(() -> jwtProcessor.parse(token))
+                .isInstanceOf(ExpiredJwtException.class);
+    }
+
+    @Test
+    @DisplayName("실패: 토큰 파싱하면서 검증 시, 서명이 다른 토큰인 경우 SignatureException 예외가 발생해야한다.")
+    void givenFakeToken_whenParse_thenThrowException() {
+        // given
+        String correctToken = jwtProcessor.generate("test", Map.of(), 60000);
+
+        String fakeToken = correctToken + "FAKE";
+
+        // when & then
+        assertThatThrownBy(() -> jwtProcessor.parse(fakeToken))
+                .isInstanceOf(SignatureException.class);
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/SignUpTokenProviderTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/SignUpTokenProviderTest.java
@@ -1,0 +1,105 @@
+package com.assetmind.server_auth.user.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.assetmind.server_auth.global.common.JwtProcessor;
+import com.assetmind.server_auth.user.exception.InvalidSignUpTokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * SignUpTokenProvider 단위 테스트
+ * 모킹된 JwtProcessor를 가지고
+ * 회원가입용 토큰 생성 검증
+ * 토큰 검증 및 이메일 추출 로직 검증
+ */
+@ExtendWith(MockitoExtension.class)
+class SignUpTokenProviderTest {
+
+    @Mock
+    private JwtProcessor jwtProcessor;
+
+    @InjectMocks
+    private SignUpTokenProvider signUpTokenProvider;
+
+    private String email = "test@test.com";
+    private String validToken = "valid-token";
+
+    @Test
+    @DisplayName("성공: 이메일로 토큰을 생성 요청을 하면 해당 이메일과 SIGN_UP 타입으로 토큰을 생성한다.")
+    void givenEmail_whenCreateToken_thenReturnCorrectSignUpToken() {
+        // given
+        given(jwtProcessor.generate(anyString(), anyMap(), anyLong())).willReturn(validToken);
+
+        // when
+        String result = signUpTokenProvider.createToken(email);
+
+        // then
+        assertThat(result).isEqualTo(validToken);
+        verify(jwtProcessor).generate(
+                eq(email),
+                eq(Map.of("type", "SIGN_UP")),
+                eq(30 * 60 * 1000L)
+        );
+    }
+
+    @Test
+    @DisplayName("성공: 토큰 검증 시 SIGN_UP 타입이 맞으면 해당 토큰의 subject인 이메일을 반환한다.")
+    void givenValidToken_whenGetEmailFromToken_thenReturnValidEmail() {
+        // given
+        // JwtProcessor가 파싱해서 돌려줄 Claims mock 객체 생성
+        Claims claims = Jwts.claims()
+                .subject(email)
+                .add("type", "SIGN_UP")
+                .build();
+
+        given(jwtProcessor.parse(validToken)).willReturn(claims);
+
+        // when
+        String result = signUpTokenProvider.getEmailFromToken(validToken);
+
+        // then
+        assertThat(result).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("실패: 토큰 검증 시 SIGN_UP 타입이 아니면 예외를 던진다.")
+    void givenNotSignUpTypeToken_whenGetEmailFromToken_thenThrowException() {
+        // given
+        Claims claims = Jwts.claims()
+                .subject(email)
+                .add("type", "ACCESS")
+                .build();
+
+        given(jwtProcessor.parse(validToken)).willReturn(claims);
+
+        // when & then
+        assertThatThrownBy(() -> signUpTokenProvider.getEmailFromToken(validToken))
+                .isInstanceOf(InvalidSignUpTokenException.class)
+                .hasMessageContaining("유효하지 않거나 용도가 잘못된 회원가입 토큰");
+    }
+
+    @Test
+    @DisplayName("실패: 토큰 검증 시 타입 Claims이 없으면 예외를 던진다.")
+    void givenNullClaimsToken_whenGetEmailFromToken_thenThrowException() {
+        // given
+        Claims claims = Jwts.claims()
+                .subject(email)
+                .build();
+
+        given(jwtProcessor.parse(validToken)).willReturn(claims);
+
+        // when & then
+        assertThatThrownBy(() -> signUpTokenProvider.getEmailFromToken(validToken))
+                .isInstanceOf(InvalidSignUpTokenException.class)
+                .hasMessageContaining("유효하지 않거나 용도가 잘못된 회원가입 토큰");
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/UserTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/UserTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.assetmind.server_auth.global.error.BusinessException;
 import com.assetmind.server_auth.global.error.ErrorCode;
-import com.assetmind.server_auth.user.domain.port.UserIdGenerator;
 import com.assetmind.server_auth.user.domain.type.Provider;
 import com.assetmind.server_auth.user.domain.type.UserRole;
 import com.assetmind.server_auth.user.domain.vo.Email;
@@ -34,9 +33,7 @@ class UserTest {
     // Password VO는 이미 암호화된 상태라고 가정하고 생성 (DB 로드용 생성자 활용)
     private final Password validPassword = new Password("ENCODED_PASSWORD_VALUE");
 
-    // ID 생성기 Stub (고정된 UUID 반환)
-    private final UUID FIXED_UUID = UUID.fromString("dea7b2fb-e7ac-4c45-86cb-9e0e5cd81e93");
-    private final UserIdGenerator idGenerator = () -> FIXED_UUID;
+    private final UUID USER_UUID = UUID.fromString("dea7b2fb-e7ac-4c45-86cb-9e0e5cd81e93");
 
     @Nested
     @DisplayName("신규 유저 생성 (createGuest)")
@@ -46,10 +43,10 @@ class UserTest {
         @DisplayName("성공: 유효한 정보로 GUEST 유저를 생성한다.")
         void givenValidInfo_whenCreateGuest_thenCreated() {
             // when
-            User user = User.createGuest(validUserInfo, validPassword, idGenerator);
+            User user = User.createGuest(USER_UUID, validUserInfo, validPassword);
 
             // then
-            assertThat(user.getId()).isEqualTo(FIXED_UUID);
+            assertThat(user.getId()).isEqualTo(USER_UUID);
             assertThat(user.getUserRole()).isEqualTo(UserRole.GUEST);
             assertThat(user.getPassword()).isEqualTo(validPassword);
             assertThat(user.getUserInfo().email()).isEqualTo(validEmail);
@@ -58,10 +55,18 @@ class UserTest {
         }
 
         @Test
+        @DisplayName("실패: 필수 정보(UserId)가 없으면 생성할 수 없다.")
+        void givenNullUserId_whenCreateGuest_thenThrowException() {
+            // when & then
+            assertThatThrownBy(() -> User.createGuest(null, validUserInfo, validPassword))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
         @DisplayName("실패: 필수 정보(UserInfo)가 없으면 생성할 수 없다.")
         void givenNullUserInfo_whenCreateGuest_thenThrowException() {
             // when & then
-            assertThatThrownBy(() -> User.createGuest(null, validPassword, idGenerator))
+            assertThatThrownBy(() -> User.createGuest(USER_UUID, null, validPassword))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -69,7 +74,7 @@ class UserTest {
         @DisplayName("실패: 필수 정보(Password)가 없으면 생성할 수 없다.")
         void givenNullPassword_whenCreateGuest_thenThrowException() {
             // when & then
-            assertThatThrownBy(() -> User.createGuest(validUserInfo, null, idGenerator))
+            assertThatThrownBy(() -> User.createGuest(USER_UUID, validUserInfo, null))
                     .isInstanceOf(NullPointerException.class);
         }
     }
@@ -82,7 +87,7 @@ class UserTest {
         @DisplayName("성공: GUEST 상태인 유저가 USER로 승격된다.")
         void givenGuestRoleUser_whenLinkSocialAndUpgrade_thenUpgradeToUser() {
             // given
-            User guestUser = User.createGuest(validUserInfo, validPassword, idGenerator);
+            User guestUser = User.createGuest(USER_UUID, validUserInfo, validPassword);
 
             // when
             guestUser.linkSocialAndUpgrade(validSocialID);
@@ -96,7 +101,7 @@ class UserTest {
         @DisplayName("실패: 이미 USER인 경우 BusinessException이 발생한다.")
         void givenUserRoleUser_whenLinkSocialAndUpgrade_thenThrowException() {
             // given
-            User user = User.createGuest(validUserInfo, validPassword, idGenerator);
+            User user = User.createGuest(USER_UUID, validUserInfo, validPassword);
             user.linkSocialAndUpgrade(validSocialID); // 먼저 USER(정회원)으로 상태 변경
 
             // when & then
@@ -110,7 +115,7 @@ class UserTest {
         @DisplayName("실패: 연동할 소셜 정보가 null이면 예외가 발생한다.")
         void givenNullSocialID_whenLinkSocialAndUpgrade_thenThrowException() {
             // given
-            User guestUser = User.createGuest(validUserInfo, validPassword, idGenerator);
+            User guestUser = User.createGuest(USER_UUID, validUserInfo, validPassword);
 
             // when & then
             assertThatThrownBy(() -> guestUser.linkSocialAndUpgrade(null))

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/vo/PasswordTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/domain/vo/PasswordTest.java
@@ -2,13 +2,12 @@ package com.assetmind.server_auth.user.domain.vo;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.assetmind.server_auth.user.domain.port.PasswordEncoder;
+import com.assetmind.server_auth.user.application.port.PasswordEncoder;
 import com.assetmind.server_auth.user.infrastructure.security.TestPasswordEncoder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Password VO 객체 단위 테스트
@@ -26,7 +25,7 @@ class PasswordTest {
         String rawPassword = "testPassword1234";
 
         // when
-        Password password = Password.create(rawPassword, encoder);
+        Password password = Password.from(encoder.encode(rawPassword));
 
         // then
         assertThat(password.value()).isEqualTo("ENCODE" + rawPassword); // 암호화 확인
@@ -35,24 +34,11 @@ class PasswordTest {
 
     @ParameterizedTest
     @NullAndEmptySource
-    @ValueSource(strings = {"짧다", "1234567", "이테스트비밀번호는20자초과입니다다다다다"})
-    @DisplayName("실패: 비밀번호가 8자 미만이거나 20자 초과이면 예외가 발생한다.")
+    @DisplayName("실패: 비밀번호가 null이나 빈 값이라면 예외가 발생한다.")
     void givenInvalidRawPassword_whenCreate_thenThrowException(String invalidPassword) {
-        assertThatThrownBy(() -> Password.create(invalidPassword, encoder))
+        assertThatThrownBy(() -> Password.from(invalidPassword))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("비밀번호는 8자 이상");
-    }
-
-    @Test
-    @DisplayName("성공: 입력한 평문이 암호화된 값과 일치하는지 확인한다.")
-    void givenRawAndEncodedPassword_whenMatch_thenReturnBoolean() {
-        // given
-        String raw = "password123";
-        Password password = Password.create(raw, encoder);
-
-        // when & then
-        assertThat(password.match(raw, encoder)).isTrue();
-        assertThat(password.match("wrongPassword", encoder)).isFalse();
+                .hasMessageContaining("비밀번호는 필수");
     }
 
 }

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/infrastructure/security/TestPasswordEncoder.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/infrastructure/security/TestPasswordEncoder.java
@@ -1,6 +1,6 @@
 package com.assetmind.server_auth.user.infrastructure.security;
 
-import com.assetmind.server_auth.user.domain.port.PasswordEncoder;
+import com.assetmind.server_auth.user.application.port.PasswordEncoder;
 
 public class TestPasswordEncoder implements PasswordEncoder {
 

--- a/docs/TCS/TCS-JWT-001.md
+++ b/docs/TCS/TCS-JWT-001.md
@@ -1,0 +1,62 @@
+# [TCS] JWT 보안 모듈 및 가입 토큰 제공자 테스트 명세서
+
+| 문서 ID | **TCS-AUTH-JWT-001**                |
+| :--- |:------------------------------------|
+| **문서 버전** | 1.0                                 |
+| **프로젝트** | AssetMind                           |
+| **작성자** | 이재석                                 |
+| **작성일** | 2026년 01월 20일                       |
+| **관련 모듈** | `global/common`, `user/application` |
+
+## 1. 개요 (Overview)
+
+본 문서는 AssetMind 인증 시스템의 핵심 보안 요소인 **JWT 처리 모듈**(`JwtProcessor`)과 회원가입 전용 **토큰 관리자**(`SignUpTokenProvider`)의 동작을 검증하기 위한 단위 테스트(Unit Test) 명세이다.  
+`JJWT 0.13.0` 라이브러리의 동작 검증과 더불어, 회원가입 비즈니스 로직(토큰 용도 구분)이 올바르게 수행되는지 중점적으로 확인한다.
+
+### 1.1. 테스트 환경
+- **Framework:** JUnit 5, AssertJ, Mockito
+- **Target Classes:** `JwtProcessorTest`, `SignUpTokenProviderTest`
+- **Key Verification:**
+    - **Security & Integrity:** 생성된 토큰의 서명(Signature) 검증 및 만료(Expiration) 처리 확인
+    - **Data Consistency:** Payload(Claims)에 저장된 데이터의 손실 없는 복원 확인
+    - **Business Logic:** 가입용 토큰(`SIGN_UP`)과 로그인용 토큰(`ACCESS`)의 명확한 구분 및 예외 처리
+
+---
+
+## 2. Common Utility 테스트 명세 (`JwtProcessor`)
+> **대상 클래스:** `JwtProcessorTest`  
+> **검증 목표:** 비즈니스 로직과 무관하게, 순수하게 JWT를 생성하고 파싱하는 기술적 기능이 정상 동작하는지 검증
+
+### 2.1. 생성 및 파싱 (Generate & Parse)
+
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **COM-JWT-001** | `generateAndParse`<br>👉 **정상적인 데이터를 담아 토큰을 생성하고, 다시 파싱한다.** | **데이터 준비**<br>- Subject: 이메일<br>- Claims: `{role: USER, age: 25}`<br>- 만료시간: 1분 | **`jwtProcessor.generate()`**<br>호출 후<br>**`jwtProcessor.parse()`** 호출 | 1. 파싱된 결과(`Claims`)의 Subject가 입력값과 일치한다.<br>2. Custom Claims(`role`, `age`) 데이터가 정확히 복원된다. |
+| **COM-JWT-002** | `expiredToken`<br>👉 **만료된 토큰을 파싱하면 예외가 발생해야 한다.** | **만료 토큰 생성**<br>유효기간을 매우 짧게(10ms) 설정 후, `Thread.sleep`으로 만료 시킴 | **`jwtProcessor.parse()`** | 1. **`ExpiredJwtException`** 예외가 발생한다.<br>2. 만료된 토큰은 절대 비즈니스 로직으로 진입해서는 안 된다. |
+| **COM-JWT-003** | `tamperedToken`<br>👉 **위변조된(서명이 다른) 토큰은 거부되어야 한다.** | **위조 토큰 준비**<br>정상 토큰 생성 후, 문자열 끝에 임의의 값("fake")을 덧붙임 | **`jwtProcessor.parse()`** | 1. **`security.SignatureException`** (혹은 `JwtException`)이 발생한다.<br>2. 서명이 깨진 토큰은 파싱 단계에서 차단된다. |
+
+---
+
+## 3. Business Service 테스트 명세 (`SignUpTokenProvider`)
+> **대상 클래스:** `SignUpTokenProviderTest`  
+> **검증 목표:** `JwtProcessor`(Mock)를 사용하여, 회원가입이라는 비즈니스 목적에 맞는 토큰을 발급하고 검증하는지 확인
+
+### 3.1. 토큰 발급 및 검증 (Create & Validate)
+
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **BIZ-SIGN-001** | `createToken`<br>👉 **가입 토큰 생성 시 'SIGN_UP' 타입이 자동으로 포함된다.** | **Mock 설정**<br>`jwtProcessor.generate` 호출 시 미리 정의된 토큰 문자열 반환 | **`provider.createToken(EMAIL)`** | 1. 반환된 토큰 문자열이 예상값과 일치한다.<br>2. `verify()` 검증: `jwtProcessor`에게 전달된 Claims 맵에 **`"type": "SIGN_UP"`** 이 정확히 포함되었는지 확인한다. |
+| **BIZ-SIGN-002** | `getEmailFromToken_Success`<br>👉 **'SIGN_UP' 타입의 토큰은 정상적으로 이메일을 반환한다.** | **Mock 설정**<br>`jwtProcessor.parse` 호출 시<br>`{sub: EMAIL, type: "SIGN_UP"}`을 담은 Claims 반환 | **`provider.getEmailFromToken()`** | 1. 메서드가 예외 없이 실행된다.<br>2. 반환된 값이 입력했던 이메일과 일치한다. |
+| **BIZ-SIGN-003** | `givenNotSignUpType...`<br>👉 **다른 용도(예: ACCESS)의 토큰을 넣으면 거절된다.** | **Mock 설정 (Unhappy Case)**<br>`jwtProcessor.parse` 호출 시<br>`{sub: EMAIL, type: "ACCESS"}`를 담은 Claims 반환 | **`provider.getEmailFromToken()`** | 1. **`InvalidSignUpTokenException`** 커스텀 예외가 발생한다.<br>2. 로그인 토큰 등으로 가입을 시도하는 보안 허점을 방어한다. |
+| **BIZ-SIGN-004** | `givenNoType...`<br>👉 **용도(type)가 없는 토큰도 거절된다.** | **Mock 설정 (Unhappy Case)**<br>`jwtProcessor.parse` 호출 시<br>`{sub: EMAIL}` (type 없음) 반환 | **`provider.getEmailFromToken()`** | 1. **`InvalidSignUpTokenException`** 커스텀 예외가 발생한다. |
+
+---
+
+## 4. 테스트 결과 요약
+
+### 4.1. 수행 결과
+| 구분 | 전체 케이스 | Pass | Fail | 비고 |
+| :--- | :---: | :---: | :---: | :--- |
+| **Common (JwtProcessor)** | 3 | 3 | 0 | 0.13.0 스펙 준수 및 보안 예외 검증 완료 |
+| **Business (Provider)** | 4 | 4 | 0 | 타입 검증 로직(Mock 활용) 완료 |
+| **합계** | **7** | **7** | **0** | **Pass** ✅ |


### PR DESCRIPTION
## 📌 작업 내용
- **회원가입 비즈니스를 지탱할 핵심 도메인 모델(User, Password)을 리팩토링 하였습니다..**
- 상태가 없는(Stateless) 가입 프로세스를 지원하기 위해 **JWT 기반의 인증 토큰 인프라**를 구축했습니다.
- 비즈니스 로직이 외부 기술에 의존하지 않도록 **Input/Output Port 인터페이스**를 정의했습니다.
- 보안 모듈(`JwtProcessor`)과 비즈니스 헬퍼(`SignUpTokenProvider`)에 대한 **단위 테스트**를 작성하고 검증 명세서를 산출했습니다.

## 🏗 기술적 의사결정 (핵심 변경 사유)

**1. Stateless 회원가입 프로세스 도입 (JWT 활용)**
> 메모리 혹은 DB에 가입 임시 데이터(이메일 인증 코드)를 저장하는 방식(Stateful)은 서버 리소스를 점유하고 관리가 복잡합니다.
- **문제점:** 이메일 인증 후 최종 가입까지의 상태를 서버가 기억해야 하므로, 트래픽 증가 시 메모리/DB 부하가 우려되었습니다.
- **해결책:** 이메일 인증이 완료되면 `암호화된 가입용 토큰(JWT)`을 발급하는 방식을 채택했습니다. 클라이언트가 최종 가입 요청 시 이 토큰을 제출하면, 서버는 상태를 기억할 필요 없이 토큰의 서명을 검증하여 가입을 승인합니다. 이를 통해 서버는 상태를 저장하지 않고(Stateless) 가입 절차를 처리할 수 있습니다.

**2. 입력 검증의 분리와 단순 원시 타입 사용 방지**
> 도메인 모델이 모든 유효성 검증을 담당하면 결합도가 높아지고, 단순 문자열(String) 사용은 의미를 명확히 전달하지 못합니다.
- **입력 검증:** 비밀번호 길이, 형식 등의 1차 검증은 추후에 **DTO(`UserRegisterRequest`)의 Bean Validation**으로 위임하여, 잘못된 요청이 도메인 로직까지 진입하는 것을 앞단에서 차단할 예정입니다.
- **도메인 모델링:** `Password` VO(Value Object)를 도입한 주된 목적은 검증 로직의 캡슐화보다는 **단순한 원시 타입 사용 방지**에 있습니다. 이를 통해 의미가 있음에도 불구하고 '단순 문자열' 사용을 방지하고 '비밀번호'를 명확히 구분하여 타입 안정성을 확보했습니다.

**3. 최신 JWT 라이브러리(0.13.0) 적용 및 모듈 분리**
> 보안 라이브러리는 최신 표준을 따르는 것이 중요하며, 기술 코드와 비즈니스 코드는 분리되어야 합니다.
- **결정:** `Deprecated`된 메서드가 많은 0.11.x 대신, 타입 안정성이 강화된 **JJWT 0.13.0** 버전을 적용했습니다.
- **구조 개선:**
    - `JwtProcessor`: 순수하게 토큰을 생성하고 파싱하는 **기술 모듈** (Utils).
    - `SignUpTokenProvider`: 토큰에 `TYPE: SIGN_UP` 태그를 심고 검증하는 **비즈니스 모듈**.
    - 위와 같이 역할을 분리하여 SRP(단일 책임 원칙)를 준수했습니다.
  
**4. JWT 구성 및 알고리즘 선정 전략**
> 토큰의 무결성을 보장하면서도 불필요한 오버헤드를 줄이기 위해 최적화된 구성을 선택했습니다.
- **Subject & Claims:**
    - `Subject`: 아직 회원가입 전 단계이므로 `userId`(PK) 대신 `email`을 식별자로 사용했습니다.
    - `Claims`: 로그인 토큰(`Access Token`)과의 혼동 및 오용을 방지하기 위해, **`type: SIGN_UP`** 이라는 명시적인 커스텀 Claim을 포함하여 용도를 엄격히 제한했습니다.
- **Algorithm (HS256):**
    - 공개키/개인키 쌍이 필요한 비대칭키(RS256) 방식보다, **대칭키 방식인 HS256(HMAC + SHA256)**이 연산 속도가 빠르고 설정이 간결하여 적합하다고 판단했습니다.

## ✅ 주요 변경점
- **Domain & VO 리팩토링:**
    - `User`: 정적 팩토리 메서드(`createGuest`) 적용.
    - `Password`: VO의 책임을 재정의하여 **과도한 검증 로직을 제거하고 타입 안정성 확보에 집중**.
- **Security Infrastructure (`global/common`):**
    - `JwtProcessor`: HMAC-SHA256 알고리즘 기반 토큰 생성/검증기 구현.
    - `SignUpTokenProvider`: 가입 전용 토큰 발급/검증 로직 구현.
    - `InvalidSignUpTokenException`: 보안 관련 커스텀 예외 추가.
- **Hexagonal Ports (`user/application/port`):**
    - `UserRegisterUseCase`, `UserRegisterCommand` (Input)
    - `VerificationCodePort`, `EmailSendPort`, `UserIdGeneratorPort` (Output)
- **Tests:**
    - `JwtProcessorTest`, `SignUpTokenProviderTest` 구현.
    - `TCS-JWT-001.md`: 테스트 명세서 추가.

## 📝 리뷰 포인트
- **JWT 0.13.0 문법:** `Jwts.builder()` 및 `verifyWith()` 등 최신 API 사용법이 적절하게 적용되었는지 확인 부탁드립니다.
- **테스트 커버리지:** 첨부된 테스트 명세서(`TCS-JWT-001`)를 참고하여, 보안상 중요한 케이스(만료, 위조, 타입 불일치)가 잘 커버되었는지 봐주세요.