### PR TITLE
[Feat] ECOS API Domestic Interest Rate & Bond Data Acquisition Module

### DIFF
--- a/apps/data-pipeline/configs/extractor.yml
+++ b/apps/data-pipeline/configs/extractor.yml
@@ -146,10 +146,55 @@ policy:
       frequency: "d"
 
   # ----------------------------------------------------------------------------
-  # [Group 3] 한국은행 (ECOS) 관련 작업
+  # [Group 3 Extension] 한국 국채(KTB) 및 환율 데이터 (ECOS Source)
   # ----------------------------------------------------------------------------
-  ecos_base_rate:
-    provider: "ECOS" # ECOSExtractor 사용
-    description: "한국은행 기준금리 추이"
-    path: "/StatisticSearch/200Y001/D/20230101/20231231"
-    params: {}
+
+  # 3-1. 한국 국채 3년물 (KTB 3Y)
+  ecos_ktb_3y:
+    provider: "ECOS"
+    description: "국고채 3년 금리 (일별)"
+    path: "/StatisticSearch"
+    params:
+      stat_code: "817Y002"
+      item_code1: "010200000"
+      cycle: "D"
+
+  # 3-2. 한국 국채 5년물 (KTB 5Y)
+  ecos_ktb_5y:
+    provider: "ECOS"
+    description: "국고채 5년 금리 (일별)"
+    path: "/StatisticSearch"
+    params:
+      stat_code: "817Y002"
+      item_code1: "010200001" # 국고채(5년)
+      cycle: "D"
+
+  # 3-3. 한국 국채 10년물 (KTB 10Y)
+  ecos_ktb_10y:
+    provider: "ECOS"
+    description: "국고채 10년 금리 (일별)"
+    path: "/StatisticSearch"
+    params:
+      stat_code: "817Y002"
+      item_code1: "010210000"
+      cycle: "D"
+
+  # 3-4. 한국 국채 30년물 (KTB 30Y)
+  ecos_ktb_30y:
+    provider: "ECOS"
+    description: "국고채 30년 금리 (일별)"
+    path: "/StatisticSearch"
+    params:
+      stat_code: "817Y002"
+      item_code1: "010230000"
+      cycle: "D"
+
+  # 3-5. 원/달러 환율 (KRW/USD)
+  ecos_exchange_rate_usd:
+    provider: "ECOS"
+    description: "원/달러 환율 (종가, 일별)"
+    path: "/StatisticSearch"
+    params:
+      stat_code: "731Y001"
+      item_code1: "0000001"
+      cycle: "D"

--- a/apps/data-pipeline/src/extractor/providers/ecos_extractor.py
+++ b/apps/data-pipeline/src/extractor/providers/ecos_extractor.py
@@ -1,0 +1,210 @@
+"""
+ECOS(한국은행 경제통계시스템) 데이터 수집기 구현체 (ECOS Extractor)
+
+이 모듈은 한국은행(BOK)의 Open API(ECOS)를 사용하여 거시경제 및 금융 데이터를 수집하는 역할을 담당합니다.
+KIS 수집기와 동일한 파이프라인(AbstractExtractor)을 따르지만, ECOS API 특유의
+'Path Variable' 기반 요청 구조를 처리하기 위해 파라미터 병합 로직을 URL 생성 로직으로 대체했습니다.
+
+데이터 흐름 (Data Flow):
+RequestDTO(job_id) -> Load Policy -> Build Path-based URL -> Async API Call -> Check Result Code -> ResponseDTO
+
+주요 기능:
+- 설정(Config)과 요청(Request) 파라미터를 결합하여 ECOS 표준 URL 동적 생성
+- Static API Key 관리 및 URL 내 주입 (Query String 미사용)
+- ECOS 고유 응답 구조(JSON) 파싱 및 'INFO-000' 성공 코드 검증
+- 수집 실패 시 도메인 표준 예외(ExtractorError) 발생
+
+Trade-off:
+- Explicit URL Construction (Path Variable):
+    - 장점: ECOS API는 파라미터 순서가 엄격한 Path 방식(/Key/Type/Lang/...)을 강제하므로, 
+      Dict 기반의 Query String(?key=value)보다 명시적인 URL 조립이 필수적임.
+    - 단점: URL의 세그먼트 순서(StatCode -> Cycle -> Date...)가 변경되면 코드를 수정해야 함.
+    - 근거: API 명세 준수가 일반화된 유연성보다 우선시되어야 하는 인프라 계층임.
+"""
+
+from typing import Any, Dict, Optional
+from datetime import datetime
+
+from .abstract_extractor import AbstractExtractor
+from ..domain.interfaces import IHttpClient
+from ..domain.dtos import RequestDTO, ResponseDTO
+from ..domain.exceptions import ExtractorError
+from ...common.config import AppConfig
+
+class ECOSExtractor(AbstractExtractor):
+    """설정(Config)에 정의된 정책을 기반으로 동작하는 한국은행(ECOS) 데이터 수집기.
+
+    Attributes:
+        config (AppConfig): 애플리케이션의 전체 설정 정보를 담고 있는 객체.
+    """
+
+    def __init__(self, http_client: IHttpClient, config: AppConfig):
+        """ECOSExtractor를 초기화합니다.
+
+        Args:
+            http_client (IHttpClient): HTTP 요청 클라이언트.
+            config (AppConfig): 앱 설정 객체.
+        """
+        # 부모 클래스(AbstractExtractor) 초기화 (여기서 config 기본 검증 수행됨)
+        super().__init__(http_client, config)
+
+        # Rationale: Fail-Fast 원칙. ECOS 수집기 인스턴스화 시점에 필수 인증키와 URL 유무를 확인.
+        if not config.ecos.base_url:
+            raise ExtractorError("Critical Config Error: 'ecos.base_url' is empty.")
+        if not config.ecos.api_key:
+            raise ExtractorError("Critical Config Error: 'ecos.api_key' is missing.")
+
+    async def extract(self, request: RequestDTO) -> ResponseDTO:
+        """데이터 수집을 수행하는 공개 메서드 (Template Method).
+
+        검증 -> 데이터 인출 -> 응답 생성의 표준 흐름을 제어합니다.
+
+        Args:
+            request (RequestDTO): 수집 요청 정보 (job_id, params 포함).
+
+        Returns:
+            ResponseDTO: 수집된 원본 데이터와 메타데이터.
+
+        Raises:
+            ExtractorError: 수집 과정 중 발생한 모든 비즈니스 예외.
+        """
+        try:
+            # 1. 요청 유효성 검증 (Validation)
+            self._validate_request(request)
+
+            # 2. 데이터 인출 (Fetching)
+            raw_data = await self._fetch_raw_data(request)
+
+            # 3. 응답 객체 생성 (Response Creation)
+            response = self._create_response(raw_data, request.job_id)
+            
+            self.logger.info(f"Extraction Successful | Job: {request.job_id}")
+            
+            return response
+
+        except ExtractorError as e:
+            # 이미 처리된 ExtractorError는 그대로 상위로 전파
+            self.logger.error(f"Extraction Failed: {e}")
+            raise e
+        except Exception as e:
+            # 예상치 못한 시스템 에러는 ExtractorError로 래핑하여 일관성 유지
+            self.logger.error(f"Unexpected System Error during extraction: {e}", exc_info=True)
+            raise ExtractorError(f"System Error: {str(e)}")
+
+    def _validate_request(self, request: RequestDTO) -> None:
+        """요청된 작업(Job)이 ECOS 수집 정책에 부합하는지 검증합니다.
+
+        1. job_id가 Config의 extraction_policy에 존재하는지 확인.
+        2. 해당 Policy의 Provider가 'ECOS'인지 확인.
+        3. 날짜 범위(start_date, end_date)가 요청에 포함되었는지 확인 (ECOS 필수).
+
+        Args:
+            request (RequestDTO): 요청 객체.
+
+        Raises:
+            ExtractorError: 정책이 없거나, Provider가 다르거나, 필수 파라미터가 누락된 경우.
+        """
+        if not request.job_id:
+            raise ExtractorError("Invalid Request: 'job_id' is mandatory.")
+
+        # Rationale: Pydantic 모델의 딕셔너리 속성(extraction_policy)에 접근.
+        policy = self.config.extraction_policy.get(request.job_id)
+
+        if not policy:
+            self.logger.error(f"Policy missing for job_id: {request.job_id}")
+            raise ExtractorError(f"Configuration Error: Policy not found for job_id '{request.job_id}'.")
+
+        # Rationale: 다른 Provider(예: KIS)의 작업을 ECOS 수집기에 요청하는 실수를 방지.
+        if policy.provider != "ECOS":
+            raise ExtractorError(f"Provider Mismatch: Job '{request.job_id}' is for '{policy.provider}', not 'ECOS'.")
+
+        # Rationale: ECOS는 URL Path에 날짜를 필수적으로 포함해야 하므로, 요청 시점 검증이 필요함.
+        if "start_date" not in request.params or "end_date" not in request.params:
+            raise ExtractorError("Invalid Request: 'start_date' and 'end_date' are mandatory for ECOS.")
+
+    async def _fetch_raw_data(self, request: RequestDTO) -> Any:
+        """설정된 정책과 요청 파라미터를 결합하여 ECOS API URL을 조립하고 호출합니다.
+
+        ECOS API 구조: /Service/Key/Type/Lang/Start/End/StatCode/Cycle/StartDate/EndDate/ItemCode
+
+        Args:
+            request (RequestDTO): 검증된 요청 객체.
+
+        Returns:
+            Any: API 원본 응답 데이터 (Dict).
+        """
+        # 1. 정책 및 인증키 로드
+        policy = self.config.extraction_policy[request.job_id]
+        api_key = self.config.ecos.api_key.get_secret_value()
+        
+        # 2. 파라미터 추출 (Config와 Request 병합 개념)
+        # Rationale: YAML Config에는 정적 정보(통계코드)가, Request에는 동적 정보(날짜)가 있음.
+        stat_code = policy.params.get("stat_code")
+        cycle = policy.params.get("cycle")
+        item_code = policy.params.get("item_code1")
+        start_date = request.params.get("start_date")
+        end_date = request.params.get("end_date")
+
+        # 3. URL 조립 (Strict Path Construction)
+        # Rationale: ECOS는 Query Param을 쓰지 않고 Path Variable 순서를 엄격히 따름.
+        # 기본 요청 건수는 1~100000건으로 고정 (대량 조회 가정).
+        base_path = policy.path.strip("/") # 예: StatisticSearch
+        url = (
+            f"{self.config.ecos.base_url}/{base_path}/"
+            f"{api_key}/json/kr/1/100000/"
+            f"{stat_code}/{cycle}/{start_date}/{end_date}/{item_code}"
+        )
+
+        self.logger.debug(f"Executing ECOS Request | Job: {request.job_id} | Path: {url}")
+
+        # 4. 비동기 호출 수행
+        # Rationale: URL에 모든 파라미터가 포함되었으므로 params 인자는 전달하지 않음.
+        return await self.http_client.get(url)
+
+    def _create_response(self, raw_data: Any, job_id: str) -> ResponseDTO:
+        """ECOS API 응답의 결과 코드(RESULT.CODE)를 확인하고 DTO로 포장합니다.
+
+        Args:
+            raw_data (Any): API 원본 응답.
+            job_id (str): 요청된 작업 ID.
+        Returns:
+            ResponseDTO: 결과 객체.
+
+        Raises:
+            ExtractorError: API 코드가 성공('INFO-000')이 아닌 경우.
+        """
+        # 1. 서비스명 추출 (Root Key)
+        # Rationale: ECOS 응답은 { "StatisticSearch": { ... } } 형태이므로 Root Key를 찾아야 함.
+        policy_path = self.config.extraction_policy[job_id].path.strip("/")
+        
+        # 2. 에러 응답 처리 (Root에 RESULT가 바로 오는 경우 - 인증 에러 등)
+        if "RESULT" in raw_data:
+            code = raw_data["RESULT"].get("CODE")
+            msg = raw_data["RESULT"].get("MESSAGE")
+            if code != "INFO-000":
+                 self.logger.error(f"ECOS API System Failure: {msg} (Code: {code})")
+                 raise ExtractorError(f"ECOS API Failed: {msg} (Code: {code})")
+
+        # 3. 정상 응답 내 비즈니스 코드 확인
+        if policy_path in raw_data:
+            result_body = raw_data[policy_path]
+            # row가 없고 RESULT만 있는 경우 (데이터 없음 등)
+            if "RESULT" in result_body:
+                code = result_body["RESULT"].get("CODE")
+                msg = result_body["RESULT"].get("MESSAGE")
+                if code != "INFO-000":
+                    self.logger.error(f"ECOS API Business Failure: {msg} (Code: {code})")
+                    raise ExtractorError(f"ECOS API Failed: {msg} (Code: {code})")
+        else:
+             # Rationale: 예상한 서비스명 키가 없는 경우 응답 구조 변경 또는 알 수 없는 에러.
+             raise ExtractorError(f"Invalid ECOS Response: Root key '{policy_path}' not found.")
+
+        return ResponseDTO(
+            data=raw_data,
+            meta={
+                "source": "ECOS",
+                "job_id": job_id,
+                "extracted_at": datetime.now().isoformat(),
+                "status": "success"
+            }
+        )

--- a/apps/data-pipeline/src/verification.py
+++ b/apps/data-pipeline/src/verification.py
@@ -2,6 +2,7 @@ from src.common.config import get_config
 from src.extractor.domain.interfaces import IAuthStrategy, IHttpClient
 from src.extractor.providers.kis_extractor import KISExtractor
 from src.extractor.providers.fred_extractor import FREDExtractor
+from src.extractor.providers.ecos_extractor import ECOSExtractor
 from typing import Any, Dict
 
 class MockHttpClient(IHttpClient):
@@ -111,6 +112,18 @@ def verify_extractor(target_provider: str = "KIS"):
             print(f"✅ FREDExtractor Instantiated.")
             print(f"   - Base URL: {config.fred.base_url}")
             print(f"   - API Key:  {'[PROTECTED]' if is_key_present else '[MISSING]'}")
+
+        elif target_provider == "ECOS":
+            # ECOS는 AuthStrategy 불필요 (Config 내 API Key 사용)
+            extractor = ECOSExtractor(
+                http_client=mock_http,
+                config=config
+            )
+            # ECOS Global Config Check
+            is_key_present = bool(config.ecos.api_key.get_secret_value())
+            print(f"✅ ECOSExtractor Instantiated.")
+            print(f"   - Base URL: {config.ecos.base_url}")
+            print(f"   - API Key:  {'[PROTECTED]' if is_key_present else '[MISSING]'}")
         
         else:
             print(f"❌ ERROR: Unknown provider type '{target_provider}'")
@@ -168,4 +181,5 @@ def verify_extractor(target_provider: str = "KIS"):
 if __name__ == "__main__":
     #verify_config()
     #verify_extractor(target_provider="KIS")
-    verify_extractor(target_provider="FRED")
+    #verify_extractor(target_provider="FRED")
+    verify_extractor(target_provider="ECOS")

--- a/apps/data-pipeline/tests/unit/extractor/providers/ecos_extractor_test.py
+++ b/apps/data-pipeline/tests/unit/extractor/providers/ecos_extractor_test.py
@@ -1,0 +1,284 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+
+# --------------------------------------------------------------------------
+# Import Real Objects (DTO) & Target Class
+# --------------------------------------------------------------------------
+from src.extractor.providers.ecos_extractor import ECOSExtractor
+from src.extractor.domain.dtos import RequestDTO, ResponseDTO
+from src.extractor.domain.exceptions import ExtractorError
+from src.extractor.domain.interfaces import IHttpClient
+from src.common.config import AppConfig 
+
+# --------------------------------------------------------------------------
+# 0. Constants & Configuration
+# --------------------------------------------------------------------------
+
+# 로그 매니저 경로 (AbstractExtractor 초기화 시 파일 I/O 유발 방지)
+TARGET_LOG_MANAGER = "src.extractor.providers.abstract_extractor.LogManager"
+
+# --------------------------------------------------------------------------
+# 1. Fixtures (Test Environment Setup)
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_http_client():
+    """[IHttpClient Mock] 외부 네트워크 통신 담당"""
+    client = MagicMock(spec=IHttpClient)
+    client.get = AsyncMock()
+    return client
+
+@pytest.fixture
+def mock_config():
+    """[AppConfig Mock] 파일 시스템 의존성 제거 및 ECOS 설정 주입"""
+    # Critical Fix: spec=AppConfig 제거. 
+    # spec을 사용하면 동적으로 속성(ecos)을 추가할 때 AttributeError가 발생할 수 있습니다.
+    config = MagicMock() 
+    
+    # ECOS 기본 설정 (Base URL, API Key)
+    # MagicMock은 속성에 처음 접근할 때 자동으로 자식 Mock을 생성합니다.
+    config.ecos.base_url = "http://api.ecos.bok.or.kr"
+    config.ecos.api_key.get_secret_value.return_value = "TEST_API_KEY"
+    
+    # 기본 정책 설정 (Happy Path용)
+    valid_policy = MagicMock()
+    valid_policy.provider = "ECOS"
+    valid_policy.path = "/StatisticSearch"
+    valid_policy.params = {
+        "stat_code": "100Y",
+        "cycle": "D",
+        "item_code1": "0001"
+    }
+    
+    config.extraction_policy = {
+        "ecos_job": valid_policy
+    }
+    return config
+
+@pytest.fixture
+def extractor(mock_http_client, mock_config):
+    """
+    [System Under Test]
+    ECOSExtractor의 인스턴스입니다.
+    부모 클래스(AbstractExtractor)의 LogManager를 Patch하여 초기화 시 로깅 로직을 무력화합니다.
+    """
+    with patch(TARGET_LOG_MANAGER) as MockLogManager:
+        # Logger Mock 생성 (호출 검증용)
+        mock_logger_instance = MagicMock()
+        MockLogManager.get_logger.return_value = mock_logger_instance
+        
+        # 인스턴스 생성
+        instance = ECOSExtractor(mock_http_client, mock_config)
+        return instance
+
+# --------------------------------------------------------------------------
+# 2. Test Cases
+# --------------------------------------------------------------------------
+
+class TestECOSExtractor:
+    
+    # ==========================================
+    # Category: Unit (Happy Path & Logic)
+    # ==========================================
+
+    @pytest.mark.asyncio
+    async def test_tc001_happy_path_success(self, extractor, mock_http_client):
+        """[TC-001] 정상 Config, 유효 Policy, 정상 응답 -> INFO-000 성공 처리 및 DTO 반환"""
+        # Given
+        request = RequestDTO(
+            job_id="ecos_job", 
+            params={"start_date": "20240101", "end_date": "20240102"}
+        )
+        
+        # ECOS 정상 응답 구조 (Service Name -> RESULT -> CODE)
+        mock_response = {
+            "StatisticSearch": {
+                "list_total_count": 5,
+                "row": [{"TIME": "20240101", "DATA_VALUE": "100"}],
+                "RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."}
+            }
+        }
+        mock_http_client.get.return_value = mock_response
+
+        # When
+        response = await extractor.extract(request)
+
+        # Then
+        assert response.meta["status"] == "success"
+        assert response.meta["source"] == "ECOS"
+        assert response.data == mock_response
+        mock_http_client.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tc002_url_construction_strict_path(self, extractor, mock_http_client):
+        """[TC-002] ECOS URL Path 조립 로직 검증 (순서 엄격 준수: Key/Type/Lang/Start/End/...)"""
+        # Given
+        request = RequestDTO(
+            job_id="ecos_job", 
+            params={"start_date": "20240101", "end_date": "20240131"}
+        )
+        # 응답은 성공으로 가정 (URL 확인이 주 목적)
+        mock_http_client.get.return_value = {"StatisticSearch": {"RESULT": {"CODE": "INFO-000"}}}
+
+        # When
+        await extractor.extract(request)
+
+        # Then
+        # Expected Format: {Base}/{Path}/{Key}/json/kr/1/100000/{Stat}/{Cycle}/{Start}/{End}/{Item}
+        expected_url = (
+            "http://api.ecos.bok.or.kr/StatisticSearch/"
+            "TEST_API_KEY/json/kr/1/100000/"
+            "100Y/D/20240101/20240131/0001"
+        )
+        
+        actual_url = mock_http_client.get.call_args[0][0] # get 메서드의 첫 번째 인자(url) 확인
+        assert actual_url == expected_url
+
+    # ==========================================
+    # Category: Unit (Config Validation)
+    # ==========================================
+
+    def test_tc003_config_empty_base_url(self, mock_http_client, mock_config):
+        """[TC-003] Config의 base_url이 비어있으면 초기화 시 ExtractorError가 발생한다."""
+        # Given
+        mock_config.ecos.base_url = ""
+
+        # When & Then
+        with patch(TARGET_LOG_MANAGER):
+            with pytest.raises(ExtractorError, match="Critical Config Error.*base_url"):
+                ECOSExtractor(mock_http_client, mock_config)
+
+    def test_tc004_config_missing_api_key(self, mock_http_client, mock_config):
+        """[TC-004] Config의 api_key가 누락되면 초기화 시 ExtractorError가 발생한다."""
+        # Given
+        mock_config.ecos.api_key = None
+
+        # When & Then
+        with patch(TARGET_LOG_MANAGER):
+            with pytest.raises(ExtractorError, match="Critical Config Error.*api_key"):
+                ECOSExtractor(mock_http_client, mock_config)
+
+    # ==========================================
+    # Category: Exception (Request Validation)
+    # ==========================================
+
+    @pytest.mark.asyncio
+    async def test_tc005_invalid_request_missing_job_id(self, extractor):
+        """[TC-005] job_id가 누락되면 ExtractorError가 발생한다."""
+        # Given
+        request = RequestDTO(job_id=None)
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="Invalid Request: 'job_id' is mandatory"):
+            await extractor.extract(request)
+
+    @pytest.mark.asyncio
+    async def test_tc006_invalid_request_missing_start_date(self, extractor):
+        """[TC-006] start_date 파라미터가 누락되면 ExtractorError가 발생한다 (ECOS 필수)."""
+        # Given
+        request = RequestDTO(job_id="ecos_job", params={"end_date": "20240101"})
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="mandatory for ECOS"):
+            await extractor.extract(request)
+
+    @pytest.mark.asyncio
+    async def test_tc007_invalid_request_missing_end_date(self, extractor):
+        """[TC-007] end_date 파라미터가 누락되면 ExtractorError가 발생한다 (ECOS 필수)."""
+        # Given
+        request = RequestDTO(job_id="ecos_job", params={"start_date": "20240101"})
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="mandatory for ECOS"):
+            await extractor.extract(request)
+
+    # ==========================================
+    # Category: Exception (Policy Validation)
+    # ==========================================
+
+    @pytest.mark.asyncio
+    async def test_tc008_config_unknown_policy(self, extractor):
+        """[TC-008] 요청한 job_id가 Config 정책에 없으면 ExtractorError가 발생한다."""
+        # Given
+        request = RequestDTO(job_id="unknown_job", params={"start_date": "2024", "end_date": "2024"})
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="Policy not found"):
+            await extractor.extract(request)
+
+    @pytest.mark.asyncio
+    async def test_tc009_config_provider_mismatch(self, extractor, mock_config):
+        """[TC-009] 해당 Policy의 Provider가 ECOS가 아니면 ExtractorError가 발생한다."""
+        # Given
+        kis_policy = MagicMock()
+        kis_policy.provider = "KIS"
+        mock_config.extraction_policy["kis_job"] = kis_policy
+        
+        request = RequestDTO(job_id="kis_job")
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="Provider Mismatch"):
+            await extractor.extract(request)
+
+    # ==========================================
+    # Category: Exception (Response Handling)
+    # ==========================================
+
+    @pytest.mark.asyncio
+    async def test_tc010_api_root_failure(self, extractor, mock_http_client):
+        """[TC-010] API 응답 Root 레벨 에러(인증 실패 등) 발생 시 ExtractorError로 처리한다."""
+        # Given
+        request = RequestDTO(job_id="ecos_job", params={"start_date": "2024", "end_date": "2024"})
+        # 인증 에러 예시: 서비스 키가 없을 때 Root에 바로 RESULT가 옴
+        mock_http_client.get.return_value = {
+            "RESULT": {"CODE": "INFO-200", "MESSAGE": "해당하는 데이터가 없습니다."}
+        }
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="ECOS API Failed"):
+            await extractor.extract(request)
+
+    @pytest.mark.asyncio
+    async def test_tc011_api_business_failure(self, extractor, mock_http_client):
+        """[TC-011] API 응답 서비스 레벨 에러(데이터 없음 등) 발생 시 ExtractorError로 처리한다."""
+        # Given
+        request = RequestDTO(job_id="ecos_job", params={"start_date": "2024", "end_date": "2024"})
+        # 서비스 키 내부에 에러가 있는 경우
+        mock_http_client.get.return_value = {
+            "StatisticSearch": {
+                "RESULT": {"CODE": "INFO-200", "MESSAGE": "No Data"}
+            }
+        }
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="ECOS API Failed"):
+            await extractor.extract(request)
+
+    @pytest.mark.asyncio
+    async def test_tc012_invalid_response_structure(self, extractor, mock_http_client):
+        """[TC-012] API 응답에 예상된 서비스명(Key)이 없으면 구조 불일치로 ExtractorError가 발생한다."""
+        # Given
+        request = RequestDTO(job_id="ecos_job", params={"start_date": "2024", "end_date": "2024"})
+        # Policy path는 'StatisticSearch'인데 엉뚱한 키가 온 경우
+        mock_http_client.get.return_value = {
+            "WrongServiceKey": {"row": []}
+        }
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="Invalid ECOS Response"):
+            await extractor.extract(request)
+
+    # ==========================================
+    # Category: Resource & State
+    # ==========================================
+
+    @pytest.mark.asyncio
+    async def test_tc013_system_error_network(self, extractor, mock_http_client):
+        """[TC-013] HttpClient에서 네트워크 예외 발생 시 System Error로 래핑하여 던진다."""
+        # Given
+        request = RequestDTO(job_id="ecos_job", params={"start_date": "2024", "end_date": "2024"})
+        mock_http_client.get.side_effect = Exception("Connection Refused")
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="System Error: Connection Refused"):
+            await extractor.extract(request)

--- a/docs/TCS/data-pipeline/TCS-ETL-004.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-004.md
@@ -1,0 +1,36 @@
+# ECOS Extractor Test Specification
+
+## 1. 개요
+
+- **Target Module:** `src.extractor.providers.ecos_extractor.ECOSExtractor`
+- **Purpose:** ECOS API 특유의 Path Variable 기반 URL 조립 정합성, 필수 날짜 파라미터 검증, 그리고 응답 코드(INFO-000) 처리 및 예외 매핑을 검증.
+- **Reference:** `kis_extractor_test.py` (구조적 일관성 유지)
+
+## 2. 테스트 환경 및 전략
+
+- **Mocking:**
+  - `IHttpClient`: 실제 네트워크 요청 차단 및 응답 조작.
+  - `AppConfig`: 설정(URL, Key) 주입 및 정책(Policy) 격리.
+  - `LogManager`: `src.extractor.providers.abstract_extractor` 내부의 로거 호출을 Patch하여 의존성 제거.
+- **Assertions:**
+  - URL 조립 결과 검증 (Strict Path Variable Order).
+  - Pydantic DTO 변환 및 메타데이터 검증.
+  - ECOS 고유 에러 코드 및 네트워크 예외 매핑 검증.
+
+## 3. 테스트 케이스 명세
+
+|  Test ID   | Category  | Given (Preconditions)                                                 | When (Action)                                       | Then (Expected Outcome)                                                                                         | Input Data                                                          | Priority |
+| :--------: | :-------: | :-------------------------------------------------------------------- | :-------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------ | :------- |
+| **TC-001** |   Unit    | 정상적인 Config(URL, Key), 유효한 Policy(StatCode, Cycle 등)가 설정됨 | `extract` 메서드 호출 (정상 Job ID, 날짜 범위 포함) | 1. `INFO-000` 응답 파싱 성공.<br>2. 반환된 DTO의 data가 Mock 응답과 일치.<br>3. `http_client.get`이 1회 호출됨. | `job_id="ecos_job"`, `start_date="20240101"`, `end_date="20240102"` | **High** |
+| **TC-002** |   Unit    | 상동. (URL 조립 로직 검증)                                            | `extract` 메서드 호출                               | **[중요]** 호출된 URL이 지정된 순서(/Key/Type/.../Start/End/...)와 정확히 일치하는지 검증.                      | `policy={"stat_code":"100Y", "cycle":"D" ...}`                      | **High** |
+| **TC-003** | Exception | `config.ecos.base_url`이 비어 있음 ("")                               | `ECOSExtractor` 인스턴스 생성 시도 (`__init__`)     | `ExtractorError` 발생 (Critical Config Error).                                                                  | `config.ecos.base_url = ""`                                         | Medium   |
+| **TC-004** | Exception | `config.ecos.api_key`가 누락됨                                        | `ECOSExtractor` 인스턴스 생성 시도 (`__init__`)     | `ExtractorError` 발생 (Critical Config Error).                                                                  | `config.ecos.api_key = None`                                        | Medium   |
+| **TC-005** | Exception | 정상 Config                                                           | `extract` 호출 시 `job_id` 누락                     | `ExtractorError` 발생 (Invalid Request).                                                                        | `job_id=None`                                                       | Medium   |
+| **TC-006** | Exception | 정상 Config                                                           | `extract` 호출 시 `start_date` 파라미터 누락        | `ExtractorError` 발생 (Mandatory for ECOS).                                                                     | `params={"end_date": "..."}`                                        | **High** |
+| **TC-007** | Exception | 정상 Config                                                           | `extract` 호출 시 `end_date` 파라미터 누락          | `ExtractorError` 발생 (Mandatory for ECOS).                                                                     | `params={"start_date": "..."}`                                      | **High** |
+| **TC-008** | Exception | Config에 정의되지 않은 `job_id`                                       | `extract` 호출                                      | `ExtractorError` 발생 (Policy not found).                                                                       | `job_id="unknown_job"`                                              | Low      |
+| **TC-009** | Exception | 해당 `job_id`의 Policy Provider가 "KIS"로 설정됨                      | `extract` 호출                                      | `ExtractorError` 발생 (Provider Mismatch).                                                                      | `policy.provider="KIS"`                                             | Medium   |
+| **TC-010** |   Unit    | API 응답 Root 레벨에 `RESULT.CODE`가 `INFO-200` (에러)임              | `extract` 호출 및 응답 수신                         | `ExtractorError` 발생 (ECOS API Failed).                                                                        | API Res: `{"RESULT": {"CODE": "INFO-200", "MESSAGE": "Error"}}`     | High     |
+| **TC-011** |   Unit    | API 응답 서비스(Service) 레벨 `RESULT.CODE`가 `INFO-200`임            | `extract` 호출 및 응답 수신                         | `ExtractorError` 발생 (Business Failure).                                                                       | API Res: `{"StatSearch": {"RESULT": {"CODE": "INFO-200"}}}`         | High     |
+| **TC-012** |   Unit    | API 응답에 예상된 서비스명(Key)이 없음                                | `extract` 호출 및 응답 수신                         | `ExtractorError` 발생 (Invalid Response).                                                                       | API Res: `{"WrongService": {...}}`                                  | Medium   |
+| **TC-013** | Exception | HttpClient에서 네트워크 예외 발생                                     | `extract` 호출                                      | `ExtractorError`로 래핑되어 발생 (System Error).                                                                | `SideEffect=Exception("Timeout")`                                   | Medium   |


### PR DESCRIPTION
## 1. 🎫 PR 요약
> **한국은행(ECOS) Open API 연동을 위한 전용 Extractor 구현 및 테스트/검증 모듈 추가**
- 기존 Query Parameter 방식과 상이한 ECOS의 'Path Variable' 기반 요청 구조를 지원하기 위해 URL 조립 로직을 재정의하고, 국채(KTB) 및 환율 데이터 수집을 위한 정책과 테스트 슈트를 통합했습니다.

## 2. 🛠 작업 내용
- **Core Implementation**: `AbstractExtractor`를 상속받는 `ECOSExtractor` 구현 (Strict URL Construction 적용).
- **Configuration**: `extractor.yml`에 ECOS Provider 정책(국고채 3/5/10/30년물, 원/달러 환율) 추가.
- **Testing**: `TCS-ETL-004` 명세에 따른 Unit/Exception 테스트 코드 `ecos_extractor_test.py` 작성 (TC-001 ~ TC-013).
- **Verification**: `verification.py`에 ECOS Extractor 초기화 및 정책 로딩 검증 로직 추가.

## 3. 💡 기술적 의사결정 (Architecture & Tech Stack)
> **ECOS API 특성을 고려한 URL 조립 전략 및 이중 에러 핸들링 설계**

- **Explicit URL Construction (Path Variable over Query Params)**
    - **결정 배경:** ECOS API는 표준적인 `?key=value` 쿼리 스트링 방식이 아닌, `/Service/Key/Type/...` 순서가 엄격히 고정된 Path Variable 방식을 강제합니다.
    - **Trade-off:** 유연성을 다소 희생하더라도, `params` 딕셔너리를 순회하는 대신 명시적인 f-string 포맷팅(`.../{stat_code}/{cycle}/{start_date}...`)을 적용하여 API 명세 준수와 정합성을 최우선으로 확보했습니다.

- **Fail-Fast Validation Strategy**
    - **결정 배경:** 불필요한 네트워크 비용을 절감하기 위해 검증 단계를 분리했습니다.
    - **구현:**
        1. **Init Time:** 인스턴스 생성 시 API Key와 Base URL 존재 여부를 즉시 확인하여 Critical Config Error를 발생시킵니다.
        2. **Runtime:** `extract()` 호출 시 ECOS 필수 값인 날짜 범위(`start_date`, `end_date`) 누락 여부를 검증합니다.

- **Dual-Layer Response Validation**
    - **결정 배경:** ECOS는 HTTP 200 OK 응답 내부에서도 `RESULT.CODE` 필드를 통해 비즈니스 에러를 반환하며, 에러 위치가 Root 레벨일 수도 있고 Service 레벨일 수도 있는 가변성을 가집니다.
    - **구현:** 응답 파싱 시 Root Key(`RESULT`)와 Service Key(`StatisticSearch`) 양쪽 모두에서 `INFO-000`(성공) 코드를 검사하도록 로직을 강화했습니다.

## 4. 📋 주요 변경점
- `src/extractor/providers/ecos_extractor.py`: ECOS 수집기 메인 구현체. Path Variable 조립 및 `INFO-000` 응답 검증 로직 포함.
- `tests/extractor/ecos_extractor_test.py`: Mocking(HttpClient, AppConfig) 기반의 단위 테스트. 정상 파싱(TC-001) 및 URL 순서 검증(TC-002) 등 포함.
- `configs/extractor.yml`: `ecos_ktb_3y`, `ecos_exchange_rate_usd` 등 5개의 신규 수집 정책 정의.
- `src/scripts/verification.py`: `verify_extractor(target_provider="ECOS")` 함수 추가를 통한 의존성 주입 및 설정 로드 통합 테스트 지원.

## 5. 📸 테스트 결과
- **Unit Test Coverage**: `TCS-ETL-004`에 정의된 전 항목(TC-001 ~ TC-013) Pass.
    - Happy Path: DTO 매핑 및 메타데이터 생성 확인.
    - Edge Case: API Key 누락, Job ID 불일치, 네트워크 타임아웃 예외 처리 검증 완료.
- **Integration Verification**: `verification.py` 실행 결과, Config 로딩 및 ECOS Extractor 인스턴스화 성공 확인.

## 6. 💬 리뷰 포인트 (Focus On)
- **URL 조립 순서:** `ecos_extractor.py`의 `_fetch_raw_data` 메서드 내 URL 포맷팅 순서가 현재 ECOS API 명세(Key/Type/Lang/Start/End/StatCode/Cycle/Dates...)와 정확히 일치하는지 교차 검증 부탁드립니다.
- **예외 매핑:** `ECOS` 고유 에러 발생 시 `ExtractorError`로 래핑하여 상위로 전파하는 구조가 기존 파이프라인의 에러 처리 정책과 일관성을 유지하는지 확인 바랍니다.