### PR TITLE
[Feat] 회원가입 비즈니스 로직(Service) 구현 및 Redis/Random 인프라 어댑터 적용

### DIFF
--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/ErrorCode.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     // User Domain 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 회원입니다."),
     ALREADY_GET_USER_PERMISSION(HttpStatus.BAD_REQUEST, "U002", "이미 정식 회원입니다."),
+    USER_DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "U003", "중복된 이메일입니다."),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "U004", "유효하지 않은 인증 코드입니다."),
 
     // Jwt 토큰 에러
     INVALID_SIGN_UP_TOKEN(HttpStatus.BAD_REQUEST, "U003", "유효하지 않거나 용도가 잘못된 회원가입 토큰입니다.");

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserRegisterService.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserRegisterService.java
@@ -89,7 +89,7 @@ public class UserRegisterService implements UserRegisterUseCase {
     public String verifyCode(String email, String code) {
         String savedCode = verificationCodePort.getCode(email);
 
-        // 토큰이 만료되었거나(null), 일치하지 않는 경우
+        // 인증 코드가 만료되었거나(null), 일치하지 않는 경우
         if (savedCode == null || !savedCode.equals(code)) {
             throw new InvalidVerificationCode();
         }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserRegisterService.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserRegisterService.java
@@ -1,0 +1,141 @@
+package com.assetmind.server_auth.user.application;
+
+import com.assetmind.server_auth.user.application.dto.UserRegisterCommand;
+import com.assetmind.server_auth.user.application.port.EmailSendPort;
+import com.assetmind.server_auth.user.application.port.PasswordEncoder;
+import com.assetmind.server_auth.user.application.port.UserIdGenerator;
+import com.assetmind.server_auth.user.application.port.UserRepository;
+import com.assetmind.server_auth.user.application.port.VerificationCodeGenerator;
+import com.assetmind.server_auth.user.application.port.VerificationCodePort;
+import com.assetmind.server_auth.user.domain.User;
+import com.assetmind.server_auth.user.domain.vo.Email;
+import com.assetmind.server_auth.user.domain.vo.Password;
+import com.assetmind.server_auth.user.domain.vo.UserInfo;
+import com.assetmind.server_auth.user.domain.vo.Username;
+import com.assetmind.server_auth.user.exception.InvalidVerificationCode;
+import com.assetmind.server_auth.user.exception.UserDuplicatedEmail;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 회원가입 비즈니스 로직 Service
+ * 회원가입을 위한 여러 모듈들을
+ * 비즈니스 요구사항을 처리하기 위해 조합
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserRegisterService implements UserRegisterUseCase {
+
+    // 외부 의존성 주입
+    private final EmailSendPort emailSendPort;
+    private final PasswordEncoder passwordEncoder;
+    private final UserIdGenerator userIdGenerator;
+    private final UserRepository userRepository;
+    private final VerificationCodePort verificationCodePort;
+    private final VerificationCodeGenerator verificationCodeGenerator;
+
+    // 헬퍼 클래스
+    private final SignUpTokenProvider signUpTokenProvider;
+
+    // 인증 코드 유효시간 (3분)
+    private static final long VERIFICATION_CODE_TTL = 180L;
+
+    /**
+     * 이메일 중복 확인
+     */
+    @Override
+    public boolean checkEmailDuplicate(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    /**
+     * 인증 코드 발송
+     * 이미 가입된 이메일이면 예외 발생
+     * 난수 코드 생성 -> Redis 저장 -> 이메일 발송
+     * @param email
+     */
+    @Override
+    @Transactional
+    public void sendVerificationCode(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new UserDuplicatedEmail();
+        }
+
+        // 인증 코드 생성
+        String code = verificationCodeGenerator.generate();
+
+        // 인증 코드 저장
+        verificationCodePort.save(email, code, VERIFICATION_CODE_TTL);
+        // 인증 코드 메일 발송
+        emailSendPort.sendEmail(email, "인증 코드 발송", code);
+
+        log.info(">>>[UserRegisterService] 가입 인증 코드 전송 : {}", email);
+    }
+
+    /**
+     * 인증 코드 검증 및 회원 가입용 토큰 발급
+     * 성공 시: Redis에서 인증 코드 삭제 후 가입용 JWT(Type: SIGN_UP) 발급
+     * 실패 시: 예외 발생
+     * @param email - 인증 코드를 전달한 email
+     * @param code - 유저가 입력한 인증 코드
+     * @return signUpToken (회원 가입용 임시 토큰)
+     */
+    @Override
+    @Transactional
+    public String verifyCode(String email, String code) {
+        String savedCode = verificationCodePort.getCode(email);
+
+        // 토큰이 만료되었거나(null), 일치하지 않는 경우
+        if (savedCode == null || !savedCode.equals(code)) {
+            throw new InvalidVerificationCode();
+        }
+
+        // 검증 성공
+        verificationCodePort.remove(email);
+
+        // 회원 가입용 토큰 발급
+        return signUpTokenProvider.createToken(email);
+    }
+
+    /**
+     * 최종 회원가입
+     * 회원 가입용 토큰 검증 -> User 도메인 객체 생성 -> DB 저장
+     * @param cmd - 회원가입 유저 데이터 DTO
+     * @return 가입된 유저 ID
+     */
+    @Override
+    @Transactional
+    public UUID register(UserRegisterCommand cmd) {
+        // 가입 토큰 검증 (위변조, 만료, 타입 확인) 및 이메일 추출
+        String verifiedEmail = signUpTokenProvider.getEmailFromToken(cmd.signUpToken());
+
+        // 토큰의 이메일 내용과 요청 바디의 이메일 내용이 같은지 확인
+        if (!verifiedEmail.equals(cmd.email())) {
+            throw new IllegalArgumentException("토큰의 이메일 정보와 입력된 이메일이 일치하지 않습니다.");
+        }
+
+        // 중복 가입 방지
+        if (userRepository.existsByEmail(cmd.email())) {
+            throw new UserDuplicatedEmail();
+        }
+
+        // 도메인 객체 생성
+        UUID userId = userIdGenerator.generate();
+        Password encodedPassword = new Password(passwordEncoder.encode(cmd.password()));
+        UserInfo userInfo = new UserInfo(
+                new Email(cmd.email()),
+                new Username(cmd.username())
+        );
+
+        User newUser = User.createGuest(userId, userInfo, encodedPassword);
+
+        // User 도메인 객체 저장
+        User savedUser = userRepository.save(newUser);
+
+        return savedUser.getId();
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserRegisterUseCase.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserRegisterUseCase.java
@@ -1,6 +1,7 @@
 package com.assetmind.server_auth.user.application;
 
 import com.assetmind.server_auth.user.application.dto.UserRegisterCommand;
+import java.util.UUID;
 
 public interface UserRegisterUseCase {
 
@@ -37,5 +38,5 @@ public interface UserRegisterUseCase {
      * @param cmd - 회원가입 유저 데이터 DTO
      * @return 가입된 유저 ID
      */
-    Long register(UserRegisterCommand cmd);
+    UUID register(UserRegisterCommand cmd);
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/UserRepository.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/UserRepository.java
@@ -34,4 +34,11 @@ public interface UserRepository {
      * @return User 도메인 객체
      */
     Optional<User> findBySocialId(SocialID socialId);
+
+    /**
+     * DB에 해당 이메일이 존재하는지 조회
+     * @param email - 찾으려는 email
+     * @return true(존재 o) / false(존재 x)
+     */
+    boolean existsByEmail(String email);
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/VerificationCodeGenerator.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/VerificationCodeGenerator.java
@@ -1,0 +1,15 @@
+package com.assetmind.server_auth.user.application.port;
+
+/**
+ * 인증 코드 생성기
+ * 이메일 인증 등에 사용할 랜덤 코드를 생성하는 역할을 정의
+ * 테스트 용이성과 랜덤 코드 생성 규칙 변경에도 유연한 대응을 위해 설계
+ */
+public interface VerificationCodeGenerator {
+
+    /**
+     * 인증 코드 생성
+     * @return 생성된 인증 코드
+     */
+    String generate();
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/VerificationCodePort.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/port/VerificationCodePort.java
@@ -2,6 +2,9 @@ package com.assetmind.server_auth.user.application.port;
 
 /**
  * 이메일 검증시 사용되는 인증번호 저장소 인터페이스
+ * 이메일 인증 코드를 저장하고 조회하는 행위를 정의
+ * Service는 인터페이스에만 의존하며,
+ * 실제 저장 기술이 무엇인지는 알 필요가 없음 (DIP 원칙)
  */
 public interface VerificationCodePort {
 
@@ -9,7 +12,7 @@ public interface VerificationCodePort {
      * 인증 코드 저장 (TTL 포함)
      * @param email - 인증 코드의 키 값, 이메일
      * @param code - 인증 코드
-     * @param ttlSeconds - 유효 시간
+     * @param ttlSeconds - 유효 시간 (초)
      */
     void save(String email, String code, long ttlSeconds);
 
@@ -22,6 +25,8 @@ public interface VerificationCodePort {
 
     /**
      * 인증 코드 삭제
+     * 인증이 성공적으로 완료되면 더 이상 해당 인증 코드를 재사용할 수 없도록
+     * 저장소에서 제거
      * @param email - 인증 코드 값의 키 값
      */
     void remove(String email);

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/exception/InvalidVerificationCode.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/exception/InvalidVerificationCode.java
@@ -1,0 +1,11 @@
+package com.assetmind.server_auth.user.exception;
+
+import com.assetmind.server_auth.global.error.BusinessException;
+import com.assetmind.server_auth.global.error.ErrorCode;
+
+public class InvalidVerificationCode extends BusinessException {
+
+    public InvalidVerificationCode() {
+        super(ErrorCode.INVALID_VERIFICATION_CODE);
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/exception/UserDuplicatedEmail.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/exception/UserDuplicatedEmail.java
@@ -1,0 +1,11 @@
+package com.assetmind.server_auth.user.exception;
+
+import com.assetmind.server_auth.global.error.BusinessException;
+import com.assetmind.server_auth.global.error.ErrorCode;
+
+public class UserDuplicatedEmail extends BusinessException {
+
+    public UserDuplicatedEmail() {
+        super(ErrorCode.USER_DUPLICATED_EMAIL);
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/generator/RandomVerificationCodeAdapter.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/generator/RandomVerificationCodeAdapter.java
@@ -1,0 +1,24 @@
+package com.assetmind.server_auth.user.infrastructure.generator;
+
+import com.assetmind.server_auth.user.application.port.VerificationCodeGenerator;
+import java.security.SecureRandom;
+import org.springframework.stereotype.Component;
+
+/**
+ * SecureRandom 기반 인증 코드 생성 구현체
+ * Java의 SecureRandom을 사용하여 예측 불가능한 6자리 난수를 생성
+ */
+@Component
+public class RandomVerificationCodeAdapter implements VerificationCodeGenerator {
+
+    // 매번 생성하지 않고 재사용
+    private static final SecureRandom secureRandom = new SecureRandom();
+
+
+    @Override
+    public String generate() {
+        // 100000 ~ 999999 사이의 난수 생성
+        int code = 100000 + secureRandom.nextInt(900000);
+        return String.valueOf(code);
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/generator/UuidGeneratorAdapter.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/generator/UuidGeneratorAdapter.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_auth.user.infrastructure.id;
+package com.assetmind.server_auth.user.infrastructure.generator;
 
 import com.assetmind.server_auth.user.application.port.UserIdGenerator;
 import java.util.UUID;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/id/UuidGeneratorAdapter.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/id/UuidGeneratorAdapter.java
@@ -1,8 +1,8 @@
 package com.assetmind.server_auth.user.infrastructure.id;
 
+import com.assetmind.server_auth.user.application.port.UserIdGenerator;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
-import org.springframework.util.IdGenerator;
 
 /**
  * ID 생성 어댑터
@@ -10,10 +10,10 @@ import org.springframework.util.IdGenerator;
  * 자바의 UUID 라이브러리를 사용하여 고유 식별자를 생성
  */
 @Component
-public class UuidGeneratorAdapter implements IdGenerator {
+public class UuidGeneratorAdapter implements UserIdGenerator {
 
     @Override
-    public UUID generateId() {
+    public UUID generate() {
         return UUID.randomUUID();
     }
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/id/UuidGeneratorAdapter.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/id/UuidGeneratorAdapter.java
@@ -1,0 +1,19 @@
+package com.assetmind.server_auth.user.infrastructure.id;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import org.springframework.util.IdGenerator;
+
+/**
+ * ID 생성 어댑터
+ * IdGenerator 인터페이스의 구현체로써
+ * 자바의 UUID 라이브러리를 사용하여 고유 식별자를 생성
+ */
+@Component
+public class UuidGeneratorAdapter implements IdGenerator {
+
+    @Override
+    public UUID generateId() {
+        return UUID.randomUUID();
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserEntity.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserEntity.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_auth.user.infrastructure.persistence;
+package com.assetmind.server_auth.user.infrastructure.persistence.jpa;
 
 import com.assetmind.server_auth.user.domain.type.Provider;
 import com.assetmind.server_auth.user.domain.type.UserRole;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserEntityMapper.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserEntityMapper.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_auth.user.infrastructure.persistence;
+package com.assetmind.server_auth.user.infrastructure.persistence.jpa;
 
 import com.assetmind.server_auth.user.domain.User;
 import com.assetmind.server_auth.user.domain.type.Provider;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserJpaRepository.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserJpaRepository.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_auth.user.infrastructure.persistence;
+package com.assetmind.server_auth.user.infrastructure.persistence.jpa;
 
 import com.assetmind.server_auth.user.domain.type.Provider;
 import java.util.Optional;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserJpaRepository.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserJpaRepository.java
@@ -19,4 +19,6 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, UUID> {
             @Param("provider") Provider provider,
             @Param("provider_id") String providerId
     );
+
+    boolean existsByEmail(String email);
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserRepositoryImpl.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserRepositoryImpl.java
@@ -37,4 +37,9 @@ public class UserRepositoryImpl implements UserRepository {
         return jpaRepository.findBySocialId(socialId.provider(), socialId.providerID())
                 .map(mapper::toDomain);
     }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return jpaRepository.existsByEmail(email);
+    }
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserRepositoryImpl.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/jpa/UserRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_auth.user.infrastructure.persistence;
+package com.assetmind.server_auth.user.infrastructure.persistence.jpa;
 
 import com.assetmind.server_auth.user.domain.User;
 import com.assetmind.server_auth.user.application.port.UserRepository;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/redis/RedisVerificationCodeAdapter.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/infrastructure/persistence/redis/RedisVerificationCodeAdapter.java
@@ -1,0 +1,41 @@
+package com.assetmind.server_auth.user.infrastructure.persistence.redis;
+
+import com.assetmind.server_auth.user.application.port.VerificationCodePort;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Redis 인증 코드 저장소 어댑터
+ * 이메일 인증 코드를 Redis에 저장하고 관리
+ * TTL을 활용해 유효기간이 지나면 데이터가 자동 삭제
+ */
+@Repository
+@RequiredArgsConstructor
+public class RedisVerificationCodeAdapter implements VerificationCodePort {
+
+    private final StringRedisTemplate redisTemplate;
+
+    // Redis Key 구분자 (예: "AUTH_CODE:test@email.com"(키) )
+    private final String PREFIX_KEY = "AUTH_CODE:";
+
+    @Override
+    public void save(String email, String code, long ttlSeconds) {
+        redisTemplate.opsForValue().set(
+                PREFIX_KEY + email, // key
+                code,   // value
+                Duration.ofSeconds(ttlSeconds)  // TTL
+        );
+    }
+
+    @Override
+    public String getCode(String email) {
+        return redisTemplate.opsForValue().get(PREFIX_KEY + email);
+    }
+
+    @Override
+    public void remove(String email) {
+        redisTemplate.delete(PREFIX_KEY + email);
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/UserRegisterServiceTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/UserRegisterServiceTest.java
@@ -1,0 +1,226 @@
+package com.assetmind.server_auth.user.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.assetmind.server_auth.user.application.dto.UserRegisterCommand;
+import com.assetmind.server_auth.user.application.port.EmailSendPort;
+import com.assetmind.server_auth.user.application.port.PasswordEncoder;
+import com.assetmind.server_auth.user.application.port.UserIdGenerator;
+import com.assetmind.server_auth.user.application.port.UserRepository;
+import com.assetmind.server_auth.user.application.port.VerificationCodeGenerator;
+import com.assetmind.server_auth.user.application.port.VerificationCodePort;
+import com.assetmind.server_auth.user.domain.User;
+import com.assetmind.server_auth.user.domain.type.UserRole;
+import com.assetmind.server_auth.user.domain.vo.Email;
+import com.assetmind.server_auth.user.domain.vo.Password;
+import com.assetmind.server_auth.user.domain.vo.UserInfo;
+import com.assetmind.server_auth.user.domain.vo.Username;
+import com.assetmind.server_auth.user.exception.InvalidVerificationCode;
+import com.assetmind.server_auth.user.exception.UserDuplicatedEmail;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * UserRegisterService 단위 테스트
+ * 이메일 중복 확인 로직 확인
+ * 가입 인증 코드 전송 로직 확인
+ * 인증 번호 검증 및 토큰 발급 로직 확인
+ * 회원가입 성공 시 유저 도메인 객체 저장 로직 확인
+ */
+@ExtendWith(MockitoExtension.class)
+class UserRegisterServiceTest {
+
+    @InjectMocks
+    private UserRegisterService userRegisterService;
+
+    // 외부 협력 객체들 Mocking
+    @Mock private EmailSendPort emailSendPort;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private UserIdGenerator userIdGenerator;
+    @Mock private UserRepository userRepository;
+    @Mock private VerificationCodeGenerator verificationCodeGenerator;
+    @Mock private VerificationCodePort verificationCodePort;
+    @Mock private SignUpTokenProvider signUpTokenProvider;
+
+    private final UserInfo userInfo = new UserInfo(
+            new Email("test@test.com"),
+            new Username("테스트001")
+    );
+    private final String token = "valid-jwt";
+
+    @Test
+    @DisplayName("성공: 중복된 이메일이 아니면 false를 응답한다.")
+    void givenValidEmail_whenCheckEmailDuplicate_thenReturnFalse() {
+        // given
+        // 중복되지 않은 이메일이 들어왔다고 가정
+        String validEmail = userInfo.email().value();
+        given(userRepository.existsByEmail(userInfo.email().value())).willReturn(false);
+
+        // when
+        boolean result = userRegisterService.checkEmailDuplicate(validEmail);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("실패: 중복된 이메일이 이면 true를 응답한다.")
+    void givenDuplicatedEmail_whenCheckEmailDuplicate_thenReturnTrue() {
+        // given
+        // 중복된 이메일이 들어왔다고 가정
+        String duplicatedEmail = "valid@test.com";
+        given(userRepository.existsByEmail(duplicatedEmail)).willReturn(true);
+
+        // when
+        boolean result = userRegisterService.checkEmailDuplicate(duplicatedEmail);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("성공: 중복된 이메일이 아니면 인증 코드 생성 후 저장하고 메일을 보낸다.")
+    void givenValidEmail_whenSendVerification_thenSaveAndSendEmail() {
+        // given
+        String validEmail = userInfo.email().value();
+        String code = "123456";
+        given(userRepository.existsByEmail(validEmail)).willReturn(false);
+        given(verificationCodeGenerator.generate()).willReturn(code);
+
+        // when
+        userRegisterService.sendVerificationCode(validEmail);
+
+        // then
+        // Redis 저장 메서드가 잘 실행되었는지 확인
+        verify(verificationCodePort).save(eq(validEmail), eq(code), eq(180L));
+        // 메일 발송 메서드가 잘 실행되었는지 확인
+        verify(emailSendPort).sendEmail(eq(validEmail), eq("인증 코드 발송"), eq(code));
+    }
+
+    @Test
+    @DisplayName("실패: 중복된 이메일이 이면 예외(UserDuplicatedEmail)를 던진다.")
+    void givenDuplicatedEmail_whenSendVerification_thenThrowException() {
+        // given
+        String duplicatedEmail = "valid@test.com";
+        given(userRepository.existsByEmail(duplicatedEmail)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userRegisterService.sendVerificationCode(duplicatedEmail))
+                .isInstanceOf(UserDuplicatedEmail.class)
+                .hasMessageContaining("중복된 이메일입니다.");
+    }
+
+
+    @Test
+    @DisplayName("성공: 유효한 인증 코드인 경우, 저장소에서 인증 코드를 삭제하고 회원가입용 토큰을 발급한다.")
+    void givenValidCode_whenVerifyCode_thenRemoveCodeAndIssueRegisterCode() {
+        // given
+        String validEmail = userInfo.email().value();
+        String mockSavedCode = "123456";
+        given(verificationCodePort.getCode(validEmail)).willReturn(mockSavedCode);
+        given(signUpTokenProvider.createToken(validEmail)).willReturn(token);
+
+        // when
+        String result = userRegisterService.verifyCode(validEmail, mockSavedCode);
+
+        // then
+        assertThat(result).isEqualTo(token);
+        verify(verificationCodePort).remove(eq(validEmail));
+    }
+
+    @Test
+    @DisplayName("실패: 유효하지 않은 인증 코드인 경우, 예외(InvalidVerificationCode)를 던진다.")
+    void givenInvalidCode_whenVerifyCode_thenThrowException() {
+        // given
+        String validEmail = userInfo.email().value();
+        String validCode = "123456";
+        given(verificationCodePort.getCode(validEmail)).willReturn("999999");
+
+        // when & then
+        assertThatThrownBy(() -> userRegisterService.verifyCode(validEmail, validCode))
+                .isInstanceOf(InvalidVerificationCode.class)
+                .hasMessageContaining("유효하지 않은 인증 코드입니다.");
+
+        // 틀린 인증번호로 접근했으니 원래있던 인증번호는 삭제되면 안됨
+        verify(verificationCodePort, never()).remove(any());
+    }
+
+    @Test
+    @DisplayName("성공: 올바른 UserRegisterCommand 라면, 회원가입에 성공하고 유저를 저장한다.")
+    void givenUserRegisterCommand_whenRegister_thenSaveUserAndReturnUserUUID() {
+        // given
+        UserRegisterCommand cmd = new UserRegisterCommand(
+                userInfo.email().value(),
+                "test1234",
+                userInfo.username().value(),
+                token
+        );
+        UUID mockUserId = UUID.randomUUID();
+
+        User mockUser = User.withId(mockUserId, userInfo, new Password("test1234"), null,
+                UserRole.GUEST);
+
+        given(signUpTokenProvider.getEmailFromToken(cmd.signUpToken())).willReturn(userInfo.email().value());
+        given(userRepository.existsByEmail(cmd.email())).willReturn(false);
+        given(userIdGenerator.generate()).willReturn(mockUserId);
+        given(passwordEncoder.encode(cmd.password())).willReturn("encoded_pw");
+
+        given(userRepository.save(any(User.class))).willReturn(mockUser);
+
+        // when
+        UUID result = userRegisterService.register(cmd);
+
+        // then
+        assertThat(result).isEqualTo(mockUserId);
+        verify(userRepository).save(any(User.class));
+        verify(passwordEncoder).encode(eq(cmd.password()));
+    }
+
+    @Test
+    @DisplayName("실패: 토큰의 이메일과 요청 이메일이 다르면, 예외(IllegalArgumentException)을 던진다.")
+    void givenInvalidEmailInToken_whenRegister_thenThrowException() {
+        // given
+        UserRegisterCommand cmd = new UserRegisterCommand(
+                userInfo.email().value(),
+                "test1234",
+                userInfo.username().value(),
+                token
+        );
+        String invalidEmail = "invalid@test.com";
+
+        // 토큰에는 invalid@test.com 이지만 요청은 test@test.com인 상황
+        given(signUpTokenProvider.getEmailFromToken(cmd.signUpToken())).willReturn(invalidEmail);
+
+        // when & then
+        assertThatThrownBy(() -> userRegisterService.register(cmd))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("토큰의 이메일 정보와 입력된 이메일이 일치하지 않습니다.");
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("실패: 중복된 이메일이라면, 예외(UserDuplicatedEmail)를 던진다.")
+    void givenDuplicatedEmail_whenRegister_thenThrowException() {
+        // given
+        UserRegisterCommand cmd = new UserRegisterCommand(
+                userInfo.email().value(),
+                "test1234",
+                userInfo.username().value(),
+                token
+        );
+        given(signUpTokenProvider.getEmailFromToken(cmd.signUpToken())).willReturn(cmd.email());
+        given(userRepository.existsByEmail(cmd.email())).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userRegisterService.register(cmd))
+                .isInstanceOf(UserDuplicatedEmail.class)
+                .hasMessageContaining("중복된 이메일입니다.");
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/infrastructure/persistence/UserRepositoryImplTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/infrastructure/persistence/UserRepositoryImplTest.java
@@ -204,4 +204,22 @@ class UserRepositoryImplTest {
             assertThat(found).isEmpty();
         }
     }
+
+    @Test
+    @DisplayName("성공: 해당 이메일이 존재하는지 조회한다. 존재하면 True를, 존재하지 않으면 False를 반환한다.")
+    void givenEmail_whenExistsByEmail_thenReturnBoolean() {
+        // given
+        UUID uuid = UUID.randomUUID();
+        User testUser = createTestUser(uuid, "test@test.com", "테스트001", "test1234",
+                Provider.GOOGLE, "google-123", UserRole.USER);
+        userRepository.save(testUser);
+
+        // when
+        boolean resultTrue = userRepository.existsByEmail(testUser.getEmailValue());
+        boolean resultFalse = userRepository.existsByEmail("NotExsist@email.com");
+
+        // then
+        assertThat(resultTrue).isTrue();
+        assertThat(resultFalse).isFalse();
+    }
 }

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/infrastructure/persistence/UserRepositoryImplTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/infrastructure/persistence/UserRepositoryImplTest.java
@@ -12,6 +12,8 @@ import com.assetmind.server_auth.user.domain.vo.Password;
 import com.assetmind.server_auth.user.domain.vo.SocialID;
 import com.assetmind.server_auth.user.domain.vo.UserInfo;
 import com.assetmind.server_auth.user.domain.vo.Username;
+import com.assetmind.server_auth.user.infrastructure.persistence.jpa.UserEntityMapper;
+import com.assetmind.server_auth.user.infrastructure.persistence.jpa.UserRepositoryImpl;
 import java.util.Optional;
 import java.util.UUID;
 import org.hibernate.exception.ConstraintViolationException;
@@ -22,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
-import org.springframework.dao.DataIntegrityViolationException;
 
 /**
  * JPA를 이용한 UserRepository의 구현체가

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/infrastructure/persistence/redis/RedisVerificationCodeAdapterTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/infrastructure/persistence/redis/RedisVerificationCodeAdapterTest.java
@@ -1,0 +1,85 @@
+package com.assetmind.server_auth.user.infrastructure.persistence.redis;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * RedisVerificationCodeAdapter 단위 테스트
+ * 단위 테스트의 속도를 위해 실제 Redis를 띄우지 않고,
+ * StringRedisTemplate의 메서드를 올바르게 호출 했는지 검증
+ * 추후 통합테스트에서 실제 Redis를 통해 검증 예정
+ */
+@ExtendWith(MockitoExtension.class)
+class RedisVerificationCodeAdapterTest {
+
+    @InjectMocks
+    private RedisVerificationCodeAdapter redisVerificationCodeAdapter;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private final String EMAIL = "test@assetmind.com";
+    private final String CODE = "123456";
+    private final long TTL = 180L;
+    private final String EXPECTED_KEY = "AUTH_CODE:" + EMAIL;
+
+    @Test
+    @DisplayName("저장 검증: Key에 Prefix가 붙고, TTL이 설정된 상태로 set()이 호출되어야 한다")
+    void givenEmailCodeTTL_whenSave_thenSavedCorrectData() {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        redisVerificationCodeAdapter.save(EMAIL, CODE, TTL);
+
+        // then
+        // verify: 실제로 이 메서드가 호출되었는지 감시
+        verify(valueOperations).set(
+                eq(EXPECTED_KEY),           // "AUTH_CODE:test@assetmind.com" 인지 확인
+                eq(CODE),                   // 코드가 맞는지 확인
+                eq(Duration.ofSeconds(TTL)) // Duration 변환이 잘 되었는지 확인
+        );
+    }
+
+    @Test
+    @DisplayName("조회 검증: Prefix가 붙은 Key로 get()을 호출하고 값을 반환해야 한다")
+    void givenSavedKey_whenGetCode_thenReturnSavedCode() {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(EXPECTED_KEY)).willReturn(CODE); // Redis에 값이 있다고 가정
+
+        // when
+        String result = redisVerificationCodeAdapter.getCode(EMAIL);
+
+        // then
+        assertThat(result).isEqualTo(CODE);
+        verify(valueOperations).get(EXPECTED_KEY); // 정확한 키로 조회했는지 확인
+    }
+
+    @Test
+    @DisplayName("삭제 검증: Prefix가 붙은 Key로 delete()가 호출되어야 한다")
+    void givenSavedKey_whenDelete_thenDeleted() {
+        // when
+        redisVerificationCodeAdapter.remove(EMAIL);
+
+        // then
+        verify(redisTemplate).delete(EXPECTED_KEY); // opsForValue()가 아니라 Template 자체의 delete 메서드 검증
+    }
+}

--- a/docs/TCS/TCS-REDIS-001.md
+++ b/docs/TCS/TCS-REDIS-001.md
@@ -1,0 +1,51 @@
+# [TCS] Redis 영속성 어댑터 테스트 명세서
+
+| 문서 ID | **TCS-INFRA-REDIS-001** |
+| :--- | :--- |
+| **문서 버전** | 1.0 |
+| **프로젝트** | AssetMind |
+| **작성자** | 이재석 |
+| **작성일** | 2026년 01월 21일 |
+| **관련 모듈** | `user/infrastructure/persistence/redis` |
+
+## 1. 개요 (Overview)
+
+본 문서는 인증 코드 저장을 담당하는 `RedisVerificationCodeAdapter`의 단위 테스트 명세이다.
+외부 시스템인 Redis와의 통신을 담당하는 `StringRedisTemplate`을 **Mocking**하여, 실제 Redis 서버 없이 비즈니스 로직에서 요구하는 저장, 조회, 삭제 명령이 올바른 파라미터(Key Prefix, TTL 등)와 함께 호출되는지 검증한다.
+
+### 1.1. 테스트 환경
+- **Framework:** JUnit 5, AssertJ, Mockito
+- **Target Class:** `RedisVerificationCodeAdapterTest`
+- **Key Verification:**
+    - **Key Naming Policy:** 모든 키에 접두사(`AUTH_CODE:`)가 올바르게 붙는지 검증
+    - **Data Integrity:** 저장하려는 데이터(Code)가 변조 없이 전달되는지 검증
+    - **TTL (Time To Live):** 유효 시간이 `Duration` 객체로 올바르게 변환되어 설정되는지 검증
+
+---
+
+## 2. Infrastructure Adapter 테스트 명세
+> **대상 클래스:** `RedisVerificationCodeAdapterTest`
+> **검증 목표:** 서비스 계층의 요청이 Redis 클라이언트 명령어로 올바르게 변환(Adapt)되는지 확인
+
+### 2.1. CRUD 동작 검증
+
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **INF-REDIS-001** | `givenEmailCodeTTL_`<br>`whenSave_thenSavedCorrectData`<br>👉 **저장 검증: Key Prefix와 만료 시간(TTL) 설정 확인** | **Mock 설정**<br>`redisTemplate.opsForValue()` 호출 시<br>Mock `ValueOperations` 반환 | **`adapter.save(EMAIL, CODE, TTL)`**<br>(TTL: 180초) | 1. `ops.set()` 메서드가 호출된다.<br>2. **Key:** `"AUTH_CODE:" + EMAIL` 형태인지 확인.<br>3. **Value:** 입력한 코드(`123456`)와 일치 확인.<br>4. **Timeout:** `Duration.ofSeconds(180)`으로 정확히 변환되었는지 확인. |
+| **INF-REDIS-002** | `givenSavedKey_`<br>`whenGetCode_thenReturnSavedCode`<br>👉 **조회 검증: 올바른 Key로 조회하고 값을 반환하는지 확인** | **Mock 설정**<br>Mock `ValueOperations`가 특정 Key 조회 시<br>`"123456"`(Code) 반환하도록 설정 | **`adapter.getCode(EMAIL)`** | 1. 반환된 값이 예상 코드(`"123456"`)와 일치한다.<br>2. `ops.get()` 호출 시 사용된 Key가 접두사(`AUTH_CODE:`)를 포함하고 있는지 검증한다. |
+| **INF-REDIS-003** | `givenSavedKey_`<br>`whenDelete_thenDeleted`<br>👉 **삭제 검증: 올바른 Key로 삭제 명령을 내리는지 확인** | **Mock 설정**<br>(별도 Stubbing 불필요) | **`adapter.remove(EMAIL)`** | 1. `redisTemplate.delete()` 메서드가 **1회** 호출된다.<br>2. 삭제 요청된 Key가 접두사(`AUTH_CODE:`)를 포함하고 있는지 검증한다. |
+
+---
+
+## 3. 테스트 결과 요약
+
+### 3.1. 수행 결과
+| 구분 | 전체 케이스 | Pass | Fail | 비고 |
+| :--- | :---: | :---: | :---: | :--- |
+| **Redis Adapter** | 3 | 3 | 0 | Prefix 및 TTL 정책 준수 확인 완료 |
+| **합계** | **3** | **3** | **0** | **Pass** ✅ |
+
+---
+
+**💡 비고:**
+본 테스트는 `Mockito`를 사용한 `단위 테스트(Unit Test)`입니다. 실제 Redis 서버 연결 상태나 네트워크 장애 상황 등을 검증하지 않으며, 이는 추후 통합 테스트(Integration Test) 단계에서 `TestContainers` 등을 활용하여 검증할 예정입니다.

--- a/docs/TCS/TCS-USR-002.md
+++ b/docs/TCS/TCS-USR-002.md
@@ -1,11 +1,11 @@
 # [TCS] 사용자(User) 영속성 어댑터 테스트 명세서
 
-| 문서 ID | **TCS-INFRA-USR-001** |
-| :--- | :--- |
-| **문서 버전** | 1.0 |
-| **프로젝트** | AssetMind |
-| **작성자** | 이재석 |
-| **작성일** | 2026년 01월 17일 |
+| 문서 ID | **TCS-INFRA-USR-001**                              |
+| :--- |:---------------------------------------------------|
+| **문서 버전** | 1.1                                                |
+| **프로젝트** | AssetMind                                          |
+| **작성자** | 이재석                                                |
+| **작성일** | 2026년 01월 17일                                      |
 | **관련 모듈** | `apps/server-auth/user/infrastructure/persistence` |
 
 ## 1. 개요 (Overview)
@@ -39,20 +39,21 @@
 
 ### 2.2. 조회 (Find) 검증
 
-| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
-| :--- | :--- | :--- | :--- | :--- |
-| **INF-005** | `givenValidUserId_`<br>`whenFindById_thenReturnSavedUser`<br>👉 **저장된 ID(UUID)로 유저를 조회한다.** | **유저 저장 완료**<br>(UUID: id_A) | **`userRepository.findById(id_A)`** | 1. `Optional`이 비어있지 않다(`isPresent`).<br>2. 조회된 유저의 ID 및 필드 값이 일치한다. |
-| **INF-006** | `givenInvalidUserId_`<br>`whenFindById_thenReturnEmpty`<br>👉 **존재하지 않는 ID로 조회 시 빈 결과를 반환한다.** | **랜덤 UUID 생성**<br>(DB에 없음) | **`userRepository.findById(randomId)`** | 1. `Optional`이 비어있다(`isEmpty`). |
-| **INF-007** | `givenValidSocialId_`<br>`whenFindBySocialId_thenReturnSavedUser`<br>👉 **일치하는 소셜 정보(Provider+ID)로 유저를 조회한다.** | **유저 저장 완료**<br>(KAKAO, id_123) | **`userRepository.findBySocialId`**<br>`(KAKAO, id_123)` | 1. `Optional`이 비어있지 않다.<br>2. 조회된 유저의 `socialID` 값이 일치한다. |
-| **INF-008** | `givenInvalidSocialId_`<br>`whenFindBySocialId_thenReturnEmpty`<br>👉 **소셜 정보가 일치하지 않으면 빈 결과를 반환한다.** | **유저 저장 완료**<br>(GOOGLE, id_999) | **`userRepository.findBySocialId`**<br>`(KAKAO, id_999)` | 1. `Optional`이 비어있다(`isEmpty`).<br>(Provider 불일치 케이스 등) |
+| ID          | 테스트 메서드 / 시나리오                                                                                                 | Given (사전 조건)                    | When (수행 행동)                                             | Then (검증 결과)                                                          |
+|:------------|:---------------------------------------------------------------------------------------------------------------|:---------------------------------|:---------------------------------------------------------|:----------------------------------------------------------------------|
+| **INF-005** | `givenValidUserId_`<br>`whenFindById_thenReturnSavedUser`<br>👉 **저장된 ID(UUID)로 유저를 조회한다.**                    | **유저 저장 완료**<br>(UUID: id_A)     | **`userRepository.findById(id_A)`**                      | 1. `Optional`이 비어있지 않다(`isPresent`).<br>2. 조회된 유저의 ID 및 필드 값이 일치한다.   |
+| **INF-006** | `givenInvalidUserId_`<br>`whenFindById_thenReturnEmpty`<br>👉 **존재하지 않는 ID로 조회 시 빈 결과를 반환한다.**                 | **랜덤 UUID 생성**<br>(DB에 없음)       | **`userRepository.findById(randomId)`**                  | 1. `Optional`이 비어있다(`isEmpty`).                                       |
+| **INF-007** | `givenValidSocialId_`<br>`whenFindBySocialId_thenReturnSavedUser`<br>👉 **일치하는 소셜 정보(Provider+ID)로 유저를 조회한다.** | **유저 저장 완료**<br>(KAKAO, id_123)  | **`userRepository.findBySocialId`**<br>`(KAKAO, id_123)` | 1. `Optional`이 비어있지 않다.<br>2. 조회된 유저의 `socialID` 값이 일치한다.             |
+| **INF-008** | `givenInvalidSocialId_`<br>`whenFindBySocialId_thenReturnEmpty`<br>👉 **소셜 정보가 일치하지 않으면 빈 결과를 반환한다.**          | **유저 저장 완료**<br>(GOOGLE, id_999) | **`userRepository.findBySocialId`**<br>`(KAKAO, id_999)` | 1. `Optional`이 비어있다(`isEmpty`).<br>(Provider 불일치 케이스 등)               |
+| **INF-009** | `givenEmail_`<br>`whenExistsByEmail_thenReturnBoolean`<br>👉 **해당 이메일이 존재하는지 조회한다. 존재하면 True를, 존재하지 않으면 False를 반환한다.**                   | **유저 저장 완료 및 타겟 이메일**            | **`userRepository.existsByEamil`**<br>`(email)`          | 1. 해당 이메일이 존재하면 `True`를 반환한다. <br> 2. 해당 이메일이 존재하지 않으면 `False`를 반환한다. |
 
 ---
 
 ## 3. 테스트 결과 요약
 
 ### 3.1. 수행 결과
-| 구분 | 전체 케이스 | Pass | Fail | 비고 |
-| :--- | :---: | :---: | :---: | :--- |
-| **Save (저장)** | 4 | 4 | 0 | Nullable 처리 및 Unique 제약조건 검증 완료 |
-| **Find (조회)** | 4 | 4 | 0 | PK 및 복합 인덱스 조회 검증 완료 |
-| **합계** | **8** | **8** | **0** | **Pass** ✅ |
+| 구분 | 전체 케이스 | Pass  | Fail | 비고 |
+| :--- |:------:|:-----:| :---: | :--- |
+| **Save (저장)** |   4    |   4   | 0 | Nullable 처리 및 Unique 제약조건 검증 완료 |
+| **Find (조회)** |   5    |   5   | 0 | PK 및 복합 인덱스 조회 검증 완료 |
+| **합계** | **9**  | **9** | **0** | **Pass** ✅ |

--- a/docs/TCS/TCS-USR-003.md
+++ b/docs/TCS/TCS-USR-003.md
@@ -1,0 +1,66 @@
+# [TCS] 회원가입 서비스 단위 테스트 명세서
+
+| 문서 ID | **TCS-USR-003**       |
+| :--- |:----------------------|
+| **문서 버전** | 1.0                   |
+| **프로젝트** | AssetMind             |
+| **작성자** | 이재석                   |
+| **작성일** | 2026년 01월 22일         |
+| **대상 모듈** | `UserRegisterService` |
+
+## 1. 개요 (Overview)
+
+본 문서는 회원가입 프로세스를 담당하는 `UserRegisterService`의 비즈니스 로직을 검증하기 위한 단위 테스트 명세이다.
+외부 의존성(Repository, Redis Port, Mail Port 등)을 **Mocking**하여 순수 서비스 로직의 흐름과 예외 처리(Unhappy Path)가 의도대로 동작하는지 확인한다.
+
+### 1.1. 테스트 환경
+- **Framework:** JUnit 5, AssertJ, Mockito
+- **Test Class:** `UserRegisterServiceTest`
+- **Mock Objects:**
+    - `UserRepository`: DB 조회/저장 모의
+    - `VerificationCodePort` / `VerificationCodeGenerator`: 인증 코드 저장/조회/생성 모의
+    - `EmailSendPort`: 메일 발송 모의
+    - `SignUpTokenProvider`: JWT 토큰 처리 모의
+    - `PasswordEncoder` / `UserIdGenerator`: 암호화 및 ID 생성 모의
+
+---
+
+## 2. 테스트 케이스 상세 (Test Cases)
+
+### 2.1. 이메일 중복 체크 (Check Email Duplicate)
+
+| ID | 시나리오 | Given (사전 조건) | When (실행) | Then (기대 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **SVC-REG-001** | **중복되지 않은 이메일 확인** | `Repository.existsByEmail()`이 `false` 반환 | `checkEmailDuplicate(validEmail)` 호출 | 1. 반환값이 `false`여야 한다. |
+| **SVC-REG-002** | **중복된 이메일 확인** | `Repository.existsByEmail()`이 `true` 반환 | `checkEmailDuplicate(duplicateEmail)` 호출 | 1. 반환값이 `true`여야 한다. |
+
+### 2.2. 인증 코드 발송 (Send Verification Code)
+
+| ID | 시나리오 | Given (사전 조건) | When (실행) | Then (기대 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **SVC-REG-003** | **정상 발송**<br>(가입되지 않은 이메일) | 1. 이메일 중복 없음 (`false`)<br>2. 생성기가 코드 `"123456"` 반환 | `sendVerificationCode(email)` 호출 | 1. `VerificationCodePort.save()`가 호출되어야 한다.<br>2. `EmailSendPort.sendEmail()`이 호출되어야 한다. |
+| **SVC-REG-004** | **발송 실패**<br>(이미 가입된 이메일) | 1. 이메일 중복 있음 (`true`) | `sendVerificationCode(email)` 호출 | 1. `UserDuplicatedEmail` 예외가 발생해야 한다.<br>2. 메일 발송 및 저장은 실행되지 않아야 한다. |
+
+### 2.3. 인증 코드 검증 (Verify Code)
+
+| ID | 시나리오 | Given (사전 조건) | When (실행) | Then (기대 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **SVC-REG-005** | **검증 성공**<br>(코드 일치) | 1. Port에 저장된 코드가 입력 코드와 **일치**함<br>2. TokenProvider가 유효한 토큰 반환 | `verifyCode(email, code)` 호출 | 1. `VerificationCodePort.remove()`가 호출되어 삭제되어야 한다.<br>2. 회원가입용 **JWT 토큰**이 반환되어야 한다. |
+| **SVC-REG-006** | **검증 실패**<br>(코드 불일치) | 1. Port에 저장된 코드가 입력 코드와 **다름** (또는 null) | `verifyCode(email, code)` 호출 | 1. `InvalidVerificationCode` 예외가 발생해야 한다.<br>2. `remove()` 메서드는 호출되지 않아야 한다. |
+
+### 2.4. 최종 회원가입 (Register)
+
+| ID | 시나리오 | Given (사전 조건) | When (실행) | Then (기대 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **SVC-REG-007** | **가입 성공**<br>(모든 데이터 유효) | 1. 토큰 내 이메일 == 요청 이메일<br>2. 이메일 중복 없음<br>3. ID 생성기/암호화 정상 동작 | `register(command)` 호출 | 1. `UserRepository.save()`가 1회 호출되어야 한다.<br>2. `PasswordEncoder.encode()`가 호출되어야 한다.<br>3. 생성된 유저의 **UUID**가 반환되어야 한다. |
+| **SVC-REG-008** | **가입 실패**<br>(토큰/요청 이메일 불일치) | 1. 토큰 내 이메일(`invalid`) != 요청 이메일(`valid`) | `register(command)` 호출 | 1. `IllegalArgumentException` 예외가 발생해야 한다.<br>2. `save()`는 호출되지 않아야 한다. |
+| **SVC-REG-009** | **가입 실패**<br>(가입 직전 중복 발견) | 1. 토큰 검증 통과<br>2. `Repository.existsByEmail()`이 `true` 반환 | `register(command)` 호출 | 1. `UserDuplicatedEmail` 예외가 발생해야 한다.<br>2. `save()`는 호출되지 않아야 한다. |
+
+---
+
+## 3. 종합 결과
+
+| 항목 | 전체 케이스 | Pass | Fail | 비고 |
+| :--- | :---: | :---: | :---: | :--- |
+| **Service Logic** | 9 | 9 | 0 | Happy/Unhappy Path 검증 완료 |
+| **합계** | **9** | **9** | **0** | **Pass** ✅ |


### PR DESCRIPTION
## 📌 작업 내용
- **회원가입의 핵심 흐름을 제어하는 비즈니스 로직(`UserRegisterService`)을 구현했습니다.**
- 이메일 인증 코드를 임시 저장하기 위한 **Redis 기반의 저장소 어댑터**를 구현했습니다.
- 테스트 용이성을 확보하기 위해 **난수 생성 로직을 별도 컴포넌트로 분리**하고 어댑터 패턴을 적용했습니다.
- 서비스 계층과 인프라 계층에 대한 **단위 테스트**를 작성하고 검증 명세서를 산출했습니다.

## 🏗 기술적 의사결정 (핵심 변경 사유)

**1. 랜덤 생성 로직의 추상화 (Strategy Pattern 적용)**
> 서비스 코드 내에서 `Math.random()`을 직접 호출하면 테스트 시 생성되는 값을 예측할 수 없어 검증이 어렵습니다.
- **문제점:** 테스트 코드에서 "특정 난수(예: 123456)가 발송되었는지" 검증하려면, 난수 생성 로직을 통제할 수 있어야 합니다.
- **해결책:** `VerificationCodeGenerator` 인터페이스를 정의하고, 구현체(`RandomVerificationCodeAdapter`)로 분리했습니다. 이를 통해 프로덕션 코드에서는 `SecureRandom`을 사용하지만, **테스트 코드에서는 고정된 값을 반환하는 Mock을 주입**하여 테스트의 결정성을 확보했습니다.

**2. Redis 어댑터 도입 및 명명 규칙**
> 인증 코드는 수명이 짧은 임시 데이터이므로 RDB보다 In-Memory DB가 적합합니다.
- **구현:** `RedisVerificationCodeAdapter`를 통해 Redis의 `TTL(Time-To-Live)` 기능을 활용, 3분이 지나면 데이터가 자동 소멸되도록 구현했습니다.
- **설계:** 인터페이스 이름을 `RedisRepository`가 아닌 `VerificationCodePort`로 명명했습니다. 이는 서비스 계층이 'Redis'라는 특정 기술에 종속되지 않고, '인증 코드를 저장한다'는 행위에만 집중하도록 하기 위함입니다. (DIP 준수)

## ✅ 주요 변경점
- **Application Service (`user/application`):**
    - `UserRegisterService`:
        - `sendVerificationCode`: 중복 검사 -> 난수 생성 -> Redis 저장 -> 메일 발송 (Async).
        - `verifyCode`: 코드 검증 -> Redis 삭제 -> **가입용 JWT(SIGN_UP Type) 발급**.
        - `register`: 토큰 검증 -> **이메일 교차 검증(토큰 vs 요청)** -> `User` 도메인 생성 -> DB 저장.
- **Infrastructure Adapters (`user/infrastructure`):**
    - `RedisVerificationCodeAdapter`: `StringRedisTemplate` 활용 및 Key Prefix(`AUTH_CODE:`) 적용.
    - `RandomVerificationCodeAdapter`: 6자리 숫자 난수 생성 구현.
    - `UserIdGeneratorAdapter`: `UUID.randomUUID()` 기반 ID 생성 구현.
- **Tests:**
    - `UserRegisterServiceTest`: 비즈니스 로직의 Happy/Unhappy Path 검증.
    - `RedisVerificationCodeAdapterTest`: Mocking을 통한 Redis 명령어 호출 검증.
    - `TCS-USR-003.md`, `TCS-REDIS-001.md`: 테스트 명세서 추가.
    
## 📝 리뷰 포인트
- **Service 흐름:** `verifyCode`에서 인증 성공 시 **가입용 토큰(JWT)**을 반환하고, `register`에서 이를 다시 검증하는 **Stateless 흐름**이 적절하게 구현되었는지 확인 부탁드립니다.
- **예외 처리:** `UserDuplicatedEmail`, `InvalidVerificationCode` 등 커스텀 예외가 적절한 시점에 발생하는지 검토 바랍니다.