### PR TITLE
[Feat] FRED API Macroeconomic & Commodity Indicator Acquisition Module

### DIFF
--- a/apps/data-pipeline/configs/extractor.yml
+++ b/apps/data-pipeline/configs/extractor.yml
@@ -109,13 +109,41 @@ policy:
   # ----------------------------------------------------------------------------
   # [Group 2] FRED (Federal Reserve Economic Data) 관련 작업
   # ----------------------------------------------------------------------------
-  fred_us_gdp:
-    provider: "FRED" # FREDExtractor 사용
-    description: "미국 실질 GDP (분기별)"
+  # 2-1. 미국 국채 2년물
+  fred_us_treasury_2y:
+    provider: "FRED"
+    description: "미국 국채 금리 2년물 (일별)"
     path: "/series/observations"
     params:
-      series_id: "GDPC1"
-      frequency: "q"
+      series_id: "DGS2" # Market Yield on U.S. Treasury Securities at 2-Year Constant Maturity
+      frequency: "d" # 일별 데이터 (Daily)
+
+  # 2-2. 미국 국채 5년물
+  fred_us_treasury_5y:
+    provider: "FRED"
+    description: "미국 국채 금리 5년물 (일별)"
+    path: "/series/observations"
+    params:
+      series_id: "DGS5" # Market Yield on U.S. Treasury Securities at 5-Year Constant Maturity
+      frequency: "d"
+
+  # 2-3. 미국 국채 10년물 (시장 벤치마크)
+  fred_us_treasury_10y:
+    provider: "FRED"
+    description: "미국 국채 금리 10년물 (일별)"
+    path: "/series/observations"
+    params:
+      series_id: "DGS10" # Market Yield on U.S. Treasury Securities at 10-Year Constant Maturity
+      frequency: "d"
+
+  # 2-4. 미국 국채 30년물
+  fred_us_treasury_30y:
+    provider: "FRED"
+    description: "미국 국채 금리 30년물 (일별)"
+    path: "/series/observations"
+    params:
+      series_id: "DGS30" # Market Yield on U.S. Treasury Securities at 30-Year Constant Maturity
+      frequency: "d"
 
   # ----------------------------------------------------------------------------
   # [Group 3] 한국은행 (ECOS) 관련 작업

--- a/apps/data-pipeline/src/extractor/providers/fred_extractor.py
+++ b/apps/data-pipeline/src/extractor/providers/fred_extractor.py
@@ -1,0 +1,192 @@
+"""
+FRED 데이터 수집기 모듈 (FRED Extractor)
+
+이 모듈은 St. Louis Fed의 FRED API를 통해 경제 지표 데이터를 수집합니다.
+기본 XML 응답을 JSON으로 강제 변환하고, 쿼리 파라미터 기반의 인증을 처리합니다.
+
+데이터 흐름 (Data Flow):
+RequestDTO(job_id) -> Validate(Config.policy) -> Merge Params(API Key + Format) -> Async API Call -> Error Check -> ResponseDTO
+
+주요 기능:
+- FRED API 호출 시 `file_type=json` 파라미터 강제 주입 (XML 파싱 비용 제거)
+- Policy(설정)와 Request(요청) 파라미터의 동적 병합 및 우선순위 처리
+- API 응답 내 논리적 에러(HTTP 200 OK 내의 Error Message) 감지
+
+Trade-off:
+- Method Override (extract):
+    - 상황: AbstractExtractor._create_response는 job_id를 인자로 받지 않음.
+    - 결정: KISExtractor와 동일하게 extract 메서드를 오버라이딩하여 ResponseDTO 생성 시 job_id를 주입.
+    - 근거: 부모 클래스의 서명(Signature)을 변경하지 않고 메타데이터(Job ID) 추적성을 확보하기 위함.
+"""
+
+from typing import Any, Dict, Optional
+from datetime import datetime
+
+from .abstract_extractor import AbstractExtractor
+from ..domain.interfaces import IHttpClient
+from ..domain.dtos import RequestDTO, ResponseDTO
+from ..domain.exceptions import ExtractorError
+from ...common.config import AppConfig
+
+
+class FREDExtractor(AbstractExtractor):
+    """설정(AppConfig)에 정의된 정책을 기반으로 FRED API를 호출하는 수집기.
+
+    Attributes:
+        http_client (IHttpClient): HTTP 요청 처리를 위한 어댑터.
+        config (AppConfig): 앱 전역 설정 객체 (FRED API Key 포함).
+    """
+
+    def __init__(self, http_client: IHttpClient, config: AppConfig):
+        """FREDExtractor를 초기화하고 필수 의존성을 검증합니다.
+
+        Args:
+            http_client (IHttpClient): HTTP 클라이언트.
+            config (AppConfig): 앱 설정 객체.
+
+        Raises:
+            ExtractorError: FRED 관련 필수 설정(Base URL, API Key)이 누락된 경우.
+        """
+        # 1. 부모 클래스 초기화 (Config None 체크 포함)
+        super().__init__(http_client, config)
+
+        # 2. FRED 전용 필수 설정 검증 (Fail-Fast)
+        # Rationale: AppConfig 객체가 존재하더라도 내부 필드가 비어있으면 런타임 에러가 발생하므로 생성 시점에 확인.
+        if not config.fred.base_url:
+            raise ExtractorError("Critical Config Error: 'fred.base_url' is empty.")
+        if not config.fred.api_key:
+            raise ExtractorError("Critical Config Error: 'fred.api_key' is missing.")
+
+    async def extract(self, request: RequestDTO) -> ResponseDTO:
+        """데이터 수집 템플릿 메서드 (Overridden).
+
+        AbstractExtractor의 기본 흐름을 따르되, _create_response 단계에서
+        job_id를 주입하기 위해 KISExtractor와 동일하게 오버라이딩하였습니다.
+
+        Args:
+            request (RequestDTO): 요청 객체.
+
+        Returns:
+            ResponseDTO: 결과 객체.
+
+        Raises:
+            ExtractorError: 수집 실패 시.
+        """
+        try:
+            # Step 1: Validation
+            self._validate_request(request)
+
+            # Step 2: Execution (Preparation & I/O)
+            raw_data = await self._fetch_raw_data(request)
+
+            # Step 3: Packaging
+            # Rationale: 부모 클래스의 _create_response는 raw_data만 받도록 정의되어 있어,
+            # job_id를 포함시키기 위해 이곳에서 호출 구조를 변경함.
+            response = self._create_response(raw_data, request.job_id)
+            
+            self.logger.info(f"Extraction Successful | Job: {request.job_id} | Source: FRED")
+            return response
+
+        except ExtractorError as e:
+            # 도메인 에러는 로깅 후 상위로 전파
+            self.logger.error(f"Extraction Failed: {e}")
+            raise e
+        except Exception as e:
+            # 예상치 못한 에러는 래핑하여 전파
+            self.logger.error(f"Unexpected System Error: {e}", exc_info=True)
+            raise ExtractorError(f"System Error: {str(e)}")
+
+    def _validate_request(self, request: RequestDTO) -> None:
+        """요청된 Job이 FRED 정책에 부합하고 필수 파라미터를 가졌는지 검증합니다.
+
+        Args:
+            request (RequestDTO): 요청 객체.
+
+        Raises:
+            ExtractorError: 정책 미존재, Provider 불일치, 필수 파라미터(series_id) 누락 시.
+        """
+        if not request.job_id:
+            raise ExtractorError("Invalid Request: 'job_id' is mandatory.")
+
+        policy = self.config.extraction_policy.get(request.job_id)
+
+        # 1. Policy 존재 여부 확인
+        if not policy:
+            self.logger.error(f"Policy missing for job_id: {request.job_id}")
+            raise ExtractorError(f"Configuration Error: Policy not found for job_id '{request.job_id}'.")
+
+        # 2. Provider 일치 여부 확인
+        if policy.provider != "FRED":
+            raise ExtractorError(f"Provider Mismatch: Job '{request.job_id}' is for '{policy.provider}', not 'FRED'.")
+
+        # 3. 필수 파라미터(series_id) 확인
+        # Rationale: FRED API의 핵심 식별자인 'series_id'가 Config나 Request 어디에도 없으면 호출이 불가능함.
+        # KISExtractor가 'tr_id'를 검사하는 것과 동일한 로직.
+        has_series_id_in_policy = "series_id" in policy.params
+        has_series_id_in_request = "series_id" in request.params
+
+        if not (has_series_id_in_policy or has_series_id_in_request):
+            raise ExtractorError(f"Missing Parameter: 'series_id' is required for job '{request.job_id}'.")
+
+    async def _fetch_raw_data(self, request: RequestDTO) -> Any:
+        """FRED API를 호출하여 원본 데이터를 가져옵니다.
+
+        Args:
+            request (RequestDTO): 요청 객체.
+
+        Returns:
+            Any: API 원본 응답 (Dict).
+        """
+        policy = self.config.extraction_policy[request.job_id]
+
+        # 1. URL 구성
+        url = f"{self.config.fred.base_url}{policy.path}"
+
+        # 2. 파라미터 병합 (Policy < Request < System Forced)
+        merged_params = policy.params.copy()
+        merged_params.update(request.params)
+        
+        # Rationale: FRED는 기본적으로 XML을 반환하므로 시스템 차원에서 JSON을 강제함.
+        merged_params["file_type"] = "json"
+        
+        # 3. 인증 정보 주입
+        # Rationale: FRED는 Header가 아닌 Query Parameter로 api_key를 받음.
+        # SecretStr 타입인 api_key를 안전하게 평문으로 변환하여 주입.
+        merged_params["api_key"] = self.config.fred.api_key.get_secret_value()
+
+        self.logger.debug(f"Executing FRED Request | Job: {request.job_id} | Path: {policy.path}")
+
+        # 4. HTTP 요청 수행
+        return await self.http_client.get(url, params=merged_params)
+
+    def _create_response(self, raw_data: Any, job_id: str) -> ResponseDTO:
+        """API 응답을 검증하고 ResponseDTO로 포장합니다.
+
+        Args:
+            raw_data (Any): API 원본 응답.
+            job_id (str): 작업 ID.
+
+        Returns:
+            ResponseDTO: 결과 객체.
+
+        Raises:
+            ExtractorError: API 응답 내 에러 메시지가 포함된 경우.
+        """
+        # Rationale: FRED API는 HTTP 200 응답에도 JSON Body에 에러 메시지를 포함할 수 있음.
+        # 예: {"error_code": 400, "error_message": "Bad Request"}
+        if "error_message" in raw_data:
+            msg = raw_data.get("error_message")
+            code = raw_data.get("error_code", "Unknown")
+            self.logger.error(f"FRED API Business Failure: {msg} (Code: {code})")
+            raise ExtractorError(f"FRED API Failed: {msg} (Code: {code})")
+
+        return ResponseDTO(
+            data=raw_data,
+            meta={
+                "source": "FRED",
+                "job_id": job_id,
+                "extracted_at": datetime.now().isoformat(),
+                # FRED API는 명시적인 성공 코드를 JSON에 주지 않으므로 HTTP 성공을 가정하여 200 기재
+                "status_code": "200"
+            }
+        )

--- a/apps/data-pipeline/src/verification.py
+++ b/apps/data-pipeline/src/verification.py
@@ -1,6 +1,7 @@
 from src.common.config import get_config
 from src.extractor.domain.interfaces import IAuthStrategy, IHttpClient
 from src.extractor.providers.kis_extractor import KISExtractor
+from src.extractor.providers.fred_extractor import FREDExtractor
 from typing import Any, Dict
 
 class MockHttpClient(IHttpClient):
@@ -16,7 +17,7 @@ class MockAuthStrategy(IAuthStrategy):
     async def get_token(self, http_client: IHttpClient) -> str:
         return "Bearer MOCK_TOKEN"
 
-def config_verification():
+def verify_config():
     """설정 모듈의 정상 동작 여부를 확인하는 내부 함수."""
     print("="*60)
     print(">>> [Step 1] Configuration Loading Started...")
@@ -52,78 +53,119 @@ def config_verification():
 
     print("✅ Verification Completed.")
 
-def kis_extractor_verification():
+def verify_extractor(target_provider: str = "KIS"):
+    """특정 Provider에 대한 설정 및 Extractor 초기화를 검증합니다.
+
+    Args:
+        target_provider (str): 'KIS' 또는 'FRED'
+    """
+    target_provider = target_provider.upper()
     print("="*80)
-    print(">>> [Step 1] Configuration Loading Verification")
+    print(f">>> [Verification Start] Target Provider: {target_provider}")
     print("="*80)
 
-    target_task = "extractor"
-    
+    # -----------------------------------------------------
+    # Step 1. Configuration Loading
+    # -----------------------------------------------------
+    print(f"\n>>> [Step 1] Loading Configuration...")
     try:
-        config = get_config(task_name=target_task)
+        config = get_config(task_name="extractor")
         print(f"✅ AppConfig Loaded Successfully!")
         print(f"   - Task Name: {config.task_name}")
-        print(f"   - Policy Count: {len(config.extraction_policy)}")
-        print("-" * 80 + "\n")
+        print(f"   - Total Policies: {len(config.extraction_policy)}")
     except Exception as e:
         print(f"❌ CRITICAL ERROR: Failed to load config. \n{e}")
         return
 
-    print("="*80)
-    print(">>> [Step 2] KIS Extractor Initialization & Policy Mapping Verification")
-    print("="*80)
+    # -----------------------------------------------------
+    # Step 2. Extractor Initialization (Dependency Injection)
+    # -----------------------------------------------------
+    print(f"\n>>> [Step 2] Initializing {target_provider} Extractor...")
 
-    # 1. Mock 의존성 주입 및 Extractor 생성
     mock_http = MockHttpClient()
     mock_auth = MockAuthStrategy()
+    extractor = None
 
     try:
-        # KISExtractor가 AppConfig를 올바르게 참조하는지 테스트
-        extractor = KISExtractor(
-            http_client=mock_http, 
-            auth_strategy=mock_auth, 
-            config=config
-        )
-        print("✅ KISExtractor Instantiated Successfully!")
+        if target_provider == "KIS":
+            # KIS는 AuthStrategy가 필수
+            extractor = KISExtractor(
+                http_client=mock_http, 
+                auth_strategy=mock_auth, 
+                config=config
+            )
+            # KIS Global Config Check
+            is_key_present = bool(config.kis.app_key.get_secret_value())
+            print(f"✅ KISExtractor Instantiated.")
+            print(f"   - Base URL: {config.kis.base_url}")
+            print(f"   - App Key:  {'[PROTECTED]' if is_key_present else '[MISSING]'}")
+
+        elif target_provider == "FRED":
+            # FRED는 AuthStrategy 불필요 (Config 내 API Key 사용)
+            extractor = FREDExtractor(
+                http_client=mock_http,
+                config=config
+            )
+            # FRED Global Config Check
+            is_key_present = bool(config.fred.api_key.get_secret_value())
+            print(f"✅ FREDExtractor Instantiated.")
+            print(f"   - Base URL: {config.fred.base_url}")
+            print(f"   - API Key:  {'[PROTECTED]' if is_key_present else '[MISSING]'}")
         
-        # 2. Global KIS Setting 확인
-        print(f"   - Base URL: {config.kis.base_url}")
-        print(f"   - App Key:  {'[PROTECTED]' if config.kis.app_key.get_secret_value() else '[MISSING]'}")
-        print("\n")
+        else:
+            print(f"❌ ERROR: Unknown provider type '{target_provider}'")
+            return
 
     except Exception as e:
-        print(f"❌ ERROR: Failed to initialize KISExtractor. Check your 'config.py' and 'kis_extractor.py' compatibility.")
+        print(f"❌ ERROR: Failed to initialize {target_provider} Extractor.")
         print(f"Details: {e}")
         return
 
-    # 3. KIS 관련 정책 전수 조사 및 출력
-    print(">>> [Step 3] Verifying Collected KIS Policies (Details)")
+    # -----------------------------------------------------
+    # Step 3. Policy Mapping Verification
+    # -----------------------------------------------------
+    print(f"\n>>> [Step 3] Verifying {target_provider} Policies in YAML")
     
-    kis_policies = {
+    # Provider 일치하는 정책 필터링
+    target_policies = {
         k: v for k, v in config.extraction_policy.items() 
-        if v.provider == "KIS"
+        if v.provider == target_provider
     }
 
-    if not kis_policies:
-        print("⚠️ WARNING: No KIS policies found in 'extractor.yml'.")
+    if not target_policies:
+        print(f"⚠️ WARNING: No policies found for provider '{target_provider}'. Check 'extractor.yml'.")
     else:
-        print(f"🔍 Found {len(kis_policies)} KIS Job(s). Printing details...\n")
+        print(f"🔍 Found {len(target_policies)} Job(s). Printing details...\n")
         
-        for job_id, policy in kis_policies.items():
+        for job_id, policy in target_policies.items():
             print(f"🔹 [Job ID] {job_id}")
             print(f"   • Description : {policy.description}")
-            print(f"   • Endpoint    : {config.kis.base_url}{policy.path}")
-            print(f"   • TR_ID       : {policy.tr_id}")
-            print(f"   • Params      : {policy.params}")
             
-            # 도메인 구분 확인 (국내/해외)
-            domain_label = policy.domain if policy.domain else "N/A"
-            print(f"   • Domain      : {domain_label}")
+            # URL 조합 시뮬레이션
+            base_url = config.kis.base_url if target_provider == "KIS" else config.fred.base_url
+            full_path = f"{base_url}{policy.path}"
+            print(f"   • Endpoint    : {full_path}")
+
+            # Provider별 핵심 속성 출력 분기
+            if target_provider == "KIS":
+                print(f"   • TR_ID       : {policy.tr_id}")
+                print(f"   • Domain      : {policy.domain}")
+            
+            elif target_provider == "FRED":
+                # FRED는 params 안에 핵심 정보(series_id)가 있음
+                s_id = policy.params.get('series_id', 'MISSING')
+                freq = policy.params.get('frequency', 'N/A')
+                print(f"   • Series ID   : {s_id}")
+                print(f"   • Frequency   : {freq}")
+
+            print(f"   • Params      : {policy.params}")
             print("   ----------------------------------------------------------------------------")
 
-    print("\n✅ Verification Completed.")
+    print(f"\n✅ [{target_provider}] Verification Completed.")
+    print("\n" + " " * 80 + "\n")
 
 
 if __name__ == "__main__":
-    #config_verification()
-    kis_extractor_verification()
+    #verify_config()
+    #verify_extractor(target_provider="KIS")
+    verify_extractor(target_provider="FRED")

--- a/apps/data-pipeline/tests/unit/extractor/providers/fred_extractor_test.py
+++ b/apps/data-pipeline/tests/unit/extractor/providers/fred_extractor_test.py
@@ -1,0 +1,237 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from datetime import datetime
+
+from src.extractor.domain.dtos import RequestDTO, ResponseDTO
+from src.extractor.domain.exceptions import ExtractorError
+from src.extractor.providers.fred_extractor import FREDExtractor
+
+# -------------------------------------------------------------------------
+# Mocks & Fixtures
+# -------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_http_client():
+    """IHttpClient Mock: 실제 네트워크 요청 차단 및 파라미터 검증용"""
+    client = MagicMock()
+    client.get = AsyncMock()
+    return client
+
+@pytest.fixture
+def mock_config():
+    """AppConfig Mock: FRED 전용 설정 및 정책 주입"""
+    config = MagicMock()
+    
+    # 1. FRED 기본 설정 (Base URL & API Key)
+    config.fred.base_url = "https://api.stlouisfed.org"
+    # SecretStr 동작 모방: get_secret_value() 호출 시 평문 반환
+    config.fred.api_key.get_secret_value.return_value = "TEST_FRED_KEY"
+    
+    # 2. 정책(Policy) 설정
+    # Case A: Normal Policy (series_id included)
+    normal_policy = MagicMock()
+    normal_policy.provider = "FRED"
+    normal_policy.path = "/fred/series/observations"
+    normal_policy.params = {"series_id": "GDP", "frequency": "q"} # Default Params
+    
+    # Case B: Policy without series_id (to test request injection)
+    flexible_policy = MagicMock()
+    flexible_policy.provider = "FRED"
+    flexible_policy.path = "/fred/series/observations"
+    flexible_policy.params = {"frequency": "m"} # series_id missing here
+    
+    # Case C: Provider Mismatch
+    kis_policy = MagicMock()
+    kis_policy.provider = "KIS" # Not FRED
+    
+    config.extraction_policy = {
+        "valid_job": normal_policy,
+        "flex_job": flexible_policy,
+        "kis_job": kis_policy
+    }
+    return config
+
+@pytest.fixture
+def extractor(mock_http_client, mock_config):
+    """FREDExtractor 인스턴스 생성 (LogManager 의존성 제거)"""
+    
+    # Critical Fix: KIS 테스트와 동일하게 부모 클래스의 LogManager 호출을 무력화
+    with patch("src.extractor.providers.abstract_extractor.LogManager") as MockLogManager:
+        MockLogManager.get_logger.return_value = MagicMock()
+        
+        # FRED는 AuthStrategy가 필요 없으므로 http_client와 config만 주입
+        extractor_instance = FREDExtractor(mock_http_client, mock_config)
+        return extractor_instance
+
+# -------------------------------------------------------------------------
+# Test Cases (TC-001 ~ TC-013)
+# -------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tc_001_happy_path_success(extractor, mock_http_client):
+    """[TC-001] 정상 Config, Policy, 응답(No Error Msg) -> 성공"""
+    # Given
+    request = RequestDTO(job_id="valid_job")
+    mock_data = {"realtime_start": "2024-01-01", "observations": [{"value": "100"}]}
+    mock_http_client.get.return_value = mock_data
+
+    # When
+    response = await extractor.extract(request)
+
+    # Then
+    assert response.data == mock_data
+    assert response.meta["source"] == "FRED"
+    assert response.meta["status_code"] == "200" # FRED는 명시적 코드가 없으므로 200 가정
+    assert response.meta["job_id"] == "valid_job"
+    mock_http_client.get.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_tc_002_logic_param_merge_distinct(extractor, mock_http_client):
+    """[TC-002] Policy Param과 Request Param 병합 확인"""
+    # Given
+    # Policy: {'series_id': 'GDP', 'frequency': 'q'}
+    request = RequestDTO(job_id="valid_job", params={"observation_start": "2020-01-01"})
+    mock_http_client.get.return_value = {}
+
+    # When
+    await extractor.extract(request)
+
+    # Then
+    call_params = mock_http_client.get.call_args[1]["params"]
+    assert call_params["series_id"] == "GDP"
+    assert call_params["frequency"] == "q"
+    assert call_params["observation_start"] == "2020-01-01"
+
+@pytest.mark.asyncio
+async def test_tc_003_logic_forced_json_injection(extractor, mock_http_client):
+    """[TC-003] Request가 xml을 요청해도 시스템이 json을 강제해야 함"""
+    # Given
+    request = RequestDTO(job_id="valid_job", params={"file_type": "xml"})
+    mock_http_client.get.return_value = {}
+
+    # When
+    await extractor.extract(request)
+
+    # Then
+    call_params = mock_http_client.get.call_args[1]["params"]
+    assert call_params["file_type"] == "json" # Override Check
+
+@pytest.mark.asyncio
+async def test_tc_004_logic_api_key_injection(extractor, mock_http_client):
+    """[TC-004] Config의 SecretKey가 평문으로 Query Param에 주입되어야 함"""
+    # Given
+    request = RequestDTO(job_id="valid_job")
+    mock_http_client.get.return_value = {}
+
+    # When
+    await extractor.extract(request)
+
+    # Then
+    call_params = mock_http_client.get.call_args[1]["params"]
+    assert call_params["api_key"] == "TEST_FRED_KEY"
+
+@pytest.mark.asyncio
+async def test_tc_005_boundary_series_id_in_request(extractor, mock_http_client):
+    """[TC-005] Policy에 series_id가 없어도 Request에 있으면 성공"""
+    # Given
+    # 'flex_job' policy has no series_id
+    request = RequestDTO(job_id="flex_job", params={"series_id": "CPI"})
+    mock_http_client.get.return_value = {}
+
+    # When
+    await extractor.extract(request)
+
+    # Then
+    call_params = mock_http_client.get.call_args[1]["params"]
+    assert call_params["series_id"] == "CPI"
+
+@pytest.mark.asyncio
+async def test_tc_006_boundary_empty_request_params(extractor, mock_http_client):
+    """[TC-006] Request Params가 비어있으면 Policy 기본값 사용"""
+    # Given
+    request = RequestDTO(job_id="valid_job", params={})
+    mock_http_client.get.return_value = {}
+
+    # When
+    await extractor.extract(request)
+
+    # Then
+    call_params = mock_http_client.get.call_args[1]["params"]
+    assert call_params["series_id"] == "GDP"
+
+def test_tc_007_config_empty_base_url(mock_http_client, mock_config):
+    """[TC-007] Config의 base_url이 비어있으면 초기화 시 에러"""
+    # Given
+    mock_config.fred.base_url = ""
+
+    # When & Then
+    with patch("src.extractor.providers.abstract_extractor.LogManager") as MockLogManager:
+        MockLogManager.get_logger.return_value = MagicMock()
+        with pytest.raises(ExtractorError, match="Critical Config Error"):
+            FREDExtractor(mock_http_client, mock_config)
+
+@pytest.mark.asyncio
+async def test_tc_008_error_missing_job_id(extractor):
+    """[TC-008] job_id 누락 시 ExtractorError"""
+    # Given
+    request = RequestDTO(job_id=None)
+
+    # When & Then
+    with pytest.raises(ExtractorError, match="Invalid Request: 'job_id' is mandatory"):
+        await extractor.extract(request)
+
+@pytest.mark.asyncio
+async def test_tc_009_error_unknown_policy(extractor):
+    """[TC-009] Config에 없는 job_id 요청 시 ExtractorError"""
+    # Given
+    request = RequestDTO(job_id="unknown_job")
+
+    # When & Then
+    with pytest.raises(ExtractorError, match="Policy not found"):
+        await extractor.extract(request)
+
+@pytest.mark.asyncio
+async def test_tc_010_error_provider_mismatch(extractor):
+    """[TC-010] Policy Provider가 FRED가 아님 -> ExtractorError"""
+    # Given
+    request = RequestDTO(job_id="kis_job") # Provider is KIS
+
+    # When & Then
+    with pytest.raises(ExtractorError, match="Provider Mismatch"):
+        await extractor.extract(request)
+
+@pytest.mark.asyncio
+async def test_tc_011_error_missing_series_id(extractor):
+    """[TC-011] Policy와 Request 모두 series_id 누락 -> ExtractorError"""
+    # Given
+    # 'flex_job' has no series_id in policy
+    request = RequestDTO(job_id="flex_job", params={}) 
+
+    # When & Then
+    with pytest.raises(ExtractorError, match="Missing Parameter: 'series_id' is required"):
+        await extractor.extract(request)
+
+@pytest.mark.asyncio
+async def test_tc_012_error_fred_business_failure(extractor, mock_http_client):
+    """[TC-012] HTTP 200이지만 Body에 error_message 포함 -> ExtractorError"""
+    # Given
+    request = RequestDTO(job_id="valid_job")
+    mock_http_client.get.return_value = {
+        "error_code": 400,
+        "error_message": "Bad Request. The value for variable series_id cannot be found."
+    }
+
+    # When & Then
+    with pytest.raises(ExtractorError, match="FRED API Failed: Bad Request"):
+        await extractor.extract(request)
+
+@pytest.mark.asyncio
+async def test_tc_013_error_system_failure(extractor, mock_http_client):
+    """[TC-013] HttpClient 네트워크 예외 발생 -> System Error로 래핑"""
+    # Given
+    request = RequestDTO(job_id="valid_job")
+    mock_http_client.get.side_effect = Exception("Connection Timeout")
+
+    # When & Then
+    with pytest.raises(ExtractorError, match="System Error: Connection Timeout"):
+        await extractor.extract(request)

--- a/docs/TCS/data-pipeline/TCS-ETL-003.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-003.md
@@ -1,0 +1,35 @@
+# FRED Extractor Test Specification
+
+## 1. 개요
+
+- **Target Module:** `src.extractor.providers.fred_extractor.FREDExtractor`
+- **Purpose:** FRED API 호출 로직의 정합성, 파라미터 병합 우선순위, JSON 강제 변환 로직 및 예외 처리를 검증.
+- **Reference:** `kis_extractor_test.py` (구조적 일관성 유지)
+
+## 2. 테스트 환경 및 전략
+
+- **Mocking:**
+  - `IHttpClient`: 실제 외부 API 호출 차단 및 응답 조작.
+  - `AppConfig`: Pydantic 검증 로직 격리 및 테스트용 정책(Policy) 주입.
+  - `LogManager`: `src.extractor.providers.abstract_extractor` 내부의 로거 호출을 Patch하여 Global Config 의존성 제거 (Critical).
+- **Assertions:**
+  - `RequestDTO` -> `Params Merge` -> `HttpClient Call` -> `ResponseDTO` 흐름 검증.
+  - `file_type=json` 및 `api_key` 주입 여부 필수 검증.
+
+## 3. 테스트 케이스 명세
+
+|  Test ID   | Category  | Given (Preconditions)                                                                                 | When (Action)           | Then (Expected Outcome)                                                                             | Input Data                    | Priority |
+| :--------: | :-------: | :---------------------------------------------------------------------------------------------------- | :---------------------- | :-------------------------------------------------------------------------------------------------- | :---------------------------- | :------- |
+| **TC-001** |   Unit    | 1. Config 정상 설정<br>2. Policy에 `series_id` 존재<br>3. API가 정상 JSON 반환 (`error_message` 없음) | `extract(request)` 호출 | 1. `ResponseDTO` 반환 성공<br>2. `source`="FRED"<br>3. `status_code`="200"<br>4. HTTP 호출 1회 발생 | `job_id="valid_job"`          | High     |
+| **TC-002** |   Unit    | 1. Policy Params: `{'freq': 'm'}`<br>2. Request Params: `{'start': '2020'}`                           | `extract(request)` 호출 | HTTP 호출 시 파라미터가 `{freq, start, api_key, file_type}` 모두 포함되어야 함                      | `params={'start': '2020'}`    | Medium   |
+| **TC-003** |   Unit    | 1. Request Params에 `file_type='xml'` 포함                                                            | `extract(request)` 호출 | **[FRED 특화]**<br>HTTP 호출 시 `file_type` 파라미터가 반드시 `'json'`으로 강제 변환되어야 함       | `params={'file_type': 'xml'}` | High     |
+| **TC-004** |   Unit    | 1. Config API Key = `'SECRET'`                                                                        | `extract(request)` 호출 | **[FRED 특화]**<br>HTTP 호출 파라미터에 `api_key='SECRET'`가 포함되어야 함                          | `job_id="valid_job"`          | High     |
+| **TC-005** |   Unit    | 1. Policy Params에 `series_id` 없음<br>2. Request Params에 `series_id` 존재                           | `extract(request)` 호출 | 정상 처리 (Request 파라미터로 필수값 충족)                                                          | `params={'series_id': 'GDP'}` | Medium   |
+| **TC-006** |   Edge    | 1. Request Params가 `{}` (Empty)                                                                      | `extract(request)` 호출 | Policy에 정의된 기본 파라미터만 사용하여 호출                                                       | `params={}`                   | Low      |
+| **TC-007** |   Unit    | 1. Config의 `fred.base_url`이 비어있음                                                                | `FREDExtractor` 초기화  | `ExtractorError("Critical Config Error...")` 발생                                                   | `Config(base_url="")`         | High     |
+| **TC-008** | Exception | 1. Request의 `job_id`가 `None`                                                                        | `extract(request)` 호출 | `ExtractorError("Invalid Request...")` 발생                                                         | `request(job_id=None)`        | Medium   |
+| **TC-009** | Exception | 1. 요청한 `job_id`가 Config Policy에 없음                                                             | `extract(request)` 호출 | `ExtractorError("Policy not found...")` 발생                                                        | `job_id="unknown"`            | Medium   |
+| **TC-010** | Exception | 1. Policy의 Provider가 "FRED"가 아님 (예: "KIS")                                                      | `extract(request)` 호출 | `ExtractorError("Provider Mismatch...")` 발생                                                       | `job_id="kis_job"`            | Medium   |
+| **TC-011** | Exception | 1. Policy와 Request 양쪽 모두 `series_id` 누락                                                        | `extract(request)` 호출 | `ExtractorError("Missing Parameter: 'series_id'...")` 발생                                          | `params={}`                   | High     |
+| **TC-012** | Exception | 1. API 응답(200 OK) Body에 `{"error_message": "Bad Request"}` 포함                                    | `extract(request)` 호출 | **[FRED 특화]**<br>`ExtractorError("FRED API Failed: Bad Request...")` 발생                         | `job_id="valid_job"`          | High     |
+| **TC-013** | Exception | 1. HTTP Client가 예기치 않은 Exception 발생                                                           | `extract(request)` 호출 | 로깅 후 `ExtractorError("System Error: ...")` 래핑 발생                                             | `job_id="valid_job"`          | Low      |


### PR DESCRIPTION
## 1. 🎫 PR 요약
> **St. Louis Fed API를 통해 미국 주요 경제 지표를 수집하기 위한 `FREDExtractor` 구현 및 테스트 코드 추가.**
- FRED API 특성을 고려하여 XML 응답 대신 JSON을 강제하고, Query Parameter 기반의 인증 처리 및 HTTP 200 OK 내 논리적 에러 핸들링 로직을 구현했습니다.

## 2. 🛠 작업 내용
- **모듈 구현:** `AbstractExtractor`를 상속받은 `FREDExtractor` 클래스 구현.
- **파라미터 로직:** 파라미터 병합 우선순위 정의 (Policy < Request < System Forced) 및 API Key 주입 로직 개발.
- **설정 추가:** `extractor.yml`에 미국 국채 금리(2년, 5년, 10년, 30년물) 수집을 위한 정책 등록.
- **테스트:**
  - `TCS-ETL-003` 명세에 따른 단위 테스트 13종(TC-001 ~ TC-013) 구현.
  - `verification.py`에 FRED 수집기 초기화 및 정책 검증 로직 추가.

## 3. 💡 기술적 의사결정 (Architecture & Tech Stack)

### A. JSON 응답 포맷 강제 (`file_type=json`)
- **결정 배경:** FRED API는 기본적으로 XML을 반환하나, 시스템의 데이터 파이프라인은 JSON 처리에 최적화되어 있습니다.
- **구현:** `_fetch_raw_data` 단계에서 시스템 레벨로 `file_type="json"` 파라미터를 강제 주입했습니다.
- **Trade-off:** XML 파싱 로직을 별도로 구현할 필요가 없어 복잡도를 낮추고 처리 속도를 높였으나, 향후 XML 전용 데이터가 필요할 경우 유연성은 다소 떨어집니다.

### B. 동적 파라미터 병합 및 API Key 주입 전략
- **결정 배경:** FRED는 Header가 아닌 Query Parameter로 API Key를 요구하며, `series_id`가 필수입니다.
- **구현:** `Policy Params` ➔ `Request Params` ➔ `System Injections` 순서로 병합되는 로직을 구현했습니다.
- **보안 및 안전성:** 사용자가 요청(Request)으로 포맷을 변경하거나 인증 정보를 덮어쓰지 못하도록 System Injection(API Key, File Type)을 가장 마지막에 적용하여 보안성을 확보했습니다.

### C. `extract` 메서드 오버라이딩 (부모 클래스와의 차이)
- **결정 배경:** 부모 클래스의 `_create_response` 메서드는 `job_id`를 인자로 받지 않아, 최종 결과 객체(`ResponseDTO`)에 작업 ID를 메타데이터로 남기기 어려웠습니다.
- **구현:** `extract` 메서드 전체를 오버라이딩하여 패키징 단계에서 `job_id`를 주입하도록 변경했습니다.
- **Trade-off:** 부모 클래스의 템플릿 메서드 패턴을 일부 벗어나 코드 중복(Try-Catch 블록)이 발생했으나, 데이터 추적성(Traceability) 확보가 더 중요하다고 판단했습니다.

### D. Soft Error (HTTP 200 내 에러) 처리
- **결정 배경:** FRED API는 잘못된 요청(예: 존재하지 않는 Series ID)에도 HTTP 200을 반환하며, Body에 에러 메시지를 포함하는 경우가 있습니다.
- **구현:** 응답 데이터에 `error_message` 필드가 존재할 경우 이를 감지하여 즉시 `ExtractorError`를 발생시키는 방어 로직을 추가했습니다.

## 4. 📋 주요 변경점

### `src/extractor/providers/fred_extractor.py`
- `_validate_request`: Policy 또는 Request에 `series_id`가 존재하는지 교차 검증.
- `_fetch_raw_data`: `AppConfig`의 `SecretStr` API Key를 평문으로 변환하여 쿼리 파라미터에 병합.
- `_create_response`: FRED 비즈니스 에러 감지 로직 추가.

### `tests/extractor/fred_extractor_test.py`
- TCS-ETL-003에 정의된 전 케이스 커버 (정상 케이스, 파라미터 병합 확인, 강제 JSON 주입 확인, 예외 처리 등).
- **Fixture 수정:** `LogManager`를 Mocking하여 테스트 환경에서 전역 설정 의존성 제거.

### `configs/extractor.yml` (FRED 관련)
- 미국 국채 금리 데이터 수집을 위한 Job ID 등록:
  - `fred_us_treasury_2y` ~ `30y` (DGS2, DGS5, DGS10, DGS30).

### `verification.py` (FRED 관련)
- `FREDExtractor`는 `AuthStrategy`가 필요 없으므로, 이를 제외하고 Config만으로 초기화하는 분기 로직 추가.
- YAML 정책 검증 시 FRED 전용 필드(`series_id`, `frequency`) 출력 기능 추가.

## 5. 📸 테스트 결과

### Unit Test Execution (pytest)
- **결과:** 총 13개 테스트 케이스(TC-001 ~ TC-013) **전체 통과 (Passed)**.
- **커버리지:**
  - Happy Path (데이터 정상 수집 확인)
  - Edge Case (파라미터 우선순위, JSON 강제 주입 확인)
  - Exception Handling (설정 누락, Provider 불일치, FRED 내부 에러 감지)

## 6. 💬 리뷰 포인트 (Focus On)
- **파라미터 우선순위 로직:** `Policy` < `Request` < `System` 순서가 의도대로 모든 엣지 케이스를 커버하는지 검토 부탁드립니다.
- **에러 감지:** FRED API의 실패 응답 패턴으로 `error_message` 키 유무만 확인하고 있는데, 추가적인 실패 패턴이 있는지 확인이 필요합니다.
- **설정 값:** `extractor.yml`에 등록된 Treasury Series ID(`DGS*`)가 정확한지 확인 부탁드립니다.