### PR TITLE
[Feat] Upbit API Digital Asset Data Acquisition Module

### DIFF
--- a/apps/data-pipeline/configs/extractor.yml
+++ b/apps/data-pipeline/configs/extractor.yml
@@ -198,3 +198,24 @@ policy:
       stat_code: "731Y001"
       item_code1: "0000001"
       cycle: "D"
+
+  # ----------------------------------------------------------------------------
+  # [Group 4 Extension] 업비트 (Upbit) 암호화폐 데이터
+  # ----------------------------------------------------------------------------
+  # 4-1. 비트코인 (BTC) 일봉 - KRW 마켓
+  upbit_btc_daily:
+    provider: "UPBIT"
+    description: "비트코인(BTC) 일봉 (KRW 마켓)"
+    path: "/v1/candles/days"
+    params:
+      market: "KRW-BTC"
+      count: 200 # 1회 요청 시 최대 반환 개수 (API 제한)
+
+  # 4-2. 이더리움 (ETH) 일봉 - KRW 마켓
+  upbit_eth_daily:
+    provider: "UPBIT"
+    description: "이더리움(ETH) 일봉 (KRW 마켓)"
+    path: "/v1/candles/days"
+    params:
+      market: "KRW-ETH"
+      count: 200

--- a/apps/data-pipeline/src/common/config.py
+++ b/apps/data-pipeline/src/common/config.py
@@ -69,6 +69,16 @@ class ECOSSettings(BaseSettings):
         extra="ignore"
     )
 
+class UPBITSettings(BaseSettings):
+    """업비트(UPBIT) API 전용 설정 모델."""
+    api_key: SecretStr = Field(alias="UPBIT_API_KEY")
+    base_url: str = Field(alias="UPBIT_BASE_URL")
+    model_config = SettingsConfigDict(
+        env_file=".env", 
+        env_file_encoding="utf-8", 
+        extra="ignore"
+    )
+
 # ==============================================================================
 # 2. 정책(Job) 검증 모델 (Validation Model)
 # ==============================================================================
@@ -81,7 +91,7 @@ class JobPolicy(BaseModel):
         path (str): API 경로.
         params (Dict): 요청 파라미터.
     """
-    provider: Literal["KIS", "FRED", "ECOS"]
+    provider: Literal["KIS", "FRED", "ECOS", "UPBIT"]
     description: str
     path: str
     
@@ -101,6 +111,7 @@ class AppConfig(BaseSettings):
         kis (KISSettings): KIS 관련 설정 그룹.
         fred (FREDSettings): FRED 관련 설정 그룹.
         ecos (ECOSSettings): ECOS 관련 설정 그룹.
+        upbit (UPBITSettings): UPBIT 관련 설정 그룹.
         extraction_policy (Dict[str, JobPolicy]): 검증된 수집 정책 목록.
     """
     task_name: str = "default_task"
@@ -109,6 +120,7 @@ class AppConfig(BaseSettings):
     kis: KISSettings = Field(default_factory=KISSettings)
     fred: FREDSettings = Field(default_factory=FREDSettings)
     ecos: ECOSSettings = Field(default_factory=ECOSSettings)
+    upbit: UPBITSettings = Field(default_factory=UPBITSettings)
 
     # YAML에서 로드된 정책 (Job ID -> Policy Model)
     extraction_policy: Dict[str, JobPolicy] = Field(default_factory=dict)

--- a/apps/data-pipeline/src/extractor/providers/upbit_extractor.py
+++ b/apps/data-pipeline/src/extractor/providers/upbit_extractor.py
@@ -1,0 +1,198 @@
+"""
+UPBIT(업비트) 데이터 수집기 구현체 (UPBIT Extractor)
+
+이 모듈은 업비트 오픈 API를 사용하여 데이터를 수집하는 역할을 담당합니다.
+모든 API 호출 정보(URL, Market Code 등)를 코드 내 상수가 아닌 외부 설정(AppConfig)에서
+동적으로 로드하여 유연성을 확보했습니다.
+
+데이터 흐름 (Data Flow):
+RequestDTO(job_id) -> Load Policy from Config -> Get Token -> Merge Params -> Async API Call -> Check Status -> ResponseDTO
+
+주요 기능:
+- 설정 파일(YAML) 기반의 API 요청 정보 동적 로딩
+- 작업 ID(job_id) 유효성 검사 및 필수 정책(Policy) 확인
+- API 응답 에러 객체(error) 검사를 통한 수집 성공 여부 판단
+- 수집 실패 시 도메인 표준 예외(ExtractorError) 발생
+
+Trade-off:
+- Runtime Config Dependency:
+    - 장점: 새로운 코인 마켓 추가 시 코드를 배포하지 않고 설정 파일 수정만으로 대응 가능.
+    - 단점: 설정 파일의 오타나 누락이 런타임 에러로 이어질 수 있음.
+    - 근거: 급변하는 암호화폐 시장 특성상 새로운 마켓 데이터 수집 요구사항에 빠르게 대응해야 함.
+"""
+
+from typing import Any, Dict, Optional
+from datetime import datetime
+
+from .abstract_extractor import AbstractExtractor
+from ..domain.interfaces import IHttpClient, IAuthStrategy
+from ..domain.dtos import RequestDTO, ResponseDTO
+from ..domain.exceptions import ExtractorError
+from ...common.config import AppConfig
+
+class UPBITExtractor(AbstractExtractor):
+    """설정(Config)에 정의된 정책을 기반으로 동작하는 업비트 데이터 수집기.
+
+    Attributes:
+        auth_strategy (IAuthStrategy): 토큰 발급(JWT) 및 갱신을 담당하는 전략 객체.
+        config (AppConfig): 애플리케이션의 전체 설정 정보를 담고 있는 객체.
+    """
+
+    def __init__(
+        self, 
+        http_client: IHttpClient, 
+        auth_strategy: IAuthStrategy, 
+        config: AppConfig
+    ):
+        """UPBITExtractor를 초기화합니다.
+
+        Args:
+            http_client (IHttpClient): HTTP 요청 클라이언트.
+            auth_strategy (IAuthStrategy): UPBIT 인증 토큰 발급 전략.
+            config (AppConfig): 앱 설정 객체.
+        """
+        # 부모 클래스(AbstractExtractor) 초기화 (여기서 config 기본 검증 수행됨)
+        super().__init__(http_client, config)
+        self.auth_strategy = auth_strategy
+        
+        # Rationale: AppConfig가 Pydantic 모델이므로 upbit 필드의 존재는 보장되지만, 
+        # 명시적으로 base_url이 비어있는지 체크하여 Fail-Fast를 유도함.
+        if not config.upbit.base_url:
+            raise ExtractorError("Critical Config Error: 'upbit.base_url' is empty in AppConfig.")
+
+    async def extract(self, request: RequestDTO) -> ResponseDTO:
+        """데이터 수집을 수행하는 공개 메서드 (Template Method).
+
+        검증 -> 데이터 인출 -> 응답 생성의 표준 흐름을 제어합니다.
+
+        Args:
+            request (RequestDTO): 수집 요청 정보 (job_id, params 포함).
+
+        Returns:
+            ResponseDTO: 수집된 원본 데이터와 메타데이터.
+
+        Raises:
+            ExtractorError: 수집 과정 중 발생한 모든 비즈니스 예외.
+        """
+        try:
+            # 1. 요청 유효성 검증 (Validation)
+            self._validate_request(request)
+
+            # 2. 데이터 인출 (Fetching)
+            raw_data = await self._fetch_raw_data(request)
+
+            # 3. 응답 객체 생성 (Response Creation)
+            response = self._create_response(raw_data, request.job_id)
+            
+            self.logger.info(f"Extraction Successful | Job: {request.job_id}")
+            
+            return response
+
+        except ExtractorError as e:
+            # 이미 처리된 ExtractorError는 그대로 상위로 전파
+            self.logger.error(f"Extraction Failed: {e}")
+            raise e
+        except Exception as e:
+            # 예상치 못한 시스템 에러는 ExtractorError로 래핑하여 일관성 유지
+            self.logger.error(f"Unexpected System Error during extraction: {e}", exc_info=True)
+            raise ExtractorError(f"System Error: {str(e)}")
+    
+    def _validate_request(self, request: RequestDTO) -> None:
+        """요청된 작업(Job)이 UPBIT 수집 정책에 부합하는지 검증합니다.
+
+        1. job_id가 Config의 extraction_policy에 존재하는지 확인.
+        2. 해당 Policy의 Provider가 'UPBIT'인지 확인.
+        3. UPBIT API 호출에 필수적인 파라미터(params) 설정 여부 확인.
+
+        Args:
+            request (RequestDTO): 요청 객체.
+
+        Raises:
+            ExtractorError: 정책이 없거나, Provider가 다르거나, 필수 필드가 누락된 경우.
+        """
+        if not request.job_id:
+            raise ExtractorError("Invalid Request: 'job_id' is mandatory.")
+
+        # Rationale: Pydantic 모델의 딕셔너리 속성(extraction_policy)에 접근.
+        policy = self.config.extraction_policy.get(request.job_id)
+        
+        if not policy:
+            self.logger.error(f"Policy missing for job_id: {request.job_id}")
+            raise ExtractorError(f"Configuration Error: Policy not found for job_id '{request.job_id}'.")
+
+        # Rationale: 다른 Provider(예: KIS)의 작업을 UPBIT 수집기에 요청하는 실수를 방지.
+        if policy.provider != "UPBIT":
+            raise ExtractorError(f"Provider Mismatch: Job '{request.job_id}' is for '{policy.provider}', not 'UPBIT'.")
+
+        # Rationale: 대부분의 업비트 API는 'market' 파라미터가 필수임. (Policy나 Request Params 중 한 곳에는 있어야 함)
+        # KIS의 tr_id 체크와 유사하게, UPBIT 로직에 필수적인 사전 검증을 수행.
+        combined_params = {**policy.params, **request.params}
+        if "market" not in combined_params and "markets" not in combined_params:
+             self.logger.warning(f"Parameter Warning: 'market' might be missing in policy '{request.job_id}'.")
+
+    async def _fetch_raw_data(self, request: RequestDTO) -> Any:
+        """설정된 정책과 인증 정보를 결합하여 UPBIT API를 호출합니다.
+
+        Args:
+            request (RequestDTO): 검증된 요청 객체.
+
+        Returns:
+            Any: API 원본 응답 데이터 (Dict or List).
+        """
+        # 1. 인증 토큰 확보 (AuthStrategy 위임)
+        token = await self.auth_strategy.get_token(self.http_client)
+
+        # 2. 정책 로드 (Validation 단계를 통과했으므로 존재 보장)
+        policy = self.config.extraction_policy[request.job_id]
+        
+        # 3. URL 구성
+        # Config의 계층 구조(config.upbit.base_url)와 객체 속성(policy.path)을 활용.
+        url = f"{self.config.upbit.base_url}{policy.path}"
+        
+        # 4. 헤더 구성
+        # Bearer Token 방식을 사용하며, 인증이 필요 없는 경우 token이 None일 수 있음.
+        headers = {
+            "accept": "application/json",
+        }
+        if token:
+            headers["authorization"] = token
+
+        # 5. 파라미터 병합
+        # Static Params(Config)와 Dynamic Params(Request)를 병합. Request가 우선순위를 가짐.
+        merged_params = {**policy.params, **request.params}
+
+        self.logger.debug(f"Executing UPBIT Request | Job: {request.job_id} | Path: {policy.path}")
+
+        # 6. 비동기 호출 수행
+        return await self.http_client.get(url, headers=headers, params=merged_params)
+
+    def _create_response(self, raw_data: Any, job_id: str) -> ResponseDTO:
+        """UPBIT API 응답의 에러 객체(error)를 확인하고 DTO로 포장합니다.
+
+        Args:
+            raw_data (Any): API 원본 응답.
+            job_id (str): 요청된 작업 ID.
+        Returns:
+            ResponseDTO: 결과 객체.
+
+        Raises:
+            ExtractorError: 응답 내에 'error' 키가 존재하는 경우.
+        """
+        # Rationale: UPBIT API는 에러 발생 시 {'error': {'name':..., 'message':...}} 형태를 반환함.
+        if isinstance(raw_data, dict) and "error" in raw_data:
+            error_payload = raw_data["error"]
+            error_name = error_payload.get("name", "UnknownError")
+            error_msg = error_payload.get("message", "No message provided")
+            
+            self.logger.error(f"UPBIT API Business Failure: {error_msg} (Name: {error_name})")
+            raise ExtractorError(f"UPBIT API Failed: {error_msg} (Name: {error_name})")
+
+        return ResponseDTO(
+            data=raw_data,
+            meta={
+                "source": "UPBIT",
+                "job_id": job_id,
+                "extracted_at": datetime.now().isoformat(),
+                "status_code": "OK" # UPBIT는 별도의 상태 코드를 본문에 주지 않으므로 OK로 통일
+            }
+        )

--- a/apps/data-pipeline/src/verification.py
+++ b/apps/data-pipeline/src/verification.py
@@ -3,6 +3,7 @@ from src.extractor.domain.interfaces import IAuthStrategy, IHttpClient
 from src.extractor.providers.kis_extractor import KISExtractor
 from src.extractor.providers.fred_extractor import FREDExtractor
 from src.extractor.providers.ecos_extractor import ECOSExtractor
+from src.extractor.providers.upbit_extractor import UPBITExtractor
 from typing import Any, Dict
 
 class MockHttpClient(IHttpClient):
@@ -124,6 +125,19 @@ def verify_extractor(target_provider: str = "KIS"):
             print(f"✅ ECOSExtractor Instantiated.")
             print(f"   - Base URL: {config.ecos.base_url}")
             print(f"   - API Key:  {'[PROTECTED]' if is_key_present else '[MISSING]'}")
+
+        elif target_provider == "UPBIT":
+            # UPBIT는 AuthStrategy 필요
+            extractor = UPBITExtractor(
+                http_client=mock_http,
+                auth_strategy=mock_auth,
+                config=config
+            )
+            # UPBIT Global Config Check
+            is_key_present = bool(config.upbit.api_key.get_secret_value())
+            print(f"✅ UPBITExtractor Instantiated.")
+            print(f"   - Base URL: {config.upbit.base_url}")
+            print(f"   - API Key:  {'[PROTECTED]' if is_key_present else '[MISSING]'}")
         
         else:
             print(f"❌ ERROR: Unknown provider type '{target_provider}'")
@@ -182,4 +196,5 @@ if __name__ == "__main__":
     #verify_config()
     #verify_extractor(target_provider="KIS")
     #verify_extractor(target_provider="FRED")
-    verify_extractor(target_provider="ECOS")
+    #verify_extractor(target_provider="ECOS")
+    verify_extractor(target_provider="UPBIT")

--- a/apps/data-pipeline/tests/unit/extractor/providers/upbit_extractor_test.py
+++ b/apps/data-pipeline/tests/unit/extractor/providers/upbit_extractor_test.py
@@ -1,0 +1,303 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+
+# --------------------------------------------------------------------------
+# Import Real Objects (DTO) & Target Class
+# --------------------------------------------------------------------------
+from src.extractor.providers.upbit_extractor import UPBITExtractor
+from src.extractor.domain.dtos import RequestDTO, ResponseDTO
+from src.extractor.domain.exceptions import ExtractorError
+from src.extractor.domain.interfaces import IHttpClient, IAuthStrategy
+from src.common.config import AppConfig
+
+# --------------------------------------------------------------------------
+# 0. Constants & Configuration
+# --------------------------------------------------------------------------
+
+# 로그 매니저 경로 (AbstractExtractor 초기화 시 파일 I/O 유발 방지)
+TARGET_LOG_MANAGER = "src.extractor.providers.abstract_extractor.LogManager"
+
+# --------------------------------------------------------------------------
+# 1. Fixtures (Test Environment Setup)
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_http_client():
+    """[IHttpClient Mock] 외부 네트워크 통신 담당"""
+    client = MagicMock(spec=IHttpClient)
+    client.get = AsyncMock()
+    return client
+
+@pytest.fixture
+def mock_auth_strategy():
+    """[IAuthStrategy Mock] 인증 토큰 발급 담당"""
+    strategy = MagicMock(spec=IAuthStrategy)
+    strategy.get_token = AsyncMock()
+    return strategy
+
+@pytest.fixture
+def mock_config():
+    """[AppConfig Mock] 파일 시스템 의존성 제거 및 UPBIT 설정 주입"""
+    config = MagicMock()
+    
+    # UPBIT 기본 설정 (Base URL)
+    config.upbit.base_url = "https://api.upbit.com/v1"
+    
+    # 기본 정책 설정 (Happy Path용)
+    valid_policy = MagicMock()
+    valid_policy.provider = "UPBIT"
+    valid_policy.path = "/candles/minutes/1"
+    valid_policy.params = {
+        "market": "KRW-BTC",
+        "count": 1
+    }
+    
+    config.extraction_policy = {
+        "upbit_job": valid_policy
+    }
+    return config
+
+@pytest.fixture
+def extractor(mock_http_client, mock_auth_strategy, mock_config):
+    """
+    [System Under Test]
+    UPBITExtractor의 인스턴스입니다.
+    부모 클래스(AbstractExtractor)의 LogManager를 Patch하여 초기화 시 로깅 로직을 무력화합니다.
+    """
+    with patch(TARGET_LOG_MANAGER) as MockLogManager:
+        # Logger Mock 생성 (호출 검증용)
+        mock_logger_instance = MagicMock()
+        MockLogManager.get_logger.return_value = mock_logger_instance
+        
+        # 인스턴스 생성
+        instance = UPBITExtractor(mock_http_client, mock_auth_strategy, mock_config)
+        return instance
+
+# --------------------------------------------------------------------------
+# 2. Test Cases
+# --------------------------------------------------------------------------
+
+class TestUPBITExtractor:
+
+    # ==========================================
+    # Category: Unit (Config Validation)
+    # ==========================================
+
+    def test_tc001_config_empty_base_url(self, mock_http_client, mock_auth_strategy, mock_config):
+        """[TC-001] Config의 base_url이 비어있으면 초기화 시 ExtractorError가 발생한다."""
+        # Given
+        mock_config.upbit.base_url = ""
+
+        # When & Then
+        with patch(TARGET_LOG_MANAGER):
+            with pytest.raises(ExtractorError, match="Critical Config Error.*base_url"):
+                UPBITExtractor(mock_http_client, mock_auth_strategy, mock_config)
+
+    # ==========================================
+    # Category: Unit (Happy Path)
+    # ==========================================
+
+    @pytest.mark.asyncio
+    async def test_tc002_happy_path_success(self, extractor, mock_http_client, mock_auth_strategy):
+        """[TC-002] 정상 Config, 유효 Policy, 인증 토큰 존재 -> OK 상태 및 DTO 반환"""
+        # Given
+        request = RequestDTO(job_id="upbit_job", params={"to": "2024-01-01 00:00:00"})
+        mock_auth_strategy.get_token.return_value = "Bearer TEST_TOKEN"
+        
+        # UPBIT 정상 응답 (예: 캔들 데이터 리스트)
+        mock_response = [{"market": "KRW-BTC", "trade_price": 50000000}]
+        mock_http_client.get.return_value = mock_response
+
+        # When
+        response = await extractor.extract(request)
+
+        # Then
+        assert response.meta["status_code"] == "OK"
+        assert response.meta["source"] == "UPBIT"
+        assert response.data == mock_response
+        mock_http_client.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tc003_url_header_construction(self, extractor, mock_http_client, mock_auth_strategy):
+        """[TC-003] URL, Header, Params가 정확한 순서와 값으로 조립되어 호출되는지 검증"""
+        # Given
+        request = RequestDTO(job_id="upbit_job")
+        mock_auth_strategy.get_token.return_value = "Bearer TEST_TOKEN"
+        mock_http_client.get.return_value = []
+
+        # When
+        await extractor.extract(request)
+
+        # Then
+        expected_url = "https://api.upbit.com/v1/candles/minutes/1"
+        expected_headers = {
+            "accept": "application/json",
+            "authorization": "Bearer TEST_TOKEN"
+        }
+        
+        # Call arguments 확인
+        args, kwargs = mock_http_client.get.call_args
+        assert args[0] == expected_url
+        assert kwargs["headers"] == expected_headers
+        assert "market" in kwargs["params"] # Policy param check
+
+    # ==========================================
+    # Category: Unit (Logic)
+    # ==========================================
+
+    @pytest.mark.asyncio
+    async def test_tc004_public_api_no_auth_header(self, extractor, mock_http_client, mock_auth_strategy):
+        """[TC-004] AuthStrategy가 None을 반환(Public API)하면 Header에 Authorization이 없어야 한다."""
+        # Given
+        request = RequestDTO(job_id="upbit_job")
+        mock_auth_strategy.get_token.return_value = None # No Token Needed
+        mock_http_client.get.return_value = []
+
+        # When
+        await extractor.extract(request)
+
+        # Then
+        _, kwargs = mock_http_client.get.call_args
+        headers = kwargs["headers"]
+        assert "authorization" not in headers
+        assert headers["accept"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_tc005_param_merge_priority(self, extractor, mock_http_client):
+        """[TC-005] Policy Params와 Request Params 충돌 시 Request Params가 우선순위를 가진다."""
+        # Given
+        # Policy: count=1 (Fixture 설정)
+        # Request: count=100
+        request = RequestDTO(job_id="upbit_job", params={"count": 100})
+        mock_http_client.get.return_value = []
+
+        # When
+        await extractor.extract(request)
+
+        # Then
+        _, kwargs = mock_http_client.get.call_args
+        actual_params = kwargs["params"]
+        assert actual_params["count"] == 100 # Request override confirmed
+
+    @pytest.mark.asyncio
+    async def test_tc006_warning_log_missing_market(self, extractor, mock_config):
+        """[TC-006] Request와 Policy 모두 market 파라미터가 없으면 Warning 로그를 기록한다."""
+        # Given
+        # Policy에서 market 제거
+        mock_config.extraction_policy["upbit_job"].params = {"count": 1}
+        request = RequestDTO(job_id="upbit_job", params={}) # No market in request either
+
+        # 로거 Mock 가져오기 (초기화 시 생성된 self.logger)
+        mock_logger = extractor.logger
+
+        # When (실행 시 에러는 안 나지만 로그가 찍혀야 함)
+        await extractor.extract(request)
+
+        # Then
+        mock_logger.warning.assert_called_with("Parameter Warning: 'market' might be missing in policy 'upbit_job'.")
+
+    @pytest.mark.asyncio
+    async def test_tc007_list_response_handling(self, extractor, mock_http_client):
+        """[TC-007] API가 Dict가 아닌 List를 반환해도 에러 없이 정상 처리된다."""
+        # Given
+        request = RequestDTO(job_id="upbit_job")
+        mock_list_response = [{"candle_acc_trade_price": 100}, {"candle_acc_trade_price": 200}]
+        mock_http_client.get.return_value = mock_list_response
+
+        # When
+        response = await extractor.extract(request)
+
+        # Then
+        assert isinstance(response.data, list)
+        assert len(response.data) == 2
+
+    # ==========================================
+    # Category: Exception (Request Validation)
+    # ==========================================
+
+    @pytest.mark.asyncio
+    async def test_tc008_invalid_request_missing_job_id(self, extractor):
+        """[TC-008] job_id가 누락되면 ExtractorError가 발생한다."""
+        # Given
+        request = RequestDTO(job_id=None)
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="Invalid Request: 'job_id' is mandatory"):
+            await extractor.extract(request)
+
+    # ==========================================
+    # Category: Exception (Policy Validation)
+    # ==========================================
+
+    @pytest.mark.asyncio
+    async def test_tc009_config_unknown_policy(self, extractor):
+        """[TC-009] 요청한 job_id가 Config 정책에 없으면 ExtractorError가 발생한다."""
+        # Given
+        request = RequestDTO(job_id="unknown_job")
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="Policy not found"):
+            await extractor.extract(request)
+
+    @pytest.mark.asyncio
+    async def test_tc010_config_provider_mismatch(self, extractor, mock_config):
+        """[TC-010] 해당 Policy의 Provider가 UPBIT가 아니면 ExtractorError가 발생한다."""
+        # Given
+        kis_policy = MagicMock()
+        kis_policy.provider = "KIS"
+        mock_config.extraction_policy["kis_job"] = kis_policy
+        
+        request = RequestDTO(job_id="kis_job")
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="Provider Mismatch"):
+            await extractor.extract(request)
+
+    # ==========================================
+    # Category: Exception (Response Handling)
+    # ==========================================
+
+    @pytest.mark.asyncio
+    async def test_tc011_api_business_failure_standard(self, extractor, mock_http_client):
+        """[TC-011] API 응답에 error 객체가 포함되면 ExtractorError로 처리한다."""
+        # Given
+        request = RequestDTO(job_id="upbit_job")
+        # Upbit Error Format
+        mock_http_client.get.return_value = {
+            "error": {
+                "name": "invalid_query_param",
+                "message": "query parameter error"
+            }
+        }
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="UPBIT API Failed: query parameter error"):
+            await extractor.extract(request)
+
+    @pytest.mark.asyncio
+    async def test_tc012_api_business_failure_malformed(self, extractor, mock_http_client):
+        """[TC-012] error 객체 내부에 상세 정보가 없어도 기본 메시지로 예외 처리한다."""
+        # Given
+        request = RequestDTO(job_id="upbit_job")
+        mock_http_client.get.return_value = {
+            "error": {} # Empty error object
+        }
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="UPBIT API Failed: No message provided"):
+            await extractor.extract(request)
+
+    # ==========================================
+    # Category: Resource & State
+    # ==========================================
+
+    @pytest.mark.asyncio
+    async def test_tc013_system_error_network(self, extractor, mock_http_client):
+        """[TC-013] HttpClient에서 네트워크 예외 발생 시 System Error로 래핑하여 던진다."""
+        # Given
+        request = RequestDTO(job_id="upbit_job")
+        mock_http_client.get.side_effect = Exception("Connection Refused")
+
+        # When & Then
+        with pytest.raises(ExtractorError, match="System Error: Connection Refused"):
+            await extractor.extract(request)

--- a/docs/TCS/data-pipeline/TCS-ETL-005.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-005.md
@@ -1,0 +1,31 @@
+# UPBIT Extractor Test Specification
+
+## 1. 개요
+
+- **대상 모듈:** `src.extractor.providers.upbit_extractor.UPBITExtractor`
+- **작성 목적:** Upbit Open API 수집 로직의 정합성 검증 및 예외 처리 견고성 확보.
+- **테스트 범위:** 인증 전략 연동, 파라미터 동적 병합, URL/Header 조립, Upbit 고유 에러 핸들링, Request/Config 유효성 검사.
+
+## 2. 테스트 환경 및 전략
+
+- **Mocking:** `IHttpClient`, `IAuthStrategy`, `AppConfig`는 철저히 Mocking하여 외부 의존성을 격리합니다.
+- **Logging:** `LogManager`를 Patch하여 테스트 중 불필요한 I/O를 방지하고, 특정 상황(Warning)에서의 로그 호출 여부를 검증합니다.
+- **Assertions:** 결과값(DTO) 뿐만 아니라, 호출된 URL, Header, Log Message를 검증하여 내부 로직의 정확성을 보장합니다.
+
+## 3. 테스트 케이스 명세
+
+|  Test ID   |         Category         | Given (Preconditions)                                                 | When (Action)                                 | Then (Expected Outcome)                                                                                      | Input Data                   | Priority |
+| :--------: | :----------------------: | :-------------------------------------------------------------------- | :-------------------------------------------- | :----------------------------------------------------------------------------------------------------------- | :--------------------------- | :------- |
+| **TC-001** |    **Unit (Config)**     | `config.upbit.base_url`이 비어있는 상태("")                           | `UPBITExtractor` 인스턴스 초기화 (`__init__`) | `ExtractorError` 발생 ("Critical Config Error").                                                             | `base_url=""`                | High     |
+| **TC-002** |  **Unit (Happy Path)**   | 정상 Config, Policy, AuthToken 존재. API는 정상 Dict 응답 반환.       | `extract(request)` 호출                       | status='OK', data=원본응답 반환. Info 로그 호출 확인.                                                        | `job_id="upbit_job"`         | High     |
+| **TC-003** |  **Unit (Happy Path)**   | 정상 Config, Policy 존재.                                             | `extract(request)` 호출                       | **URL**(`base+path`), **Header**(`Bearer Token`), **Params**가 순서대로 조립되어 `client.get` 호출됨을 검증. | `job_id="upbit_job"`, params | High     |
+| **TC-004** |     **Unit (Logic)**     | `AuthStrategy`가 `None`을 반환 (Public API).                          | `extract(request)` 호출                       | `client.get` 호출 시 헤더에 `Authorization` 필드가 **없어야 함**.                                            | `job_id="public_job"`        | Medium   |
+| **TC-005** |     **Unit (Logic)**     | Policy Params(`count=1`)와 Request Params(`count=100`)가 중복.        | `extract(request)` 호출                       | `client.get` 호출 시 **Request Param(`count=100`)이 우선** 적용되었는지 검증.                                | `params={'count': 100}`      | Medium   |
+| **TC-006** |     **Unit (Logic)**     | Request와 Policy 양쪽 모두 `market` 파라미터 없음.                    | `extract(request)` 호출                       | 예외 없이 진행되나, **Warning 로그**가 기록됨을 검증.                                                        | `params={}` (No market)      | Medium   |
+| **TC-007** |     **Unit (Logic)**     | API가 Dict가 아닌 **List** (예: 캔들 데이터)를 반환.                  | `extract(request)` 호출                       | 에러 없이 정상 처리되며 `ResponseDTO.data`가 List인지 검증.                                                  | API Resp: `[{}, {}]`         | Medium   |
+| **TC-008** | **Exception (Request)**  | `request.job_id`가 `None`.                                            | `extract(request)` 호출                       | `ExtractorError` 발생 ("Invalid Request").                                                                   | `job_id=None`                | High     |
+| **TC-009** |  **Exception (Policy)**  | 요청한 `job_id`가 Config Policy 맵에 없음.                            | `extract(request)` 호출                       | `ExtractorError` 발생 ("Policy not found").                                                                  | `job_id="unknown"`           | High     |
+| **TC-010** |  **Exception (Policy)**  | 해당 Policy의 Provider가 "UPBIT"가 아님 (예: "KIS").                  | `extract(request)` 호출                       | `ExtractorError` 발생 ("Provider Mismatch").                                                                 | `provider="KIS"`             | High     |
+| **TC-011** | **Exception (Response)** | API 응답 Body에 `error` 객체 포함 (`{"error": {"message": "Fail"}}`). | `extract(request)` 호출                       | `ExtractorError` 발생 (메시지 포함).                                                                         | API Resp: `{"error": ...}`   | High     |
+| **TC-012** | **Exception (Response)** | API 응답 Body에 `error` 키가 있으나 내부 필드 누락.                   | `extract(request)` 호출                       | `ExtractorError` 발생 (기본 메시지 "UnknownError" 등 확인).                                                  | API Resp: `{"error": {}}`    | Low      |
+| **TC-013** |       **Resource**       | `http_client.get` 호출 시 `ConnectionError` 발생.                     | `extract(request)` 호출                       | `ExtractorError`로 래핑되어 던져짐 ("System Error").                                                         | `client.get` raises Ex       | High     |


### PR DESCRIPTION
## 1. 🎫 PR 요약
> **암호화폐 시장 데이터 수집을 위한 Upbit Extractor 구현 및 정책 통합**
- 확장성을 고려하여 설정 기반(YAML)으로 동작하는 `UPBITExtractor`를 구현하고, 비트코인/이더리움 일봉 수집 정책을 정의했습니다.
- Upbit Open API의 고유한 에러 응답 포맷 핸들링과 파라미터 우선순위 병합 로직을 적용하여 안정성을 확보했습니다.

## 2. 🛠 작업 내용
- **`UPBITExtractor` 구현**: `AbstractExtractor`를 상속받아 Upbit 고유의 요청/응답 처리 로직 구현.
- **수집 정책(Policy) 추가**: `extractor.yml`에 BTC(비트코인), ETH(이더리움) KRW 마켓 일봉 수집 설정 추가.
- **단위 테스트 작성**: `upbit_extractor_test.py`를 통해 설정 검증, Happy Path, 예외 처리 등 13개 케이스(TCS-ETL-005) 검증.
- **검증 스크립트 업데이트**: `verification.py`에 Upbit Provider 초기화 및 정책 매핑 검증 로직 추가.

## 3. 💡 기술적 의사결정 (Architecture & Tech Stack)

### A. Runtime Config Dependency (YAML 기반 정책 관리)
- **결정 배경:** 암호화폐 시장은 신규 상장 및 상장 폐지가 빈번함. 새로운 코인(예: XRP, SOL) 수집이 필요할 때 배포 없이 설정 파일 수정만으로 대응하기 위함.
- **Trade-off:**
    - **Pros:** 높은 유연성과 운영 효율성.
    - **Cons:** 설정 파일의 오타나 누락이 런타임 에러로 이어질 위험 존재.
    - **Mitigation:** `__init__` 시점의 Fail-Fast 검증(Base URL 체크)과 `_validate_request` 메서드를 통한 런타임 방어 로직 구현.

### B. 파라미터 병합 전략 (Request Override)
- **결정 배경:** 기본 정책(YAML)에는 통상적인 수집 기준(예: `count=1`)을 정의하되, 백필(Backfill) 등 특수한 상황에서는 요청 시점에 파라미터를 변경해야 함.
- **구현 내용:** `merged_params = {**policy.params, **request.params}`
- **효과:** 정적 정책의 안정성과 동적 요청의 유연성을 동시에 확보.

### C. Upbit 고유 에러 핸들링
- **결정 배경:** Upbit API는 HTTP Status 200을 반환하면서 Body에 `{"error": ...}` 객체를 포함하는 경우가 있음 (Soft Error).
- **구현 내용:** `_create_response` 단계에서 응답 Body에 `error` 키 존재 여부를 검사하여, 존재 시 `ExtractorError`로 강제 변환(Raise).

## 4. 📋 주요 변경점
- `src/extractor/providers/upbit_extractor.py`: Upbit API 호출 및 응답 처리 핵심 로직 구현.
- `configs/extractor.yml`: `upbit_btc_daily`, `upbit_eth_daily` 등 수집 정책 정의.
- `verification.py`: `verify_extractor(target_provider="UPBIT")` 함수 추가 및 Global Config/Policy 검증 로직 통합.
- `tests/unit/extractor/upbit_extractor_test.py`: Mocking을 활용한 비동기 테스트 케이스 작성.

## 5. 📸 테스트 결과
### 5.1 Unit Test (`pytest`)
- **결과:** Total **13 Passed**
- **커버리지:**
    - Config Validation (URL 누락 등)
    - Authentication Flow (Header 조립)
    - Logic (Parameter Merge, Warning Logging)
    - Exception Handling (Network Error, API Business Error)

### 5.2 Manual Verification (`verification.py`)
- **수행 결과:**
    - ✅ AppConfig Loaded Successfully
    - ✅ UPBITExtractor Instantiated (API Key Protected Check)
    - 🔍 Policy Mapping Verified (Endpoint: `https://api.upbit.com/v1/candles/days`, Params: `market`, `count`)

## 6. 💬 리뷰 포인트 (Focus On)
- **에러 파싱 로직 (`_create_response`)**: Upbit API의 에러 응답 구조(`error` -> `name`, `message`)가 변경될 가능성에 대비해 구조가 적절한지 확인 부탁드립니다.
- **필수 파라미터 검증**: `market` 파라미터 누락 시 Exception이 아닌 Warning 로그만 남기도록 처리했습니다. (`_validate_request`). 이 수준의 검증이 충분한지 의견 바랍니다.