### PR TITLE
[Feat] 실시간 주가 데이터 파서(Parser) 분리 및 고도화

### DIFF
--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/dto/KisRealTimeData.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/dto/KisRealTimeData.java
@@ -1,16 +1,19 @@
 package com.assetmind.server_stock.market_access.infrastructure.kis.dto;
 
+import lombok.Builder;
+
 /**
  * KIS 실시간 체결 데이터 (H0STCNT0) DTO
  * 46개의 모든 필드를 포함하지 않고 핵심 15개 필드를 포함
  */
+@Builder
 public record KisRealTimeData(
         String symbol,              // 종목코드
         String executionTime,       // 체결 시간 (HHmmss)
         Long currentPrice,          // 현재가
         Long changeSign,            // 대비 부호 (1:상한, 2:상승, 3:보합, 4:하한, 5:하락)
         Long priceChange,           // 전일 대비
-        Double ChangeRate,          // 등락률
+        Double changeRate,          // 등락률
         Long openPrice,             // 시가
         Long highPrice,             // 고가
         Long lowPrice,              // 저가

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/dto/KisRealTimeData.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/dto/KisRealTimeData.java
@@ -1,0 +1,26 @@
+package com.assetmind.server_stock.market_access.infrastructure.kis.dto;
+
+/**
+ * KIS 실시간 체결 데이터 (H0STCNT0) DTO
+ * 46개의 모든 필드를 포함하지 않고 핵심 15개 필드를 포함
+ */
+public record KisRealTimeData(
+        String symbol,              // 종목코드
+        String executionTime,       // 체결 시간 (HHmmss)
+        Long currentPrice,          // 현재가
+        Long changeSign,            // 대비 부호 (1:상한, 2:상승, 3:보합, 4:하한, 5:하락)
+        Long priceChange,           // 전일 대비
+        Double ChangeRate,          // 등락률
+        Long openPrice,             // 시가
+        Long highPrice,             // 고가
+        Long lowPrice,              // 저가
+        Long executionVolume,       // 체결 거래량
+        Long cumulativeVolume,      // 누적 거래량
+        Long cumulativeAmount,      // 누적 거래 대금
+        Double volumePower,         // 체결 강도
+        String marketStatus         // 장운영 구분 코드 (첫번째-상태, 두번째-종류)
+                                    // 첫번째 -> 1:장개시전, 2:장중, 3:장종류후, 4:시간외단일가, 7:일반Buy-in, 8:당일Buy-in
+                                    // 두번째 -> 0:보통, 1:종가, 2:대량, 3:바스켓, 7:정리매매, 8:Buy-in
+) {
+
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
@@ -1,8 +1,11 @@
 package com.assetmind.server_stock.market_access.infrastructure.kis.websocket;
 
+import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisRealTimeData;
 import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisSubscriptionRequest;
+import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisRealTimeDataParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,6 +33,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 public class KisWebSocketHandler extends TextWebSocketHandler {
 
     private final ObjectMapper objectMapper;
+    private final KisRealTimeDataParser dataParser;
 
     @Setter
     private String approveKey;
@@ -88,19 +92,17 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) {
         String payload = message.getPayload();
-
         if (payload == null || payload.isEmpty()) return;
 
-        char firstChar = payload.charAt(0);
 
         try {
-            if (firstChar == '{') {
+            if (payload.startsWith("{")) {
                 // '{'로 시작한다면 JSON 포맷 (구독 응답, PINGPONG)
                 processJsonMessage(payload);
             } else {
                 // 텍스트 포맷 (실시간 주식 데이터)
                 // KIS 데이터 포맷: 암호화여부(0/1) | TR_ID | 데이터(^으로 구분)
-                processStockData(payload);
+                handleRealTimeData(payload);
             }
         } catch (Exception e) {
             log.error("[KIS WS] 메시지 처리 중 에러 발생 (Payload: {})", payload, e);
@@ -119,60 +121,14 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
     }
 
     // 실시간 주식 데이터 처리
-    private void processStockData(String payload) {
-        String[] parts = payload.split("\\|");
+    private void handleRealTimeData(String payload) {
+        List<KisRealTimeData> dataList = dataParser.parse(payload);
 
-        // 최소 길이 체크
-        if (parts.length < 3) return;
+        dataList.forEach(data -> {
+            log.info("[KIS WS] 실시간 체결 데이터 : {}", data.toString());
+        });
 
-        int count = 1;
-        String rawData;
-
-        // 3번째 항목(parts[2])이 숫자인지 먼저 확인 (Try-Catch 대신 정규식 사용)
-        if (parts[2].matches("\\d+")) {
-            // 숫자다! -> 개수 필드가 존재함
-            try {
-                count = Integer.parseInt(parts[2]);
-            } catch (NumberFormatException e) {
-                count = 1; // 혹시라도 실패하면 1개로 처리
-            }
-            // 데이터는 4번째(인덱스 3)부터 시작
-            rawData = (parts.length > 3) ? parts[3] : "";
-        } else {
-            // 숫자가 아니다 ("H" 등) -> 개수 필드 생략됨, 바로 데이터 시작
-            count = 1;
-            rawData = parts[2];
-        }
-
-        // 데이터가 비어있으면 종료
-        if (rawData == null || rawData.isEmpty()) return;
-
-        // 상세 데이터 파싱
-        String[] details = rawData.split("\\^");
-        final int FIELD_COUNT = 46;
-
-        // 데이터 개수 만큼 반복해서 추출
-        for (int i = 0; i < count; i++) {
-            // 현재 데이터의 시작 인덱스
-            int offset = i * FIELD_COUNT;
-
-            // 배열 범위 체크
-            if (offset + 5 >= details.length) break;
-
-            // 주요 필드 추출
-            String stockCode = details[offset + 0]; // 종목코드
-            String time = details[offset + 1]; // 체결시간
-            String currentPrice = details[offset + 2]; // 현재가
-            String sign = details[offset + 3]; // 전일대비 부호 (1: 상한, 2: 상승, 3:보합, 4:하한, 5:하락)
-            String changeRate = details[offset + 5]; // 등락률
-            String volume = details[offset + 12];
-
-            log.info("[체결] {} | 시간:{} | 현재가: {}원 | 등락률: {}% | 거래량: {}", stockCode, time, currentPrice, changeRate, volume);
-        }
-
-        // log.info(">>> [실시간 데이터 수신] TR_ID: {}, RawData: {}", trId, data);
-
-        // TODO: 나중에 실제 데이터를 더 세분화하여 값을 추출하고 DB에 저장
+        //TODO: 추후 DB 연동 및 Spring Event 연동 예정
     }
 
     @Override

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisRealTimeDataParser.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisRealTimeDataParser.java
@@ -1,5 +1,77 @@
 package com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser;
 
+import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisRealTimeData;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * KIS 실시간 체결 데이터 (H0STCNT0)의 응답을
+ * KisRealTimeData DTO로 파싱
+ */
+@Slf4j
+@Component
 public class KisRealTimeDataParser {
 
+    private static final String FIRST_DELIMITER = "\\|";
+    private static final String SECOND_DELIMITER = "\\^";
+    private static final int FIELD_COUNT = 46;
+
+    public List<KisRealTimeData> parse(String payload) {
+        List<KisRealTimeData> resultList = new ArrayList<>();
+
+        try {
+            String[] parts = payload.split(FIRST_DELIMITER);
+            if (parts.length < 3) return resultList;
+
+            // 주식 데이터의 개수 파악 및 Raw 데이터(^구분자로 이어진 실제 데이터 예: 종목코드, 주가, 시가, 등등) 추출
+            int dataCount;
+            String rawData;
+            if (parts[2].matches("\\d+")) {
+                // payload내의 주식 데이터가 여러개일 때 -> 0|H0STCNT0|002|005930^...
+                // 002처럼 데이터의 개수가 들어옴
+                dataCount = Integer.parseInt(parts[2]);
+                rawData = parts[3];
+            } else {
+                // payload내의 주식 데이터가 단건일 때 -> 0|H0STCNT0|005930^...
+                // 데이터의 개수가 들어오지 않음
+                dataCount = 1;
+                rawData = parts[2];
+            }
+
+            if (rawData == null || rawData.isEmpty()) return resultList;
+
+            // ^ 구분자로 연속된 주가 데이터 분리
+            String[] details = rawData.split(SECOND_DELIMITER, -1); // 빈 값 무시 X
+
+            for (int i = 0; i < dataCount; i++) {
+                int offset = i * FIELD_COUNT;
+                resultList.add(mapToDto(details, offset));
+            }
+        } catch (Exception e) {
+            log.error("KIS 실시간 체결 데이터 파싱 중 오류 발생. Payload: {}, Error: {}", payload, e.getMessage());
+        }
+
+        return resultList;
+    }
+
+    private KisRealTimeData mapToDto(String[] details, int offset) {
+        return KisRealTimeData.builder()
+                .symbol(details[offset + 0])
+                .executionTime(details[offset + 1])
+                .currentPrice(Long.parseLong(details[offset + 2]))
+                .changeSign(Long.parseLong(details[offset + 3]))
+                .priceChange(Long.parseLong(details[offset + 4]))
+                .changeRate(Double.parseDouble(details[offset + 5]))
+                .openPrice(Long.parseLong(details[offset + 7]))
+                .highPrice(Long.parseLong(details[offset + 8]))
+                .lowPrice(Long.parseLong(details[offset + 9]))
+                .executionVolume(Long.parseLong(details[offset + 12]))
+                .cumulativeVolume(Long.parseLong(details[offset + 13]))
+                .cumulativeAmount(Long.parseLong(details[offset + 14]))
+                .volumePower(Double.parseDouble(details[offset + 18]))
+                .marketStatus(details[offset + 34])
+                .build();
+    }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisRealTimeDataParser.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisRealTimeDataParser.java
@@ -1,0 +1,5 @@
+package com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser;
+
+public class KisRealTimeDataParser {
+
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandlerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandlerTest.java
@@ -1,5 +1,7 @@
 package com.assetmind.server_stock.market_access.infrastructure.kis.websocket;
 
+import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisRealTimeData;
+import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisRealTimeDataParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +38,9 @@ class KisWebSocketHandlerTest {
 
     @Mock
     private WebSocketSession session; // 가짜 세션
+
+    @Mock
+    private KisRealTimeDataParser dataParser;
 
     private final String TEST_KEY = "TEST_APP_KEY";
 
@@ -88,52 +93,25 @@ class KisWebSocketHandlerTest {
     }
 
     @Nested
-    @DisplayName("데이터 파싱 테스트")
-    class AfterConnectionEstablished {
-
-        @BeforeEach
-        void initSession() {
-            // 파싱 테스트를 위해 세션 연결 상태 가정
-            handler.afterConnectionEstablished(session);
-        }
+    @DisplayName("실시간 데이터 처리 테스트")
+    class RealTimeDataHandling {
 
         @Test
-        @DisplayName("성공: 일반적인 주식 체결 데이터(Count=1) 파싱")
-        void givenNormalStockData_whenHandleMessage_thenParsingPayload() {
-            // 0|ID|개수|데이터(종목코드^시간^현재가^...^등락률...)
-            String payload = "0|H0STCNT0|001|005930^123000^80000^1^0^2.5^dummy^dummy^dummy^dummy^dummy^dummy^100";
+        @DisplayName("성공: 실시간 데이터 수신 시 파서를 호출하고 데이터를 처리해야 한다")
+        void givenRealTimePayload_whenHandleMessage_thenInvokeParser() throws Exception {
+            // Given
+            String payload = "0|H0STCNT0|001|005930^123000^80000^1^0^2.5^...^100";
+            // 파서가 결과 리스트를 반환하도록 설정
+            when(dataParser.parse(payload)).thenReturn(List.of(
+                    new KisRealTimeData("005930", "123000", 80000L, 1L, 0L, 2.5,
+                            80000L, 81000L, 79000L, 100L, 1000L, 1000000L, 100.0, "20")
+            ));
 
-            assertDoesNotThrow(() -> handler.handleMessage(session, new TextMessage(payload)));
-            // 로그가 찍히고 에러가 없으면 통과
-        }
+            // When
+            handler.handleMessage(session, new TextMessage(payload));
 
-        @Test
-        @DisplayName("성공: 멀티 레코드(Count=2) 데이터 파싱")
-        void givenMultiStockData_whenHandleMessage_thenParsingPayload() {
-            // 데이터 2건이 이어서 들어옴
-            String record1 = "005930^123000^80000^1^0^2.5^d^d^d^d^d^d^100";
-            String record2 = "000660^123001^150000^2^0^-1.0^d^d^d^d^d^d^200";
-            String payload = "0|H0STCNT0|002|" + record1 + "^" + record2;
-
-            assertDoesNotThrow(() -> handler.handleMessage(session, new TextMessage(payload)));
-        }
-
-        @Test
-        @DisplayName("성공: 'H' 에러 데이터 (개수 필드 누락) 방어 처리")
-        void givenErrorStockData_whenHandleMessage_thenParsingPayload() {
-            // 0|ID|데이터 (가운데 개수 필드가 없고 바로 데이터가 옴) -> parts[2]가 숫자가 아님
-            // "H" 에러 유발 케이스
-            String payload = "0|H0STCNT0|005930^123000^80000^1^0^2.5^d^d^d^d^d^d^100";
-
-            assertDoesNotThrow(() -> handler.handleMessage(session, new TextMessage(payload)));
-            // NumberFormatException 없이 정상 처리되어야 함
-        }
-
-        @Test
-        @DisplayName("성공: JSON 제어 메시지 (PINGPONG 등) 처리")
-        void givenJsonOperatorData_whenHandleMessage_thenParsingPayload() {
-            String jsonPayload = "{\"header\":{\"tr_id\":\"PINGPONG\"}}";
-            assertDoesNotThrow(() -> handler.handleMessage(session, new TextMessage(jsonPayload)));
+            // Then
+            verify(dataParser, times(1)).parse(payload); // 파서가 1번 호출되었는지 검증
         }
     }
 

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisRealTimeDataParserTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisRealTimeDataParserTest.java
@@ -1,0 +1,42 @@
+package com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisRealTimeData;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class KisRealTimeDataParserTest {
+
+    private final KisRealTimeDataParser parser = new KisRealTimeDataParser();
+
+    @Test
+    @DisplayName("성공: 'H' 에러(개수 필드 누락) 시에도 1건으로 간주하여 파싱한다")
+    void givenOneRecord_whenParse_thenParsing() {
+        // given
+        String payload = "0|H0STCNT0|005930^123000^80000^1^500^0.65^0^80000^81000^79000^0^0^100^1000^100000^0^0^0^100.0^0^0^0^0^0^0^0^0^0^0^0^0^0^0^0^20^0^0^0^0^0^0^0^0^0^70000";
+
+        // when
+        List<KisRealTimeData> result = parser.parse(payload);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().symbol()).isEqualTo("005930");
+        assertThat(result.getFirst().marketStatus()).isEqualTo("20");
+    }
+
+    @Test
+    @DisplayName("성공: 멀티 레코드가 포함된 데이터를 정확한 개수만큼 파싱한다")
+    void givenMultiRecord_whenParse_thenParsing() {
+        // given
+        String record = "0^1^2^3^4^5^6^7^8^9^10^11^12^13^14^15^16^17^18^19^20^21^22^23^24^25^26^27^28^29^30^31^32^33^34^35^36^37^38^39^40^41^42^43^44^45";
+        String payload = "0|H0STCNT0|2|" + record + "^" + record;
+
+        // when
+        List<KisRealTimeData> result = parser.parse(payload);
+
+        // then
+        assertThat(result).hasSize(2);
+    }
+}

--- a/docs/TCS/stock/TCS-KIS-002.md
+++ b/docs/TCS/stock/TCS-KIS-002.md
@@ -1,11 +1,11 @@
 # [TCS] KIS 실시간 웹소켓 핸들러(WebSocket Handler) 테스트 명세서
 
-| 문서 ID | **TCS-KIS-002**                             |
-| :--- |:--------------------------------------------|
-| **문서 버전** | 1.0                                         |
-| **프로젝트** | AssetMind                                   |
-| **작성자** | 이재석                                         |
-| **작성일** | 2026년 02월 05일                               |
+| 문서 ID | **TCS-KIS-002**                              |
+| :--- |:---------------------------------------------|
+| **문서 버전** | 1.1                                          |
+| **프로젝트** | AssetMind                                    |
+| **작성자** | 이재석                                          |
+| **작성일** | 2026년 02월 05일                                |
 | **관련 모듈** | `KisWebSocketHandler`, `KisWebsocketAdapter` |
 
 ## 1. 개요 (Overview)
@@ -32,23 +32,21 @@
 | **WSH-001** | `givenNoSession_whenSubscribeNewStock_`<br>`thenSendAfterConnection`<br>👉 **세션 연결 전 구독 요청은 대기열에 저장되었다가, 연결 후 한꺼번에 전송되어야 한다.** | **세션 없음 (Null)**<br>연결되지 않은 초기 상태                                | 1. **구독 요청** (`subscribe`)<br>2. **연결 성공 이벤트 발생** (`afterConnectionEstablished`) | 1. 구독 요청 시점엔 전송 메서드가 호출되지 않음 (`never`).<br>2. 대기열(`pendingList`)에 요청이 저장됨.<br>3. 연결 직후 메시지가 전송됨 (`verify`). |
 | **WSH-002** | `givenSession_whenSubscribeNewStock_`<br>`thenSendSubscribeRequest`<br>👉 **이미 연결된 상태에서는 대기열 없이 바로 전송해야 한다.** | **세션 활성 (Open)**<br>`afterConnectionEstablished`가 이미 호출된 상태       | **구독 요청** (`subscribe`)                      | 1. 대기열을 거치지 않고 즉시 `sendMessage`가 호출된다 (`times(1)`).                                         |
 
-### 2.2. 데이터 파싱 및 방어 로직 (Data Parsing & Defense)
+### 2.2. 실시간 데이터 처리 (Data Parsing)
 
-| ID          | 테스트 메서드 / 시나리오                                                                                                                        | Given (사전 조건)                                                       | When (수행 행동)                                 | Then (검증 결과)                                                                                       |
-|:------------|:--------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------|:---------------------------------------------|:---------------------------------------------------------------------------------------------------|
-| **WSH-003** | `givenNormalStockData_whenHandleMessage_`<br>`thenParsingPayload`<br>👉 **일반적인 주식 체결 데이터(Count=1)를 정상적으로 파싱해야 한다.** | **정상 텍스트 패킷**<br>`0|ID|001|데이터...` (파이프 구분자 포함)                 | **메시지 수신** (`handleMessage`)                | 1. 예외가 발생하지 않음 (`assertDoesNotThrow`).<br>2. 내부 파싱 로직을 통해 데이터 로그가 정상 출력됨.                       |
-| **WSH-004** | `givenMultiStockData_whenHandleMessage_`<br>`thenParsingPayload`<br>👉 **멀티 레코드(Count=2 이상) 데이터가 와도 반복문을 통해 모두 처리해야 한다.** | **멀티 텍스트 패킷**<br>`0|ID|002|데이터1^데이터2` (데이터 2건 포함)              | **메시지 수신** (`handleMessage`)                | 1. 반복문이 2회 실행되어 두 종목의 데이터를 모두 처리함.<br>2. 오프셋 계산이 정확하여 데이터가 섞이지 않음.                        |
-| **WSH-005** | `givenErrorStockData_whenHandleMessage_`<br>`thenParsingPayload`<br>👉 **'H' 에러 데이터(개수 필드 누락)가 와도 시스템이 죽지 않고 방어 처리해야 한다.** | **비정상 패킷 ("H" 에러)**<br>`0|ID|데이터...` (가운데 개수 필드 생략됨)             | **메시지 수신** (`handleMessage`)                | 1. `NumberFormatException`이 발생하지 않음.<br>2. 개수를 1개로 간주하고 정상적으로 데이터를 추출함.                         |
-| **WSH-006** | `givenJsonOperatorData_whenHandleMessage_`<br>`thenParsingPayload`<br>👉 **JSON 제어 메시지(PINGPONG, 구독응답)는 JSON으로 처리해야 한다.** | **JSON 패킷**<br>`{"header": {"tr_id": "PINGPONG"}}`                | **메시지 수신** (`handleMessage`)                | 1. 첫 글자가 `{`임을 감지하고 JSON 파서로 분기함.<br>2. 텍스트 파싱 로직을 타지 않고 정상 처리됨.                             |
+| ID          | 테스트 메서드 / 시나리오                                                                                                                        | Given (사전 조건)                                      | When (수행 행동)                                 | Then (검증 결과)         |
+|:------------|:--------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------|:---------------------------------------------|:---------------------|
+| **WSH-003** | `givenRealTimePayload_whenHandleMessage_`<br>`thenInvokeParser`<br>👉 **실시간 데이터 수신 시 파서를 호출하고 데이터를 처리해야 한다** | **정상 텍스트 패킷**<br>`0\|ID\| 001\|데이터... (파이프 구분자 포함) | **메시지 수신** (`handleMessage`)                | 1. 파서가 한번 호출 되었는지 검증 |
+
 
 ### 2.3. 예외 처리 및 자원 정리 (Exception & Cleanup)
 
 | ID          | 테스트 메서드 / 시나리오                                                                                                                        | Given (사전 조건)                                                       | When (수행 행동)                                 | Then (검증 결과)                                                                                       |
 |:------------|:--------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------|:---------------------------------------------|:---------------------------------------------------------------------------------------------------|
-| **WSH-007** | `givenJsonError_whenSubscribeNewStock_`<br>`thenNotExitSystem`<br>👉 **객체 변환(JSON) 실패 시 시스템이 죽지 않고 로그만 남겨야 한다.** | **Mapper 고장 (Mock)**<br>`writeValueAsString` 호출 시 예외 발생 설정         | **구독 요청** (`subscribe`)                      | 1. 예외가 `catch` 블록에서 처리되어 시스템 종료를 방지함.<br>2. `sendMessage`는 호출되지 않음 (`never`).                  |
-| **WSH-008** | `givenTransportError_whenSubscribeNewStock_`<br>`thenNotExitSystem`<br>👉 **전송 중 IO 예외가 발생해도 다음 종목 처리는 계속되어야 한다.** | **네트워크 불안정 (Mock)**<br>첫 번째 전송 시 `IOException` 발생 설정              | **다수 종목 구독 요청** | 1. 첫 번째 종목 전송 실패 로그 출력.<br>2. 반복문이 중단되지 않고 **두 번째 종목 전송을 시도**함 (`times(2)`).               |
-| **WSH-009** | `whenCloseConnection_`<br>`thenCleanUpSessionAndFiled`<br>👉 **연결 종료 요청 시 세션을 닫고 내부 상태 변수를 초기화해야 한다.** | **세션 활성 (Open)**<br>구독 목록(`Set`)에 데이터가 존재하는 상태                   | **연결 종료** (`closeConnection`)                | 1. `session.close()`가 호출됨.<br>2. `currentSession`이 `null`로 초기화됨.<br>3. `subscribedStock`이 비워짐. |
-| **WSH-010** | `givenCloseError_whenCloseConnection_`<br>`thenCleanUpSessionAndFiled`<br>👉 **종료 중 에러가 발생해도 자원 정리는 수행되어야 한다 (Finally 검증).** | **종료 실패 (Mock)**<br>`close()` 호출 시 `IOException` 발생 설정             | **연결 종료** (`closeConnection`)                | 1. 예외가 발생하지만 무시됨.<br>2. `finally` 블록이 실행되어 내부 변수(`null`, `clear`) 초기화가 보장됨.                 |
+| **WSH-004** | `givenJsonError_whenSubscribeNewStock_`<br>`thenNotExitSystem`<br>👉 **객체 변환(JSON) 실패 시 시스템이 죽지 않고 로그만 남겨야 한다.** | **Mapper 고장 (Mock)**<br>`writeValueAsString` 호출 시 예외 발생 설정         | **구독 요청** (`subscribe`)                      | 1. 예외가 `catch` 블록에서 처리되어 시스템 종료를 방지함.<br>2. `sendMessage`는 호출되지 않음 (`never`).                  |
+| **WSH-005** | `givenTransportError_whenSubscribeNewStock_`<br>`thenNotExitSystem`<br>👉 **전송 중 IO 예외가 발생해도 다음 종목 처리는 계속되어야 한다.** | **네트워크 불안정 (Mock)**<br>첫 번째 전송 시 `IOException` 발생 설정              | **다수 종목 구독 요청** | 1. 첫 번째 종목 전송 실패 로그 출력.<br>2. 반복문이 중단되지 않고 **두 번째 종목 전송을 시도**함 (`times(2)`).               |
+| **WSH-006** | `whenCloseConnection_`<br>`thenCleanUpSessionAndFiled`<br>👉 **연결 종료 요청 시 세션을 닫고 내부 상태 변수를 초기화해야 한다.** | **세션 활성 (Open)**<br>구독 목록(`Set`)에 데이터가 존재하는 상태                   | **연결 종료** (`closeConnection`)                | 1. `session.close()`가 호출됨.<br>2. `currentSession`이 `null`로 초기화됨.<br>3. `subscribedStock`이 비워짐. |
+| **WSH-007** | `givenCloseError_whenCloseConnection_`<br>`thenCleanUpSessionAndFiled`<br>👉 **종료 중 에러가 발생해도 자원 정리는 수행되어야 한다 (Finally 검증).** | **종료 실패 (Mock)**<br>`close()` 호출 시 `IOException` 발생 설정             | **연결 종료** (`closeConnection`)                | 1. 예외가 발생하지만 무시됨.<br>2. `finally` 블록이 실행되어 내부 변수(`null`, `clear`) 초기화가 보장됨.                 |
 
 ---
 


### PR DESCRIPTION
## 📌 작업 내용
- **실시간 데이터 파서 분리:** 기존 `KisWebSocketHandler`에 하드코딩되어 있던 파싱 로직을 전용 컴포넌트(`KisRealTimeDataParser`)로 추출하여 책임을 분리했습니다.
- **DTO 체계화:** KIS 실시간 체결가 전문(46개 필드) 중 비즈니스 핵심 지표 15개를 선정하여 `KisRealTimeData` DTO로 구조화했습니다.
- **방어적 파싱 로직 강화:** 데이터 개수 필드 누락("H" 에러) 및 패킷 끝부분 빈 값 처리(`split` limit 설정) 등 외부 API의 불규칙한 응답에 대한 방어 로직을 고도화했습니다.
- **단위 테스트 및 명세서 작성:** 분리된 파서의 정확성을 검증하기 위한 단위 테스트(`KisRealTimeDataParserTest`)를 추가하고 테스트 명세서를 업데이트했습니다.

## 🏗 기술적 의사결정 (핵심 변경 사유)

**1. 파싱 책임 분리 (Separation of Parser)**
> 핸들러가 네트워크 통신과 데이터 파싱을 모두 담당할 경우 비대해지고 유지보수가 어려워집니다.
- **구현:** `KisRealTimeDataParser` 컴포넌트를 신설하여 `|` 및 `^` 구분자 기반의 복잡한 로직을 캡슐화했습니다.
- **이유:** 외부 API 규격 변경 시 파서만 수정하면 되도록 응집도를 높이고, 핸들러는 메시지 흐름 제어에만 집중하게 하기 위함입니다.

**2. 방어적 파싱 로직 ("H" Error Defense)**
> KIS 서버가 간헐적으로 데이터 개수 필드를 누락하여 보내는 상황에서 시스템 안정성을 확보해야 합니다.
- **구현:** 3번째 필드가 숫자인지 **정규식**으로 검사하여, 숫자가 아닐 경우 **단건 데이터(Count=1)로 간주하는 Fallback 로직**을 적용했습니다.
- **이유:** 데이터 포맷 오류로 인해 전체 웹소켓 세션이 종료되는 것을 방지하고 유연하게 데이터를 수용하기 위함입니다.

**3. `split(..., -1)`을 통한 데이터 유실 방지**
> 자원의 기본 `split`은 마지막 빈 필드들을 제거하므로, 고정 인덱스 참조 시 에러가 발생할 위험이 있습니다.
- **구현:** `limit` 파라미터를 `-1`로 설정하여 모든 빈 문자열을 보존하도록 했습니다.
- **이유:** 46개 필드 중 뒤쪽에 위치한 '장운영 구분 코드(34번)'나 'VI 기준가(44번)' 등을 인덱스로 안전하게 참조하기 위한 필수 조치입니다.

## ✅ 주요 변경점

### Infrastructure Layer (`market_access.infrastructure.kis`)
- **`KisRealTimeDataParser` (New):**
    - 실시간 데이터 스트링을 `List<KisRealTimeData>`로 변환하는 핵심 로직 구현.
    - 멀티 레코드 패킷 수신 시 `offset` 계산을 통한 반복 처리 지원.
- **`KisRealTimeData` (DTO):**
    - 현재가, 대비부호, 등락률, 시/고/저가, 체결강도 등 핵심 15개 필드 정의.
- **`KisWebSocketHandler` (Refactored):**
    - 직접 파싱하던 로직을 제거하고 `KisRealTimeDataParser`를 주입받아 위임하도록 리팩토링.

### Test Codes
- **`KisRealTimeDataParserTest` (New):**
    - 정상 단건/다건 파싱 검증.
    - "H" 에러(개수 누락) 상황에서의 정상 작동 검증.
- **`KisWebSocketHandlerTest` (Updated):**
    - 파서와의 협력 관계(메시지 수신 시 파서 호출 여부) 검증 중심으로 수정.

## 📝 리뷰 포인트
- **인덱스 매핑 정확성:** `mapToDto` 메서드에서 참조하는 인덱스들이 KIS 공식 문서의 46개 필드 순서와 일치하는지 확인 부탁드립니다.
- **변환 로직:** 파싱된 `KisRealTimeData`가 핸들러를 거쳐 서비스 레이어로 전달되는 흐름이 매끄러운지 검토 바랍니다.