### PR TITLE
[Feat] 로그인, 로그아웃, 토큰 재발급(RTR) 기능 구현 및 테스트 작성

### DIFF
--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/BusinessException.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/BusinessException.java
@@ -1,5 +1,8 @@
 package com.assetmind.server_auth.global.error;
 
+import lombok.Getter;
+
+@Getter
 public class BusinessException extends RuntimeException {
 
     private final ErrorCode errorCode;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/ErrorCode.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     ALREADY_GET_USER_PERMISSION(HttpStatus.BAD_REQUEST, "U002", "이미 정식 회원입니다."),
     USER_DUPLICATED_EMAIL(HttpStatus.CONFLICT, "U003", "중복된 이메일입니다."),
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "U004", "유효하지 않은 인증 코드입니다."),
-    INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "U005", "비밀번호가 맞지 않습니다."),
+    INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "U005", "비밀번호가 맞지 않습니다."),
 
     // Jwt 토큰 에러
     INVALID_SIGN_UP_TOKEN(HttpStatus.BAD_REQUEST, "T001", "유효하지 않거나 용도가 잘못된 회원가입 토큰입니다."),

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/GlobalExceptionHandler.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.assetmind.server_auth.global.error;
 
 import com.assetmind.server_auth.global.common.ApiResponse;
+import com.assetmind.server_auth.user.exception.AuthException;
 import com.assetmind.server_auth.user.exception.InvalidSignUpTokenException;
 import com.assetmind.server_auth.user.exception.InvalidVerificationCode;
 import com.assetmind.server_auth.user.exception.UserDuplicatedEmail;
@@ -74,6 +75,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
                 .body(ApiResponse.fail("유효하지 않거나 만료된 가입 토큰입니다."));
+    }
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAuthException(AuthException e) {
+        log.error("Auth Exception: {}", e.getMessage());
+
+        ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(e.getMessage()));
     }
 
     /**

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/GlobalExceptionHandler.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/error/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
@@ -71,7 +72,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(InvalidSignUpTokenException.class)
     public ResponseEntity<ApiResponse<Void>> handleInvalidSignUpToken(InvalidSignUpTokenException e) {
-        log.error("Invalid SignUp Token: {}", e.getMessage());
+        log.warn("Invalid SignUp Token: {}", e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
                 .body(ApiResponse.fail("유효하지 않거나 만료된 가입 토큰입니다."));
@@ -79,7 +80,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AuthException.class)
     public ResponseEntity<ApiResponse<Void>> handleAuthException(AuthException e) {
-        log.error("Auth Exception: {}", e.getMessage());
+        log.warn("Auth Exception: {}", e.getMessage());
 
         ErrorCode errorCode = e.getErrorCode();
 
@@ -111,6 +112,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.fail("요청하신 URL을 찾을 수 없습니다."));
+    }
+
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingRequestCookie(MissingRequestCookieException e) {
+        log.warn("Missing Request Cookie: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.fail("필수 쿠키가 누락되었습니다."));
     }
 
     /**

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/util/CookieUtils.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/util/CookieUtils.java
@@ -1,0 +1,49 @@
+package com.assetmind.server_auth.global.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+/**
+ * HttpOnly, Secure, SameSite 보안이 적용된 쿠키를 생성하는 유틸리티 클래스
+ * 쿠키 생성 로직을 관리
+ */
+@Component
+public class CookieUtils {
+
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+
+    @Value("${jwt.cookie.secure}")
+    private boolean secure;
+
+    /**
+     * 리프레시 토큰을 담은 보안 쿠키를 생성
+     * 로그인 성공 시 클라이언트에게 발급할 때 사용
+     * @param refreshToken - 저장할 토큰 값
+     * @return 설정이 완료된 ResponseCookie 객체
+     */
+    public ResponseCookie createRefreshTokenCookie(String refreshToken, long maxAge) {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .httpOnly(true)
+                .secure(secure)
+                .path("/")
+                .maxAge(maxAge)
+                .sameSite("Lax")
+                .build();
+    }
+
+    /**
+     * 로그아웃 시 브라우저의 쿠키를 삭제하기 위한 '만료된 쿠키'를 생성
+     * (쿠키는 서버가 직접 삭제할 수 없으므로, 만료 시간(maxAge)을 0으로 덮어씌움)
+     * @return Max-Age가 0인 삭제용 ResponseCookie 객체
+     */
+    public ResponseCookie createDeletedCookie() {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                .httpOnly(true)
+                .secure(secure)
+                .path("/")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/global/util/JwtProcessor.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/global/util/JwtProcessor.java
@@ -1,13 +1,11 @@
-package com.assetmind.server_auth.global.common;
+package com.assetmind.server_auth.global.util;
 
 import com.assetmind.server_auth.global.config.JwtProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Jwts.SIG;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
-import java.security.Key;
 import java.util.Date;
 import java.util.Map;
 import javax.crypto.SecretKey;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserAuthService.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserAuthService.java
@@ -79,7 +79,7 @@ public class UserAuthService implements UserAuthUseCase {
         TokenSetDto tokenSet = authTokenProvider.createTokenSet(userId, user.getUserRole());
 
         // refreshToken 저장소에 다시 저장 (덮어쓰기)
-        refreshTokenPort.save(userId, user.getUserRole().toString(), tokenSet.refreshTokenExpire() / 1000);
+        refreshTokenPort.save(userId, tokenSet.refreshToken(), tokenSet.refreshTokenExpire() / 1000);
 
         return tokenSet;
     }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserAuthService.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserAuthService.java
@@ -8,6 +8,7 @@ import com.assetmind.server_auth.user.application.port.RefreshTokenPort;
 import com.assetmind.server_auth.user.application.port.UserRepository;
 import com.assetmind.server_auth.user.application.provider.AuthTokenProvider;
 import com.assetmind.server_auth.user.domain.User;
+import com.assetmind.server_auth.user.domain.type.UserRole;
 import com.assetmind.server_auth.user.exception.AuthException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -53,5 +54,33 @@ public class UserAuthService implements UserAuthUseCase {
     @Transactional
     public void logout(UUID userId) {
         refreshTokenPort.delete(userId);
+    }
+
+    @Override
+    public TokenSetDto reissueToken(String refreshToken) {
+        // 토큰 유효성 검증
+        authTokenProvider.validateToken(refreshToken);
+
+        // 토큰에서 유저 정보 추출 (userId)
+        UUID userId = authTokenProvider.getUserIdFromToken(refreshToken);
+
+        String storedRefreshToken = refreshTokenPort.getRefreshToken(userId);
+        // 저장소에 토큰이 없거나 요청한 토큰과 다른 토큰이라면 제거
+        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+            refreshTokenPort.delete(userId);
+            throw new AuthException(ErrorCode.INVALID_TOKEN);
+        }
+
+        // role이 변경되었을 수도 있으니, 유저 정보 최신화
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        // 새 토큰 발급
+        TokenSetDto tokenSet = authTokenProvider.createTokenSet(userId, user.getUserRole());
+
+        // refreshToken 저장소에 다시 저장 (덮어쓰기)
+        refreshTokenPort.save(userId, user.getUserRole().toString(), tokenSet.refreshTokenExpire() / 1000);
+
+        return tokenSet;
     }
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserAuthUseCase.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/UserAuthUseCase.java
@@ -13,7 +13,7 @@ public interface UserAuthUseCase {
     /**
      * 유저 로그인
      * @param cmd - 로그인 정보(이메일, 비밀번호)
-     * @return accessToken
+     * @return 토큰 세트(accessToken, refreshToken)
      */
     TokenSetDto login(UserLoginCommand cmd);
 
@@ -22,4 +22,13 @@ public interface UserAuthUseCase {
      * @param userId - 로그아웃할 유저의 ID
      */
     void logout(UUID userId);
+
+    /**
+     * 토큰 재발급
+     * 보안을 한 층 더 강화하기 위해 재발급 시
+     * AccessToken, RefreshToken 둘 다 재발급 (RTR 전략)
+     * @param refreshToken - 재발급 받기위한 토큰
+     * @return 토큰 세트(accessToken, refreshToken)
+     */
+    TokenSetDto reissueToken(String refreshToken);
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/provider/AuthTokenProvider.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/provider/AuthTokenProvider.java
@@ -1,6 +1,6 @@
 package com.assetmind.server_auth.user.application.provider;
 
-import com.assetmind.server_auth.global.common.JwtProcessor;
+import com.assetmind.server_auth.global.util.JwtProcessor;
 import com.assetmind.server_auth.global.error.ErrorCode;
 import com.assetmind.server_auth.user.application.dto.TokenSetDto;
 import com.assetmind.server_auth.user.domain.type.UserRole;
@@ -8,7 +8,6 @@ import com.assetmind.server_auth.user.exception.AuthException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
-import java.security.SignatureException;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/provider/SignUpTokenProvider.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/application/provider/SignUpTokenProvider.java
@@ -1,6 +1,6 @@
 package com.assetmind.server_auth.user.application.provider;
 
-import com.assetmind.server_auth.global.common.JwtProcessor;
+import com.assetmind.server_auth.global.util.JwtProcessor;
 import com.assetmind.server_auth.user.exception.InvalidSignUpTokenException;
 import io.jsonwebtoken.Claims;
 import java.util.Map;

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/UserAuthController.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/UserAuthController.java
@@ -5,7 +5,7 @@ import com.assetmind.server_auth.global.util.CookieUtils;
 import com.assetmind.server_auth.user.application.UserAuthUseCase;
 import com.assetmind.server_auth.user.application.dto.TokenSetDto;
 import com.assetmind.server_auth.user.presentation.dto.LoginRequest;
-import com.assetmind.server_auth.user.presentation.dto.LoginResponse;
+import com.assetmind.server_auth.user.presentation.dto.TokenResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,7 +36,7 @@ public class UserAuthController {
      * POST /api/auth/login
      */
     @PostMapping("/login")
-    public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
+    public ApiResponse<TokenResponse> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
         TokenSetDto tokenSet = userAuthUseCase.login(request.toCommand());
 
         // 쿠키 생성
@@ -45,7 +46,7 @@ public class UserAuthController {
         // 응답 헤더에 쿠키 추가
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
-        return ApiResponse.success(new LoginResponse(tokenSet.accessToken()));
+        return ApiResponse.success(new TokenResponse(tokenSet.accessToken()));
     }
 
     /**
@@ -61,5 +62,25 @@ public class UserAuthController {
         response.addHeader(HttpHeaders.SET_COOKIE, deletedCookie.toString());
 
         return ApiResponse.success("로그아웃 성공");
+    }
+
+    /**
+     * 토큰 재발급 API
+     * @CookieValue를 통해서 Cookie에 있는 값을 입력받음
+     * null이면 스프링에서 자체적으로 예외를 던짐
+     */
+    @PostMapping("/reissue")
+    public ApiResponse<TokenResponse> reissueRefreshToken(
+            @CookieValue(name = "refresh_token") String refreshToken,
+            HttpServletResponse response
+    ) {
+        TokenSetDto tokenSet = userAuthUseCase.reissueToken(refreshToken);
+
+        ResponseCookie refreshTokenCookie = cookieUtils.createRefreshTokenCookie(
+                tokenSet.refreshToken(), tokenSet.refreshTokenExpire() / 1000);
+
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return ApiResponse.success(new TokenResponse(tokenSet.accessToken()));
     }
 }

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/UserAuthController.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/UserAuthController.java
@@ -1,0 +1,65 @@
+package com.assetmind.server_auth.user.presentation;
+
+import com.assetmind.server_auth.global.common.ApiResponse;
+import com.assetmind.server_auth.global.util.CookieUtils;
+import com.assetmind.server_auth.user.application.UserAuthUseCase;
+import com.assetmind.server_auth.user.application.dto.TokenSetDto;
+import com.assetmind.server_auth.user.presentation.dto.LoginRequest;
+import com.assetmind.server_auth.user.presentation.dto.LoginResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 인증 관련 Controller
+ * 로그인/로그아웃, ID/PW 찾기의 API 담당
+ */
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class UserAuthController {
+
+    private final UserAuthUseCase userAuthUseCase;
+    private final CookieUtils cookieUtils;
+
+    /**
+     * 로그인 API
+     * POST /api/auth/login
+     */
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
+        TokenSetDto tokenSet = userAuthUseCase.login(request.toCommand());
+
+        // 쿠키 생성
+        ResponseCookie refreshTokenCookie = cookieUtils.createRefreshTokenCookie(
+                tokenSet.refreshToken(), tokenSet.refreshTokenExpire() / 1000);
+
+        // 응답 헤더에 쿠키 추가
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return ApiResponse.success(new LoginResponse(tokenSet.accessToken()));
+    }
+
+    /**
+     * 로그아웃 API
+     * @AuthenticationPrincipal을 사용하여 SecurityContextHolder에 있는 userId를 바로 주입받음
+     */
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(@AuthenticationPrincipal UUID userId, HttpServletResponse response) {
+        userAuthUseCase.logout(userId);
+
+        ResponseCookie deletedCookie = cookieUtils.createDeletedCookie();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, deletedCookie.toString());
+
+        return ApiResponse.success("로그아웃 성공");
+    }
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/dto/LoginRequest.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/dto/LoginRequest.java
@@ -1,0 +1,23 @@
+package com.assetmind.server_auth.user.presentation.dto;
+
+import com.assetmind.server_auth.user.application.dto.UserLoginCommand;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record LoginRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+                message = "비밀번호는 8자 이상, 영문/숫자/특수문자를 포함해야 합니다.")
+        String password
+) {
+
+    public UserLoginCommand toCommand() {
+        return new UserLoginCommand(this.email, this.password);
+    }
+
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/dto/LoginResponse.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/dto/LoginResponse.java
@@ -1,0 +1,10 @@
+package com.assetmind.server_auth.user.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record LoginResponse(
+        @JsonProperty("access_token")
+        String accessToken
+) {
+
+}

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/dto/TokenResponse.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/dto/TokenResponse.java
@@ -2,7 +2,7 @@ package com.assetmind.server_auth.user.presentation.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record LoginResponse(
+public record TokenResponse(
         @JsonProperty("access_token")
         String accessToken
 ) {

--- a/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/dto/UserRegisterRequest.java
+++ b/apps/server-auth/src/main/java/com/assetmind/server_auth/user/presentation/dto/UserRegisterRequest.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.Size;
 
 public record UserRegisterRequest(
         @NotBlank(message = "이메일은 필수입니다.")
-        @Email(message = "올바른 이메일 형식이 이납니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
 
         @NotBlank(message = "비밀번호는 필수입니다.")

--- a/apps/server-auth/src/main/resources/application-local.yaml
+++ b/apps/server-auth/src/main/resources/application-local.yaml
@@ -42,3 +42,5 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET_KEY}
+  cookie:
+    secure: false # HTTPS 설정

--- a/apps/server-auth/src/main/resources/application-prod.yaml
+++ b/apps/server-auth/src/main/resources/application-prod.yaml
@@ -1,0 +1,46 @@
+spring:
+  application:
+    name: server-auth
+
+  jpa:
+    hibernate:
+      ddl-auto: create # 테스트 시작 시 생성, 끝나면 삭제
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    database: postgresql
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_HOST:localhost}:5432/${POSTGRES_DB:assetmind}
+    username: ${POSTGRES_USER:postgres}
+    password: ${POSTGRES_PASSWORD}
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: 6379
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true                # 구글 로그인 필수
+          starttls:
+            enable: true            # 통신 내용 암호화
+            required: true          # 내용 암호화 안되면 전송 금지
+          connectiontimeout: 5000   # 5초안에 연결 안되면 포기
+          timeout: 5000             # 5초 동안 응답 없으면 포기
+          writetimeout: 5000        # 5초 동안 전송 안되면 포기
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  cookie:
+    secure: true # HTTPS 설정

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/global/common/JwtProcessorTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/global/common/JwtProcessorTest.java
@@ -3,6 +3,7 @@ package com.assetmind.server_auth.global.common;
 import static org.assertj.core.api.Assertions.*;
 
 import com.assetmind.server_auth.global.config.JwtProperties;
+import com.assetmind.server_auth.global.util.JwtProcessor;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/global/util/CookieUtilsTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/global/util/CookieUtilsTest.java
@@ -1,0 +1,79 @@
+package com.assetmind.server_auth.global.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * CookieUtils 단위 테스트
+ * 토큰 쿠키 생성 시 보안 설정이 잘 되는지 검증
+ * 토큰 쿠기 삭제 시 maxAge = 0이 잘 설정 되는지 검증
+ */
+class CookieUtilsTest {
+
+    private CookieUtils cookieUtils;
+
+    private static final long MAX_AGE = 604800;
+
+    @BeforeEach
+    void setUp() {
+        cookieUtils = new CookieUtils();
+
+        // @Value 필드에 테스트용 값 주입
+        ReflectionTestUtils.setField(cookieUtils, "secure", true);
+    }
+
+    @Test
+    @DisplayName("성공: 운영 환경(Https)에서 리프레시 토큰 쿠키 생성 시 모든 보안 설정이 적용된다.")
+    void givenRefreshTokenInProd_whenCreateRefreshTokenCookie_thenReturnSecureResponseCookie() {
+        // given
+        String token = "test-refresh-token";
+
+        // when
+        ResponseCookie cookie = cookieUtils.createRefreshTokenCookie(token, MAX_AGE);
+
+        // then
+        assertThat(cookie.getValue()).isEqualTo(token);
+        assertThat(cookie.isHttpOnly()).isTrue();  // 필수
+        assertThat(cookie.isSecure()).isTrue();    // 필수 (운영환경)
+        assertThat(cookie.getPath()).isEqualTo("/");
+        assertThat(cookie.getMaxAge().getSeconds()).isEqualTo(MAX_AGE);
+        assertThat(cookie.getSameSite()).isEqualTo("Lax");
+    }
+
+    @Test
+    @DisplayName("성공: 로컬 환경(Http)에서 리프레시 토큰 쿠키 생성 시 Secure = false로 보안 설정이 적용된다.")
+    void givenRefreshTokenInLocal_whenCreateRefreshTokenCookie_thenReturnNotSecureResponseCookie() {
+        // given
+        String token = "test-refresh-token";
+        ReflectionTestUtils.setField(cookieUtils, "secure", false);
+
+        // when
+        ResponseCookie cookie = cookieUtils.createRefreshTokenCookie(token, MAX_AGE);
+
+        // then
+        assertThat(cookie.getValue()).isEqualTo(token);
+        assertThat(cookie.isHttpOnly()).isTrue();  // 필수
+        assertThat(cookie.isSecure()).isFalse();    // 필수 (운영환경)
+        assertThat(cookie.getPath()).isEqualTo("/");
+        assertThat(cookie.getMaxAge().getSeconds()).isEqualTo(MAX_AGE);
+        assertThat(cookie.getSameSite()).isEqualTo("Lax");
+    }
+
+    @Test
+    @DisplayName("성공: 삭제용 쿠키 생성 시, maxAge가 0이고 값이 빈 상태이다.")
+    void whenCreateDeleteCookie_thenReturnEmptyResponseCookie() {
+        // when
+        ResponseCookie cookie = cookieUtils.createDeletedCookie();
+
+        // then
+        assertThat(cookie.getValue()).isEmpty(); // 값 비움
+        assertThat(cookie.getMaxAge().getSeconds()).isZero(); // 즉시 만료
+        assertThat(cookie.isHttpOnly()).isTrue();
+        assertThat(cookie.getPath()).isEqualTo("/");
+    }
+}

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/global/util/JwtProcessorTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/global/util/JwtProcessorTest.java
@@ -1,9 +1,8 @@
-package com.assetmind.server_auth.global.common;
+package com.assetmind.server_auth.global.util;
 
 import static org.assertj.core.api.Assertions.*;
 
 import com.assetmind.server_auth.global.config.JwtProperties;
-import com.assetmind.server_auth.global.util.JwtProcessor;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/UserAuthServiceTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/UserAuthServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * UserAuthService 단위 테스트
  * 로그인 로직 확인
  * 로그아웃 로직 확인
+ * 토큰 재발급 로직 확인
  */
 @ExtendWith(MockitoExtension.class)
 class UserAuthServiceTest {
@@ -129,5 +130,99 @@ class UserAuthServiceTest {
 
         // then
         then(refreshTokenPort).should().delete(USER_ID);
+    }
+
+    @Test
+    @DisplayName("성공: 유효한 리프레시 토큰으로 재발급 요청 시, 토큰을 갱신하고 Redis를 업데이트한다.")
+    void givenValidRefreshToken_whenReissueRefreshToken_thenReturnNewTokenSet() {
+        // given
+        String requestRefreshToken = "valid-old-refresh-token";
+
+        // 새로 발급될 토큰 정보
+        String newAccessToken = "new-access-token";
+        String newRefreshToken = "new-refresh-token";
+        TokenSetDto newTokenSet = new TokenSetDto(newAccessToken, newRefreshToken, 10000L);
+
+        // 토큰 자체 유효성 검증 (Provider)
+        willDoNothing().given(authTokenProvider).validateToken(requestRefreshToken);
+
+        // 토큰에서 사용자 ID 및 Role 추출
+        given(authTokenProvider.getUserIdFromToken(requestRefreshToken)).willReturn(USER_ID);
+
+        // 유저 정보 최신화
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+        // Redis에 저장된 토큰 조회 및 일치 확인
+        given(refreshTokenPort.getRefreshToken(USER_ID)).willReturn(requestRefreshToken);
+
+        given(user.getUserRole()).willReturn(UserRole.GUEST);
+
+        // 새 토큰 생성
+        given(authTokenProvider.createTokenSet(USER_ID, UserRole.GUEST)).willReturn(newTokenSet);
+
+        // when
+        TokenSetDto result = authService.reissueToken(requestRefreshToken);
+
+        // then
+        assertThat(result).isEqualTo(newTokenSet);
+
+        // 검증: Redis에 새로운 리프레시 토큰이 저장되었는지 (RTR: Refresh Token Rotation)
+        then(refreshTokenPort).should().save(eq(USER_ID), eq(newRefreshToken), eq(10L));
+    }
+
+    @Test
+    @DisplayName("실패: 요청한 리프레시 토큰이 유효하지 않은 형식(혹은 만료)이라면 예외를 발생시킨다.")
+    void givenInvalidRefreshTokenFormat_whenReissueRefreshToken_thenThrowException() {
+        // given
+        String invalidToken = "invalid-format-token";
+
+        // Provider 검증 실패
+        willThrow(new AuthException(ErrorCode.INVALID_TOKEN))
+                .given(authTokenProvider).validateToken(invalidToken);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueToken(invalidToken))
+                .isInstanceOf(AuthException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TOKEN);
+
+        // Redis 조회나 저장 로직이 동작하지 않음을 검증
+        then(refreshTokenPort).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("실패: Redis에 저장된 리프레시 토큰이 없다면(만료됨/로그아웃됨) 예외를 발생시킨다.")
+    void givenRefreshTokenNotFoundInRedis_whenReissueRefreshToken_thenThrowException() {
+        // given
+        String requestRefreshToken = "valid-format-but-not-in-redis";
+
+        willDoNothing().given(authTokenProvider).validateToken(requestRefreshToken);
+        given(authTokenProvider.getUserIdFromToken(requestRefreshToken)).willReturn(USER_ID);
+
+        // Redis 조회 결과 없음 (TTL 만료 등)
+        given(refreshTokenPort.getRefreshToken(USER_ID)).willReturn(isNull());
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueToken(requestRefreshToken))
+                .isInstanceOf(AuthException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TOKEN);
+    }
+
+    @Test
+    @DisplayName("실패: 요청한 토큰과 Redis에 저장된 토큰이 일치하지 않는다면 예외를 발생시킨다.")
+    void givenTokenMismatch_whenReissueRefreshToken_thenThrowException() {
+        // given
+        String requestRefreshToken = "request-refresh-token";
+        String storedRefreshToken = "latest-valid-refresh-token";
+
+        willDoNothing().given(authTokenProvider).validateToken(requestRefreshToken);
+        given(authTokenProvider.getUserIdFromToken(requestRefreshToken)).willReturn(USER_ID);
+
+        // Redis에는 다른 토큰이 저장되어 있음 (이미 다른 기기에서 갱신했거나 공격 시도) requestRefreshToken != storedRefreshToken
+        given(refreshTokenPort.getRefreshToken(USER_ID)).willReturn(storedRefreshToken);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueToken(requestRefreshToken))
+                .isInstanceOf(AuthException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TOKEN); // 혹은 TOKEN_MISMATCH
     }
 }

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/provider/AuthTokenProviderTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/provider/AuthTokenProviderTest.java
@@ -3,7 +3,7 @@ package com.assetmind.server_auth.user.application.provider;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import com.assetmind.server_auth.global.common.JwtProcessor;
+import com.assetmind.server_auth.global.util.JwtProcessor;
 import com.assetmind.server_auth.global.error.ErrorCode;
 import com.assetmind.server_auth.user.application.dto.TokenSetDto;
 import com.assetmind.server_auth.user.domain.type.UserRole;
@@ -11,7 +11,6 @@ import com.assetmind.server_auth.user.exception.AuthException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.security.SignatureException;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/provider/SignUpTokenProviderTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/application/provider/SignUpTokenProviderTest.java
@@ -3,7 +3,7 @@ package com.assetmind.server_auth.user.application.provider;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import com.assetmind.server_auth.global.common.JwtProcessor;
+import com.assetmind.server_auth.global.util.JwtProcessor;
 import com.assetmind.server_auth.user.exception.InvalidSignUpTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/presentation/UserAuthControllerTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/presentation/UserAuthControllerTest.java
@@ -1,10 +1,6 @@
 package com.assetmind.server_auth.user.presentation;
 
 import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -20,12 +16,12 @@ import com.assetmind.server_auth.user.application.dto.UserLoginCommand;
 import com.assetmind.server_auth.user.exception.AuthException;
 import com.assetmind.server_auth.user.presentation.dto.LoginRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -202,5 +198,76 @@ class UserAuthControllerTest {
 
         // 서비스 로그아웃 호출 확인
         then(authUseCase).should().logout(eq(userId));
+    }
+
+    @Test
+    @DisplayName("성공: [POST] 유효한 Refresh Token 쿠키로 재발급 요청 시, 새 토큰을 발급하고 쿠키를 갱신한다.")
+    void givenValidRefreshTokenCookie_whenReissue_thenRespondNewTokenSet200() throws Exception {
+        // given
+        String oldRefreshToken = "old-refresh-token";
+        String newAccessToken = "new-access-token";
+        String newRefreshToken = "new-refresh-token";
+
+        TokenSetDto newTokenSet = new TokenSetDto(newAccessToken, newRefreshToken, 10000L);
+
+        // 1. Mocking: 서비스 로직
+        given(authUseCase.reissueToken(eq(oldRefreshToken))).willReturn(newTokenSet);
+
+        // 2. Mocking: 응답용 새 쿠키 생성
+        ResponseCookie newCookie = ResponseCookie.from("refresh_token", newRefreshToken)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(10)
+                .build();
+        given(cookieUtils.createRefreshTokenCookie(eq(newRefreshToken), eq(10L))).willReturn(newCookie);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reissue")
+                        .with(csrf())
+                        .cookie(new Cookie("refresh_token", oldRefreshToken)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").isEmpty())
+                .andExpect(jsonPath("$.data.access_token").value(newAccessToken))
+                .andExpect(header().exists("Set-Cookie"))
+                .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("refresh_token=" + newRefreshToken)));
+    }
+
+    @Test
+    @DisplayName("실패: [POST] 요청에 Refresh Token 쿠키가 없다면 401 Unauthorized 응답한다.")
+    void givenNoRefreshTokenCookie_whenReissue_thenRespond401() throws Exception {
+        // given
+        // 쿠키를 넣지 않고 요청
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reissue")
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("필수 쿠키가 누락되었습니다."))
+                .andExpect(jsonPath("$.data").isEmpty())
+                .andExpect(status().isUnauthorized()); // @CookieValue(required=true)에 의해 401 발생
+    }
+
+    @Test
+    @DisplayName("실패: [POST] 만료되거나 유효하지 않은 Refresh Token으로 요청 시 401 응답한다.")
+    void givenInvalidRefreshToken_whenReissue_thenRespond401() throws Exception {
+        // given
+        String invalidToken = "invalid-token";
+
+        // Mocking: 서비스에서 예외 발생
+        given(authUseCase.reissueToken(eq(invalidToken)))
+                .willThrow(new AuthException(ErrorCode.INVALID_TOKEN));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reissue")
+                        .with(csrf())
+                        .cookie(new jakarta.servlet.http.Cookie("refresh_token", invalidToken)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized()) // 401
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_TOKEN.getMessage()))
+                .andExpect(jsonPath("$.data").isEmpty());
     }
 }

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/user/presentation/UserAuthControllerTest.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/user/presentation/UserAuthControllerTest.java
@@ -1,0 +1,206 @@
+package com.assetmind.server_auth.user.presentation;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.assetmind.server_auth.global.config.SecurityConfig;
+import com.assetmind.server_auth.global.error.ErrorCode;
+import com.assetmind.server_auth.global.util.CookieUtils;
+import com.assetmind.server_auth.user.application.UserAuthUseCase;
+import com.assetmind.server_auth.user.application.dto.TokenSetDto;
+import com.assetmind.server_auth.user.application.dto.UserLoginCommand;
+import com.assetmind.server_auth.user.exception.AuthException;
+import com.assetmind.server_auth.user.presentation.dto.LoginRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * UserAuthControllerTest 슬라이스 테스트
+ * Request DTO의 @Valid 입력값 검증
+ * GlobalExceptionHandler의 예외 처리 검증
+ * 로그인 / 로그아웃 API 로직 검증
+ */
+@WebMvcTest(UserAuthController.class)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
+class UserAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserAuthUseCase authUseCase;
+
+    @MockitoBean
+    private CookieUtils cookieUtils;
+
+    @Test
+    @DisplayName("성공: [POST] 유효한 로그인 정보로 로그인에 성공하면 accessToken은 body로, refreshToken은 cookie에 넣어서 응답한다.")
+    void givenLoginRequest_whenLogin_thenRespondTokenSet200() throws Exception {
+        // given
+        LoginRequest request = new LoginRequest("test@email.com", "!Pass123");
+        TokenSetDto tokenSet = new TokenSetDto("access-token", "refresh-token", 10000L); // 10초
+
+        // Mocking: 서비스가 토큰셋 반환
+        given(authUseCase.login(any(UserLoginCommand.class))).willReturn(tokenSet);
+
+        // Mocking: 쿠키 유틸이 쿠키 생성
+        ResponseCookie mockCookie = ResponseCookie.from("refresh_token", "refresh-token")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(10)
+                .build();
+        given(cookieUtils.createRefreshTokenCookie(any(), eq(10L))).willReturn(mockCookie);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .with(csrf()) // POST 요청 필수
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").isEmpty())
+                .andExpect(jsonPath("$.data.access_token").value("access-token"))
+                // 헤더에 Set-Cookie가 존재하는지 확인
+                .andExpect(header().exists("Set-Cookie"))
+                .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("refresh_token=refresh-token")));
+    }
+
+    @Test
+    @DisplayName("실패: [POST] 잘못된 형식의 이메일로 로그인을 시도하면 형식 오류 예외를 (400) 응답한다.")
+    void givenInvalidEmail_whenLogin_thenRespond400() throws Exception {
+        // given
+        LoginRequest request = new LoginRequest("invalid-email", "!Pass123"); // 이메일 형식 X
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest()) // 400 Bad Request
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("올바른 이메일 형식이 아닙니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("실패: [POST] 잘못된 형식의 비밀번호로 로그인을 시도하면 형식 오류 예외를 (400) 응답한다.")
+    void givenInvalidPassword_whenLogin_thenRespond400() throws Exception {
+        // given
+        LoginRequest request = new LoginRequest("test@email.com", "123"); // 비밀번호 규칙 위반 (너무 짧음 등)
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("비밀번호는 8자 이상, 영문/숫자/특수문자를 포함해야 합니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("실패: [POST] 존재하지 않는 이메일로 로그인을 시도하면 예외를 (404) 응답한다.")
+    void givenNotExistEmail_whenLogin_thenRespond404() throws Exception {
+        // given
+        LoginRequest request = new LoginRequest("notfound@email.com", "!Pass123");
+
+        // Mocking: 서비스에서 예외 발생 시키기
+        given(authUseCase.login(any(UserLoginCommand.class)))
+                .willThrow(new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound()) // 404 Not Found
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.USER_NOT_FOUND.getMessage()))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("실패: [POST] 맞지 않는 비밀번호로 로그인을 시도하면 예외를 (401) 응답한다.")
+    void givenIncorrectPassword_whenLogin_thenRespond401() throws Exception {
+        // given
+        LoginRequest request = new LoginRequest("test@email.com", "wrongPassword!123");
+
+        // Mocking: 비밀번호 불일치 예외
+        given(authUseCase.login(any(UserLoginCommand.class)))
+                .willThrow(new AuthException(ErrorCode.INCORRECT_PASSWORD)); // ErrorCode의 상태값이 401인지 확인 필요
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                // 만약 ErrorCode.INCORRECT_PASSWORD의 status가 401이라면:
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.INCORRECT_PASSWORD.getMessage()))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("성공: [POST] 로그인된 유저가 유효한 userId로 로그아웃을 하면 refreshToken이 삭제되고, 빈 쿠키 값을 넣어서 응답한다.")
+    void givenValidUserId_whenLogout_thenRespondEmptyCookie200() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // 인증 객체 생성 (Filter 통과 가정)
+        Authentication auth = new UsernamePasswordAuthenticationToken(userId, null, List.of(new SimpleGrantedAuthority("GUEST")));
+
+        // Mocking: 쿠키 삭제용 쿠키 생성
+        ResponseCookie deletionCookie = ResponseCookie.from("refresh_token", "")
+                .maxAge(0) // 즉시 만료
+                .build();
+        given(cookieUtils.createDeletedCookie()).willReturn(deletionCookie);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/logout")
+                        .with(csrf())
+                        .with(authentication(auth))) // 👈 인증된 상태 주입
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("로그아웃 성공"))
+                .andExpect(jsonPath("$.data").isEmpty())
+                .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Max-Age=0")));
+
+        // 서비스 로그아웃 호출 확인
+        then(authUseCase).should().logout(eq(userId));
+    }
+}

--- a/docs/TCS/auth/TCS-USR-003.md
+++ b/docs/TCS/auth/TCS-USR-003.md
@@ -2,7 +2,7 @@
 
 | 문서 ID | **TCS-USR-003**                          |
 | :--- |:-----------------------------------------|
-| **문서 버전** | 1.1                                      |
+| **문서 버전** | 1.2                                      |
 | **프로젝트** | AssetMind                                |
 | **작성자** | 이재석                                      |
 | **작성일** | 2026년 01월 22일                            |
@@ -77,6 +77,14 @@
 | :--- | :--- | :--- | :--- | :--- |
 | **SVC-AUTH-004** | **로그아웃 성공**<br>(Redis 토큰 삭제) | (별도 사전 조건 없음) | `logout(userId)` 호출 | 1. `refreshTokenPort.delete(userId)`가 1회 호출된다.<br>2. 이를 통해 해당 유저의 리프레시 토큰이 영구 삭제된다. |
 
+### 3.3. 토큰 재발급 (Reissue)
+
+| ID | 시나리오 | Given (사전 조건) | When (실행) | Then (기대 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **SVC-AUTH-005** | **재발급 성공**<br>(유효 토큰 + Redis 일치) | 1. `validateToken`: 통과<br>2. `refreshTokenPort.get`: 요청 토큰과 일치<br>3. `userRepository`: 유저 조회 & Role 정보 존재 | `reissueToken(token)` 호출 | 1. 새로운 Access/Refresh Token Set이 반환된다.<br>2. **RTR(Rotation)**을 위해 `refreshTokenPort.save()`가 호출되어 토큰이 교체된다. |
+| **SVC-AUTH-006** | **재발급 실패**<br>(형식 오류/만료) | 1. `validateToken`: **예외 발생** (유효하지 않음) | `reissueToken(token)` 호출 | 1. **`AuthException`** (`INVALID_TOKEN`) 발생.<br>2. Redis 조회 및 저장 로직은 실행되지 않는다. |
+| **SVC-AUTH-007** | **재발급 실패**<br>(Redis 불일치/없음) | 1. `validateToken`: 통과<br>2. `refreshTokenPort.get`: `Empty` or 불일치 | `reissueToken(token)` 호출 | 1. **`AuthException`** (`REFRESH_TOKEN_EXPIRED`) 발생.<br>2. 토큰 탈취 가능성을 고려하여 재발급이 거부된다. |
+
 ---
 
 ## 4. 종합 결과
@@ -84,5 +92,5 @@
 | 항목 | 전체 케이스 |  Pass  | Fail | 비고                       |
 | :--- |:------:|:------:| :---: |:-------------------------|
 | **Service Logic** |   9    |   9    | 0 | Happy/Unhappy Path 검증 완료 |
-| **Auth Service** |   4    |   4    | 0 | 로그인/로그아웃 로직 검증 완료        |
-| **합계** | **13** | **13** | **0** | **Pass** ✅               |
+| **Auth Service** |   7    |   7    | 0 | 로그인/로그아웃/토큰 재발급 로직 검증 완료 |
+| **합계** | **16** | **16** | **0** | **Pass** ✅               |

--- a/docs/TCS/auth/TCS-USR-004.md
+++ b/docs/TCS/auth/TCS-USR-004.md
@@ -1,28 +1,30 @@
-# [TCS] 회원가입 컨트롤러 단위 테스트 명세서
+# [TCS] 회원가입 및 인증 컨트롤러 단위 테스트 명세서
 
-| 문서 ID | **TCS-USR-004**          |
-| :--- |:-------------------------|
-| **문서 버전** | 1.0                      |
-| **프로젝트** | AssetMind                |
-| **작성자** | 이재석                      |
-| **작성일** | 2026년 01월 25일            |
-| **대상 모듈** | `UserRegisterController` |
+| 문서 ID | **TCS-USR-004**                               |
+| :--- |:----------------------------------------------|
+| **문서 버전** | 1.1                                           |
+| **프로젝트** | AssetMind                                     |
+| **작성자** | 이재석                                           |
+| **작성일** | 2026년 01월 25일                                 |
+| **대상 모듈** | `UserRegisterController`, `UserAuthController` |
 
 ## 1. 개요 (Overview)
 
-본 문서는 클라이언트의 HTTP 요청을 처리하는 **Web Adapter 계층(`UserRegisterController`)**을 검증하기 위한 단위 테스트 명세이다.
-`@WebMvcTest`를 사용하여 컨트롤러를 슬라이스 테스트하며, **Request DTO 유효성 검증(@Valid)**, **Service 호출 여부**, **GlobalExceptionHandler를 통한 공통 응답 포맷(ApiResponse)을** 중점적으로 확인한다.
+본 문서는 클라이언트의 HTTP 요청을 처리하는 **Web Adapter 계층(`UserRegisterController`, `UserAuthController`)을** 검증하기 위한 단위 테스트 명세이다.
+`@WebMvcTest`를 사용하여 컨트롤러를 슬라이스 테스트하며, **Request DTO 유효성 검증(@Valid)**, **Service 호출 여부**, **GlobalExceptionHandler를 통한 공통 응답 포맷(ApiResponse)을**, **Cookie 처리** 중점적으로 확인한다.
 
 ### 1.1. 테스트 환경
 - **Framework:** JUnit 5, Mockito (`@MockitoBean`), MockMvc
-- **Test Class:** `UserRegisterControllerTest`
-- **Configuration:** `@AutoConfigureMockMvc(addFilters = false)` (Security Filter 비활성화)
+- **Test Class:** `UserRegisterControllerTest`, `UserAuthControllerTest`
+- **Configuration:** `@AutoConfigureMockMvc(addFilters = false)` (Security Filter 비활성화, 필요한 경우 `with(csrf())`, `with(authentication())` 사용)
 - **Mock Objects:**
     - `UserRegisterUseCase`: 비즈니스 로직(Service) 모의
+    - `UserAuthUseCase`: 로그인/로그아웃/재발급 비즈니스 로직 모의
+    - `CookieUtils`: 쿠키 생성 로직 모의
 
 ---
 
-## 2. 테스트 케이스 상세 (Test Cases)
+## 2. 회원가입 컨트롤러 테스트 (`UserRegisterController`)
 
 ### 2.1. 이메일 중복 체크 (Check Email Duplicate)
 **Endpoint:** `GET /api/auth/check-email`
@@ -62,9 +64,40 @@
 
 ---
 
-## 3. 종합 결과
+## 3. 인증 컨트롤러 테스트 (`UserAuthController`)
 
-| 항목 | 전체 케이스 | Pass | Fail | 비고 |
-| :--- | :---: | :---: | :---: | :--- |
-| **Controller Logic** | 12 | 12 | 0 | Validation 및 ExceptionHandler 검증 완료 |
-| **합계** | **12** | **12** | **0** | **Pass** ✅ |
+### 3.1. 로그인 (Login)
+**Endpoint:** `POST /api/auth/login`
+
+| ID | 시나리오 | Given (사전 조건) | When (실행) | Then (기대 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **WEB-AUTH-001** | **로그인 성공**<br>(토큰 발급) | 1. Service가 `TokenSetDto` 반환<br>2. `CookieUtils`가 Refresh Cookie 생성 | `POST /login` 호출<br>(body: validLoginReq) | 1. HTTP 상태 코드 **200 OK**<br>2. Body `data.access_token` 존재<br>3. Header `Set-Cookie`에 `refresh_token` 포함 |
+| **WEB-AUTH-002** | **로그인 실패**<br>(입력값 검증 오류) | (Mocking 불필요) | `POST /login` 호출<br>(body: invalidEmail or invalidPw) | 1. HTTP 상태 코드 **400 Bad Request**<br>2. `message`에 유효성 검증 실패 사유 포함 (형식 오류 등) |
+| **WEB-AUTH-003** | **로그인 실패**<br>(존재하지 않는 유저) | Service가 `AuthException` (`USER_NOT_FOUND`) 발생 | `POST /login` 호출<br>(body: notFoundEmail) | 1. HTTP 상태 코드 **404 Not Found**<br>2. `message`에 "유저를 찾을 수 없음" 포함 |
+| **WEB-AUTH-004** | **로그인 실패**<br>(비밀번호 불일치) | Service가 `AuthException` (`INCORRECT_PASSWORD`) 발생 | `POST /login` 호출<br>(body: wrongPassword) | 1. HTTP 상태 코드 **401 Unauthorized**<br>2. `message`에 "비밀번호 불일치" 포함 |
+
+### 3.2. 로그아웃 (Logout)
+**Endpoint:** `POST /api/auth/logout`
+
+| ID | 시나리오 | Given (사전 조건) | When (실행) | Then (기대 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **WEB-AUTH-005** | **로그아웃 성공**<br>(쿠키 삭제) | 1. `CookieUtils`가 삭제용 쿠키(Max-Age=0) 생성<br>2. Security Context에 인증 정보 존재 | `POST /logout` 호출 | 1. HTTP 상태 코드 **200 OK**<br>2. Header `Set-Cookie`에 `Max-Age=0` 확인<br>3. Service `logout(userId)` 호출 확인 |
+
+### 3.3. 토큰 재발급 (Reissue)
+**Endpoint:** `POST /api/auth/reissue`
+
+| ID | 시나리오 | Given (사전 조건) | When (실행) | Then (기대 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **WEB-AUTH-006** | **재발급 성공**<br>(쿠키 갱신) | 1. Request 쿠키에 유효한 Token 존재<br>2. Service가 새 `TokenSetDto` 반환 | `POST /reissue` 호출<br>(Cookie: refresh_token) | 1. HTTP 상태 코드 **200 OK**<br>2. Body `data.access_token` 갱신 확인<br>3. Header `Set-Cookie`에 새 토큰 값 확인 |
+| **WEB-AUTH-007** | **재발급 실패**<br>(쿠키 누락) | Request에 쿠키 없음 | `POST /reissue` 호출 | 1. HTTP 상태 코드 **401 Unauthorized**<br>2. `message`에 "필수 쿠키 누락" 포함<br>(`@CookieValue` 검증) |
+| **WEB-AUTH-008** | **재발급 실패**<br>(토큰 만료/유효성 X) | Service가 `AuthException` (`INVALID_TOKEN`) 발생 | `POST /reissue` 호출<br>(Cookie: invalidToken) | 1. HTTP 상태 코드 **401 Unauthorized**<br>2. `message`에 "유효하지 않은 토큰" 포함 |
+
+---
+
+## 4. 종합 결과
+
+| 항목                         | 전체 케이스 |  Pass  | Fail | 비고 |
+|:---------------------------|:------:|:------:| :---: | :--- |
+| **UserRegisterController** |   12   |   12   | 0 | Validation 및 ExceptionHandler 검증 완료 |
+| **UserAuthController**     |   8    |   8    | 0 | 로그인/로그아웃/재발급 흐름 검증 완료 |
+| **합계**                     | **20** | **20** | **0** | **Pass** ✅ |


### PR DESCRIPTION
## 📌 작업 내용
- **인증 컨트롤러(`UserAuthController`) 구현:** 로그인(`POST /login`), 로그아웃(`POST /logout`), 토큰 재발급(`POST /reissue`) 엔드포인트를 구현했습니다.
- **비즈니스 로직(`UserAuthService`) 고도화:** 단순 로그인뿐만 아니라, 보안을 강화한 **RTR(Refresh Token Rotation)** 방식의 재발급 로직을 적용했습니다.
- **검증 및 문서화:** 서비스 계층(`UserAuthServiceTest`)과 웹 계층(`UserAuthControllerTest`)에 대한 단위 테스트를 작성하고 이에 따른 테스트 명세서(`TCS-USR-003`, `TCS-USR-004`)를 최신화했습니다.

## 🏗 기술적 의사결정 (핵심 변경 사유)

**1. Refresh Token Rotation (RTR) 전략 도입**
> 탈취된 리프레시 토큰의 재사용을 방지해야 합니다.
- **구현:** 토큰 재발급 요청 시, Access Token만 새로 발급하는 것이 아니라 **Refresh Token도 함께 교체(Rotate)**하고 Redis에 덮어씌웁니다.
- **이점:** 만약 공격자가 리프레시 토큰을 탈취하더라도, 사용자가 재발급을 시도하는 순간 이전 토큰은 무효화되거나 불일치 감지로 인해 차단되므로 보안성이 대폭 향상된다고 생각합니다.

**2. 토큰 전달 방식의 분리 (Security & Usability)**
> XSS 공격 방지와 클라이언트 편의성을 동시에 고려해야 합니다.
- **결정:** - **Access Token:** Response Body로 전달 (클라이언트가 Header에 담아 쓰기 편함).
    - **Refresh Token:** `HttpOnly`, `Secure` 설정이 된 **Cookie**로 전달.
- **이유:** 리프레시 토큰은 수명이 길기 때문에 JavaScript로 접근 불가능한 `HttpOnly Cookie`에 담아 XSS 공격으로부터 보호하고, Access Token은 사용성을 위해 Body로 전달하는 하이브리드 방식을 채택했습니다.

**3. 컨트롤러 테스트 전략 (`@WebMvcTest`)**
> 컨트롤러의 역할에 따라 HTTP 요청/응답 매핑과 예외 처리에 집중해야 합니다.
- **구현:** `UserRegisterUseCase`와 `UserAuthUseCase`를 Mocking하여 서비스 로직과 분리된 슬라이스 테스트를 진행했습니다.
- **검증 포인트:** - Request DTO의 `@Valid` 검증 동작 여부.
    - `CookieUtils`를 통한 쿠키 생성 및 삭제(`Max-Age=0`) 로직.
    - GlobalExceptionHandler를 통한 에러 응답 포맷(`ApiResponse`) 일관성 확인.

## ✅ 주요 변경점
- **Presentation Layer (`UserAuthController`):**
    - `login()`: `TokenSetDto` 반환 후, Access Token은 Body, Refresh Token은 Cookie로 분리 응답.
    - `logout()`: Redis에서 토큰 삭제 및 클라이언트 쿠키 만료 처리 (`Max-Age=0`).
    - `reissueRefreshToken()`: 쿠키에서 Refresh Token 추출 -> 검증 -> RTR 적용 후 새 토큰 세트 응답.
- **Application Layer (`UserAuthService`):**
    - `reissueToken()`: 토큰 유효성 검사, Redis 저장 값 비교, User Role 조회 후 새 토큰 발급 로직 추가.
- **Test Codes:**
    - `UserAuthServiceTest`: Redis 저장, 삭제, RTR 로직 검증 (Mockito).
    - `UserAuthControllerTest`: MockMvc를 활용한 HTTP Status, Cookie, JSON Body 검증.

## 📝 리뷰 포인트
- **RTR 로직:** `reissueToken` 메서드에서 Redis 조회 후 새로운 토큰으로 덮어쓰는 로직(`refreshTokenPort.save`)이 의도대로 안전하게 구현되었는지 확인 부탁드립니다.
- **Cookie 설정:** `UserAuthController`에서 `ResponseCookie`를 생성할 때 `HttpOnly`, `Path`, `MaxAge` 설정이 적절한지 검토 바랍니다.
- **테스트 케이스:** `UserAuthControllerTest`에서 쿠키 유무에 따른 분기(400/401 에러) 처리가 꼼꼼하게 되었는지 확인 부탁드립니다.