### PR TITLE
[Feat, Test] AuthTokenProvider 구현 및 테스트

### DIFF
--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/ErrorCode.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/ErrorCode.java
@@ -20,7 +20,12 @@ public enum ErrorCode {
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "U004", "유효하지 않은 인증 코드입니다."),
 
     // Jwt 토큰 에러
-    INVALID_SIGN_UP_TOKEN(HttpStatus.BAD_REQUEST, "U003", "유효하지 않거나 용도가 잘못된 회원가입 토큰입니다.");
+    INVALID_SIGN_UP_TOKEN(HttpStatus.BAD_REQUEST, "T001", "유효하지 않거나 용도가 잘못된 회원가입 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "T003", "토큰이 만료되었습니다."),
+    INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "T004", "토큰 서명이 유효하지 않습니다."),
+    INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "T004", "잘못된 토큰 타입입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "T005", "유효하지 않은 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "T006", "유효하지 않거나 만료된 리프레시 토큰입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserRegisterService.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserRegisterService.java
@@ -7,6 +7,7 @@ import com.assetmind.server_auth.user.application.port.UserIdGenerator;
 import com.assetmind.server_auth.user.application.port.UserRepository;
 import com.assetmind.server_auth.user.application.port.VerificationCodeGenerator;
 import com.assetmind.server_auth.user.application.port.VerificationCodePort;
+import com.assetmind.server_auth.user.application.provider.SignUpTokenProvider;
 import com.assetmind.server_auth.user.domain.User;
 import com.assetmind.server_auth.user.domain.vo.Email;
 import com.assetmind.server_auth.user.domain.vo.Password;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/dto/TokenSetDto.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/dto/TokenSetDto.java
@@ -1,0 +1,9 @@
+package com.assetmind.server_auth.user.application.dto;
+
+public record TokenSetDto(
+        String accessToken,
+        String refreshToken,
+        long  refreshTokenExpire
+) {
+
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/provider/AuthTokenProvider.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/provider/AuthTokenProvider.java
@@ -1,9 +1,14 @@
 package com.assetmind.server_auth.user.application.provider;
 
 import com.assetmind.server_auth.global.common.JwtProcessor;
+import com.assetmind.server_auth.global.error.ErrorCode;
 import com.assetmind.server_auth.user.application.dto.TokenSetDto;
 import com.assetmind.server_auth.user.domain.type.UserRole;
+import com.assetmind.server_auth.user.exception.AuthException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import java.security.SignatureException;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +55,7 @@ public class AuthTokenProvider {
      * @return UUID
      */
     public UUID getUserIdFromToken(String token) {
-        Claims claims = jwtProcessor.parse(token);
+        Claims claims = getClaims(token);
 
         return UUID.fromString(claims.getSubject());
     }
@@ -61,9 +66,42 @@ public class AuthTokenProvider {
      * @return GUEST/USER
      */
     public UserRole getRoleFromToken(String token) {
-        Claims claims = jwtProcessor.parse(token);
+        Claims claims = getClaims(token);
         String roleString = claims.get(ROLE_CLAIM, String.class);
-        return UserRole.valueOf(roleString);
 
+        return UserRole.valueOf(roleString);
+    }
+
+    /**
+     * 토큰 값을 검증하고 예외를 던진다.
+     * @param token
+     */
+    public void validateToken(String token) {
+        getClaims(token);
+    }
+
+    private Claims getClaims(String token) {
+        try {
+            Claims claims = jwtProcessor.parse(token);
+
+            // 로그인 시 받은 Auth 용 토큰이 아니라면 타입 에러
+            if (claims.get(ROLE_CLAIM) == null) {
+                throw new AuthException(ErrorCode.INVALID_TOKEN_TYPE);
+            }
+
+            return claims;
+        } catch (ExpiredJwtException e) {
+            // 토큰이 만료 됐을 때
+            throw new AuthException(ErrorCode.EXPIRED_TOKEN);
+        } catch (MalformedJwtException e) {
+            // 토큰 서명이 유효하지 않을 떄
+            throw new AuthException(ErrorCode.INVALID_TOKEN_SIGNATURE);
+        } catch (AuthException e) {
+            // try 문에서 던진 예외가 다른 예외로 잡히지 않기 위함
+            throw e;
+        } catch (Exception e) {
+            // 그외 모든 오류
+            throw new AuthException(ErrorCode.INVALID_TOKEN);
+        }
     }
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/provider/AuthTokenProvider.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/provider/AuthTokenProvider.java
@@ -1,0 +1,69 @@
+package com.assetmind.server_auth.user.application.provider;
+
+import com.assetmind.server_auth.global.common.JwtProcessor;
+import com.assetmind.server_auth.user.application.dto.TokenSetDto;
+import com.assetmind.server_auth.user.domain.type.UserRole;
+import io.jsonwebtoken.Claims;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 로그인 성공 후 서비스 이용을 위한
+ * Access/Refresh Token을 발행 헬퍼 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class AuthTokenProvider {
+
+    private final JwtProcessor jwtProcessor;
+
+    // accessToken 만료시간 30분
+    private static final long ACCESS_EXPIRATION_MS = 30 * 60 * 1000L;
+
+    // refreshToken 만료시간 7일
+    private static final long REFRESH_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000L;
+
+    private static final String ROLE_CLAIM = "role";
+
+    /**
+     * accessToken과 refreshToken을 생성하고
+     * access/refresh token 세트를 응답한다.
+     * @param userId - 서명, 토큰의 주인
+     * @param role - body
+     * @return
+     */
+    public TokenSetDto createTokenSet(UUID userId, UserRole role) {
+        String subject = userId.toString();
+        Map<String, Object> claims = Map.of(ROLE_CLAIM, role);
+
+        String accessToken = jwtProcessor.generate(subject, claims, ACCESS_EXPIRATION_MS);
+        String refreshToken = jwtProcessor.generate(subject, claims, REFRESH_EXPIRATION_MS);
+
+        return new TokenSetDto(accessToken, refreshToken, REFRESH_EXPIRATION_MS);
+    }
+
+    /**
+     * 토큰을 통해 subject인 UUID를 반환한다.
+     * @param token
+     * @return UUID
+     */
+    public UUID getUserIdFromToken(String token) {
+        Claims claims = jwtProcessor.parse(token);
+
+        return UUID.fromString(claims.getSubject());
+    }
+
+    /**
+     * 토큰을 통해 해당 토큰 주인의 role을 반환한다.
+     * @param token
+     * @return GUEST/USER
+     */
+    public UserRole getRoleFromToken(String token) {
+        Claims claims = jwtProcessor.parse(token);
+        String roleString = claims.get(ROLE_CLAIM, String.class);
+        return UserRole.valueOf(roleString);
+
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/provider/SignUpTokenProvider.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/provider/SignUpTokenProvider.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_auth.user.application;
+package com.assetmind.server_auth.user.application.provider;
 
 import com.assetmind.server_auth.global.common.JwtProcessor;
 import com.assetmind.server_auth.user.exception.InvalidSignUpTokenException;
@@ -7,6 +7,10 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+/**
+ * 회원가입 도중 이메일 인증에 성공을 증명하는
+ * 회원가입용 임시 토큰 발행 헬퍼 클래스
+ */
 @Component
 @RequiredArgsConstructor
 public class SignUpTokenProvider {

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/exception/AuthException.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/exception/AuthException.java
@@ -1,0 +1,11 @@
+package com.assetmind.server_auth.user.exception;
+
+import com.assetmind.server_auth.global.error.BusinessException;
+import com.assetmind.server_auth.global.error.ErrorCode;
+
+public class AuthException extends BusinessException {
+
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/integration/UserRegisterIntegrationTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/integration/UserRegisterIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.assetmind.server_auth.integration;
 
 import com.assetmind.server_auth.support.IntegrationTestSupport;
-import com.assetmind.server_auth.user.application.SignUpTokenProvider;
+import com.assetmind.server_auth.user.application.provider.SignUpTokenProvider;
 import com.assetmind.server_auth.user.application.port.EmailSendPort;
 import com.assetmind.server_auth.user.domain.type.UserRole;
 import com.assetmind.server_auth.user.infrastructure.persistence.jpa.UserEntity;

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/SignUpTokenProviderTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/SignUpTokenProviderTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import com.assetmind.server_auth.global.common.JwtProcessor;
+import com.assetmind.server_auth.user.application.provider.SignUpTokenProvider;
 import com.assetmind.server_auth.user.exception.InvalidSignUpTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/UserRegisterServiceTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/UserRegisterServiceTest.java
@@ -10,6 +10,7 @@ import com.assetmind.server_auth.user.application.port.UserIdGenerator;
 import com.assetmind.server_auth.user.application.port.UserRepository;
 import com.assetmind.server_auth.user.application.port.VerificationCodeGenerator;
 import com.assetmind.server_auth.user.application.port.VerificationCodePort;
+import com.assetmind.server_auth.user.application.provider.SignUpTokenProvider;
 import com.assetmind.server_auth.user.domain.User;
 import com.assetmind.server_auth.user.domain.type.UserRole;
 import com.assetmind.server_auth.user.domain.vo.Email;

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/provider/AuthTokenProviderTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/provider/AuthTokenProviderTest.java
@@ -1,0 +1,157 @@
+package com.assetmind.server_auth.user.application.provider;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.assetmind.server_auth.global.common.JwtProcessor;
+import com.assetmind.server_auth.global.error.ErrorCode;
+import com.assetmind.server_auth.user.application.dto.TokenSetDto;
+import com.assetmind.server_auth.user.domain.type.UserRole;
+import com.assetmind.server_auth.user.exception.AuthException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * AuthTokenProvider 단위 테스트
+ * 모킹된 JwtProcessor를 가지고
+ * 인증용 토큰 생성 검증
+ * 토큰(UUID, UserRole) 추출 로직 검증
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthTokenProviderTest {
+
+    @Mock
+    private JwtProcessor jwtProcessor;
+
+    @Mock
+    private Claims claims;
+
+    @InjectMocks
+    private AuthTokenProvider authTokenProvider;
+
+    private final UUID USER_ID = UUID.randomUUID();
+    private final UserRole ROLE = UserRole.GUEST;
+
+    @Test
+    @DisplayName("성공: Access/Refresh 토큰이 정상 생성된다.")
+    void givenValidInfo_whenCreateTokenSet_thenReturnTokenSet() {
+        // given
+        String mockAccessToken = "access-token";
+        String mockRefreshToken = "refresh-token";
+
+        given(jwtProcessor.generate(anyString(), anyMap(), anyLong())).willReturn(mockAccessToken, mockRefreshToken);
+
+        // when
+        TokenSetDto result = authTokenProvider.createTokenSet(USER_ID, ROLE);
+
+        // then
+        assertThat(result.accessToken()).isEqualTo(mockAccessToken);
+        assertThat(result.refreshToken()).isEqualTo(mockRefreshToken);
+
+        verify(jwtProcessor, times(2)).generate(eq(USER_ID.toString()), anyMap(), anyLong());
+    }
+
+    @Test
+    @DisplayName("성공: 유효한 토큰이라면 UUID를 반환한다.")
+    void givenValidToken_whenGetUserIdFromToken_thenReturnUUID() {
+        // given
+        String validToken = "valid-token";
+        given(jwtProcessor.parse(validToken)).willReturn(claims);
+
+        given(claims.get("role")).willReturn(ROLE.toString());
+        given(claims.getSubject()).willReturn(USER_ID.toString());
+
+        // when
+        UUID result = authTokenProvider.getUserIdFromToken(validToken);
+
+        // then
+        assertThat(result).isEqualTo(USER_ID);
+    }
+
+    @Test
+    @DisplayName("성공: 유효한 토큰이라면 UserRole을 반환한다.")
+    void givenValidToken_whenGetRoleFromToken_thenReturnUserRole() {
+        // given
+        String token = "valid-token";
+        given(jwtProcessor.parse(token)).willReturn(claims);
+
+        given(claims.get("role")).willReturn(ROLE.toString());
+
+        // 실제 값 추출용 (UserRole.valueOf("USER"))
+        given(claims.get("role", String.class)).willReturn("GUEST");
+
+        // when
+        UserRole resultRole = authTokenProvider.getRoleFromToken(token);
+
+        // then
+        assertThat(resultRole).isEqualTo(ROLE);
+    }
+
+    @Test
+    @DisplayName("성공: 유효한 토큰이면 검증에 성공한다.")
+    void givenValidToken_whenValidateToken_thenReturnVoid() {
+        // given
+        String token = "valid-token";
+        given(jwtProcessor.parse(token)).willReturn(claims);
+        given(claims.get("role")).willReturn(ROLE); // Role 존재
+
+        // when & then (예외가 발생하지 않음을 검증)
+        assertThatCode(() -> authTokenProvider.validateToken(token))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("실패: Auth 전용 토큰이 아니라면(Role 없음) 예외를 던진다.")
+    void givenSignUpToken_whenValidateToken_thenThrowException() {
+        // given
+        String signUpToken = "signup-token"; // 가입용 토큰(Role 없음)
+        given(jwtProcessor.parse(signUpToken)).willReturn(claims);
+
+        // *핵심*: Role Claim이 Null임
+        given(claims.get("role")).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> authTokenProvider.validateToken(signUpToken))
+                .isInstanceOf(AuthException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TOKEN_TYPE);
+    }
+
+    @Test
+    @DisplayName("실패: 형식이 잘못된 토큰이라면 예외를 던진다.")
+    void givenMalformedToken_whenValidateToken_thenThrowException() {
+        // given
+        String malformedToken = "malformed-token";
+        given(jwtProcessor.parse(malformedToken))
+                .willThrow(new MalformedJwtException("malformed"));
+
+        // when & then
+        assertThatThrownBy(() -> authTokenProvider.validateToken(malformedToken))
+                .isInstanceOf(AuthException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TOKEN_SIGNATURE);
+    }
+
+    @Test
+    @DisplayName("실패: 만료된 토큰이라면 예외를 던진다.")
+    void givenExpiredToken_whenValidateToken_thenThrowException() {
+        // given
+        String expiredToken = "expired-token";
+        // 라이브러리 예외(ExpiredJwtException) 발생 시뮬레이션
+        given(jwtProcessor.parse(expiredToken))
+                .willThrow(new ExpiredJwtException(null, null, "expired"));
+
+        // when & then -> AuthException(EXPIRED_TOKEN)으로 변환되어야 함
+        assertThatThrownBy(() -> authTokenProvider.validateToken(expiredToken))
+                .isInstanceOf(AuthException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXPIRED_TOKEN);
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/provider/SignUpTokenProviderTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/provider/SignUpTokenProviderTest.java
@@ -1,10 +1,9 @@
-package com.assetmind.server_auth.user.application;
+package com.assetmind.server_auth.user.application.provider;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import com.assetmind.server_auth.global.common.JwtProcessor;
-import com.assetmind.server_auth.user.application.provider.SignUpTokenProvider;
 import com.assetmind.server_auth.user.exception.InvalidSignUpTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;

--- a/docs/TCS/auth/TCS-JWT-001.md
+++ b/docs/TCS/auth/TCS-JWT-001.md
@@ -2,7 +2,7 @@
 
 | 문서 ID | **TCS-AUTH-JWT-001**                |
 | :--- |:------------------------------------|
-| **문서 버전** | 1.0                                 |
+| **문서 버전** | 1.1                                 |
 | **프로젝트** | AssetMind                           |
 | **작성자** | 이재석                                 |
 | **작성일** | 2026년 01월 20일                       |
@@ -10,16 +10,16 @@
 
 ## 1. 개요 (Overview)
 
-본 문서는 AssetMind 인증 시스템의 핵심 보안 요소인 **JWT 처리 모듈**(`JwtProcessor`)과 회원가입 전용 **토큰 관리자**(`SignUpTokenProvider`)의 동작을 검증하기 위한 단위 테스트(Unit Test) 명세이다.  
+본 문서는 AssetMind 인증 시스템의 핵심 보안 요소인 **JWT 처리 모듈**(`JwtProcessor`)과 회원가입 전용 **토큰 관리자**(`SignUpTokenProvider`, `AuthTokenProvider`)의 동작을 검증하기 위한 단위 테스트(Unit Test) 명세이다.  
 `JJWT 0.13.0` 라이브러리의 동작 검증과 더불어, 회원가입 비즈니스 로직(토큰 용도 구분)이 올바르게 수행되는지 중점적으로 확인한다.
 
 ### 1.1. 테스트 환경
 - **Framework:** JUnit 5, AssertJ, Mockito
-- **Target Classes:** `JwtProcessorTest`, `SignUpTokenProviderTest`
+- **Target Classes:** `JwtProcessorTest`, `SignUpTokenProviderTest`, `AuthTokenProvider`
 - **Key Verification:**
     - **Security & Integrity:** 생성된 토큰의 서명(Signature) 검증 및 만료(Expiration) 처리 확인
-    - **Data Consistency:** Payload(Claims)에 저장된 데이터의 손실 없는 복원 확인
-    - **Business Logic:** 가입용 토큰(`SIGN_UP`)과 로그인용 토큰(`ACCESS`)의 명확한 구분 및 예외 처리
+    - **Cross-Token Prevention:** 가입용 토큰(`SIGN_UP`)과 인증용 토큰(`Auth`)의 교차 사용 방지
+    - **Exception Mapping:** 라이브러리 예외(`ExpiredJwtException` 등)를 도메인 예외(`AuthException`)로 올바르게 변환하는지 확인
 
 ---
 
@@ -52,11 +52,30 @@
 
 ---
 
-## 4. 테스트 결과 요약
+## 4.1. 인증 토큰 발급 및 파싱 (Create & Extract)
 
-### 4.1. 수행 결과
-| 구분 | 전체 케이스 | Pass | Fail | 비고 |
-| :--- | :---: | :---: | :---: | :--- |
-| **Common (JwtProcessor)** | 3 | 3 | 0 | 0.13.0 스펙 준수 및 보안 예외 검증 완료 |
-| **Business (Provider)** | 4 | 4 | 0 | 타입 검증 로직(Mock 활용) 완료 |
-| **합계** | **7** | **7** | **0** | **Pass** ✅ |
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **BIZ-AUTH-001** | `createTokenSet`<br>👉 **Access/Refresh 토큰 쌍이 정상 생성된다.** | **Mock 설정**<br>`jwtProcessor.generate`가 각각의 토큰 문자열 반환 | **`provider.createTokenSet(UUID, Role)`** | 1. Access, Refresh 토큰이 모두 포함된 DTO가 반환된다.<br>2. Refresh Token의 만료 시간(`ttl`)이 설정값과 일치한다.<br>3. `verify()`: `jwtProcessor`가 총 2회 호출되었음을 확인한다. |
+| **BIZ-AUTH-002** | `getUserId` / `getRole`<br>👉 **유효한 토큰에서 UUID와 Role을 정상 추출한다.** | **Mock 설정**<br>`parse` 호출 시 `{sub: UUID, role: "USER"}` 반환 | **`provider.getUserId...`**<br>**`provider.getRole...`** | 1. String 형태의 Subject가 **`UUID`** 객체로 정상 변환된다.<br>2. String 형태의 role claim이 **`UserRole`** Enum으로 정상 변환된다. |
+
+### 4.2. 보안 및 예외 검증 (Validation & Exception)
+
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **BIZ-AUTH-003** | `validate_Success`<br>👉 **Role Claim이 포함된 정상 토큰은 검증을 통과한다.** | **Mock 설정**<br>`parse` 시 `{role: "USER"}` 포함 Claims 반환 | **`provider.validateToken()`** | 1. 예외가 발생하지 않는다 (`doesNotThrowAnyException`). |
+| **BIZ-AUTH-004** | `validate_Fail_NoRole`<br>👉 **가입 토큰(Role 없음)이 들어오면 타입 에러가 발생한다.** | **Mock 설정**<br>`parse` 시 `{sub: EMAIL, type: SIGN_UP}` (Role 없음) 반환 | **`provider.validateToken()`** | 1. **`AuthException`** 발생<br>2. ErrorCode: **`INVALID_TOKEN_TYPE` (T004)** 확인<br>3. 가입 토큰으로 로그인 API에 접근하는 것을 차단한다. |
+| **BIZ-AUTH-005** | `validate_Fail_Expired`<br>👉 **만료된 토큰은 EXPIRED_TOKEN 예외로 번역된다.** | **Mock 설정**<br>`parse` 호출 시 라이브러리의 `ExpiredJwtException` 발생 | **`provider.validateToken()`** | 1. **`AuthException`** 발생<br>2. ErrorCode: **`EXPIRED_TOKEN` (T001)** 확인<br>3. 라이브러리 예외가 도메인 예외로 래핑됨을 검증한다. |
+| **BIZ-AUTH-006** | `validate_Fail_Signature`<br>👉 **서명 위조/손상 시 INVALID_SIGNATURE 예외로 번역된다.** | **Mock 설정**<br>`parse` 호출 시 라이브러리의 `SignatureException` 또는 `Malformed...` 발생 | **`provider.validateToken()`** | 1. **`AuthException`** 발생<br>2. ErrorCode: **`INVALID_TOKEN_SIGNATURE` (T002)** 확인 |
+
+---
+
+## 5. 테스트 결과 요약
+
+### 5.1. 수행 결과
+| 구분                        | 전체 케이스 |  Pass  | Fail | 비고 |
+|:--------------------------|:------:|:------:| :---: | :--- |
+| **Common (JwtProcessor)** |   3    |   3    | 0 | 0.13.0 스펙 준수 및 보안 예외 검증 완료 |
+| **Business 1 (SignUp)**   |   4    |   4    | 0 | 타입 검증 로직(Mock 활용) 완료 |
+| **Business 2 (Auth)**     |   6    |   6    | 0 | **New**: 예외 번역 및 교차 사용 방지 검증 완료 |
+| **합계**                    | **13** | **13** | **0** | **Pass** ✅ |


### PR DESCRIPTION
## 📌 작업 내용
- **로그인 성공 시 Access/Refresh Token을 발급하고 검증하는 `AuthTokenProvider`를 구현했습니다.**
- 외부 라이브러리(`jjwt`)의 기술적 예외를 도메인 언어로 변환하는 **예외 번역(Exception Translation) 로직을** 적용했습니다.
- 회원가입용 토큰(`SignUpToken`)이 인증 인가 로직을 우회하지 못하도록 **교차 사용 방지(Cross-Token Prevention) 로직을** 추가했습니다.
- `JwtProcessor`를 모킹(Mocking)하여 모든 예외 시나리오를 검증하는 **단위 테스트(`AuthTokenProviderTest`)와 검증 명세서(`TCS v1.1`)를** 작성했습니다.

## 🏗 기술적 의사결정 (핵심 변경 사유)

**1. 예외 번역 전략 (Exception Translation)**
> 외부 라이브러리(`jjwt`)의 예외(`ExpiredJwtException` 등)가 필터나 컨트롤러 계층으로 전파되면, 라이브러리 교체 시 수정 범위가 넓어지고 상위 계층 코드가 지저분해집니다.
- **문제점:** Security Filter에서 `try-catch`로 `SignatureException`, `MalformedJwtException` 등을 각각 잡아야 하는 번거로움이 있었습니다.
- **해결책:** Provider 내부에서 모든 `jjwt` 예외를 잡아서 `AuthException`이라는 단일 도메인 예외로 포장하여 던지도록 구현했습니다. 이제 상위 계층은 `AuthException` 하나만 처리하면 되며, 내부의 `ErrorCode`(T001, T002 등)를 통해 구체적인 원인을 파악할 수 있습니다.

**2. 안전한 파싱 로직 (Centralized Parsing with `getClaims`)**
> 검증되지 않은 토큰에서 데이터를 꺼내려다 `NullPointerException`이나 예상치 못한 500 에러가 발생하는 것을 방지해야 합니다.
- **기존 위험:** `validateToken()`을 호출하지 않고 `getUserIdFromToken()`을 바로 호출할 경우, 만료된 토큰이나 타입이 다른 토큰이 들어오면 런타임 에러가 발생할 위험이 있었습니다.
- **개선:** `private getClaims()` 메서드를 신설하여 **"파싱 + 검증 + 예외 변환"** 로직을 한곳에 모았습니다. 모든 Public 조회 메서드(`getUserId`, `getRole`)가 반드시 이 관문을 통과하도록 강제하여 데이터 무결성을 보장했습니다.

**3. 토큰 교차 사용 방지 (Cross-Token Prevention)**
> 회원가입용 토큰(`SignUpToken`)을 탈취하여 로그인된 사용자처럼 위장하는 보안 취약점을 막아야 합니다.
- **구현:** `SignUpToken`에는 `Role` 정보가 없다는 점에 착안하여, 파싱 시 **`ROLE_CLAIM` 존재 여부를 필수적으로 검사**합니다.
- **결과:** 만약 가입용 토큰이 들어오면 `INVALID_TOKEN_TYPE` 예외를 발생시켜, 인증 로직 진입을 원천 차단했습니다.

## ✅ 주요 변경점
- **Auth Provider (`user/application/provider`):**
    - `AuthTokenProvider`: Access(30분), Refresh(7일) 토큰 생성 및 검증 로직 구현.
    - **Refactoring:** 중복되는 `try-catch` 블록을 제거하고 `getClaims`로 통합.
- **Global Error (`global/error`):**
    - `ErrorCode` 추가: `EXPIRED_TOKEN`(만료), `INVALID_TOKEN_SIGNATURE`(위조), `INVALID_TOKEN_TYPE`(용도 불일치).
    - `AuthException`: ErrorCode를 담는 런타임 예외 래퍼 클래스.
- **Tests:**
    - `AuthTokenProviderTest`: `JwtProcessor`를 Mocking하여 순수 비즈니스 로직(토큰 생성, 예외 매핑) 검증.
    - `TCS-AUTH-JWT-001.md`: v1.1로 업데이트 (AuthTokenProvider 테스트 시나리오 6종 추가).

## 📝 리뷰 포인트
- **예외 처리:** `jjwt`의 다양한 예외들이 `AuthException`의 적절한 `ErrorCode`로 잘 매핑되었는지 확인 부탁드립니다.
- **보안 로직:** `SignUpToken`과 `AuthToken`을 구분하는 방식(Role Claim 유무 확인)이 충분히 안전한지 의견 주시면 감사하겠습니다.
- **테스트 명세:** `TCS-AUTH-JWT-001` 문서에 정의된 시나리오가 비즈니스 요구사항을 모두 커버하고 있는지 검토 부탁드립니다.