### PR TITLE
[Feat] 저장소 설정 및 Entity 구현 및 단위 테스트

### DIFF
--- a/apps/docker-compose.yml
+++ b/apps/docker-compose.yml
@@ -1,3 +1,4 @@
+# 통합 데이터베이스, server-auth와 server-stock이 같이 사용
 version: '3.8'
 
 services:

--- a/apps/server-auth/src/main/resources/application-local.yaml
+++ b/apps/server-auth/src/main/resources/application-local.yaml
@@ -15,7 +15,7 @@ spring:
 
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${DB_HOST:localhost}:5432/${POSTGRES_DB:assetmind}
+    url: jdbc:postgresql://${DB_HOST:localhost}:5432/${POSTGRES_DB:assetmind_auth}
     username: ${POSTGRES_USER:postgres}
     password: ${POSTGRES_PASSWORD}
 
@@ -23,6 +23,7 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: 6379
+      database: 0
 
   mail:
     host: smtp.gmail.com

--- a/apps/server-stock/build.gradle
+++ b/apps/server-stock/build.gradle
@@ -3,5 +3,11 @@ description = 'realtime-stock server'
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'org.postgresql:postgresql'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 }

--- a/apps/server-stock/build.gradle
+++ b/apps/server-stock/build.gradle
@@ -10,4 +10,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:postgresql'
+	testImplementation 'org.testcontainers:redis'
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/StockHistoryRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/StockHistoryRepository.java
@@ -1,0 +1,23 @@
+package com.assetmind.server_stock.stock.domain.repository;
+
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockDataEntity;
+import java.util.List;
+
+/**
+ * 과거 차트 데이터를 저장하고 조회하는 행동을 정의
+ *
+ * 해당 인터페이스는 Domain 계층인데도 불구하고 편의성을 위해 Infrastructure 계층의 {@link StockDataEntity}를 의존
+ * 1. 과거 차트 데이터는 상태 변경이 없는 객체이므로 복잡한 도메인 로직이 필요없음.
+ * 2. 과거 차트 데이터를 조회시 수천 건의 데이터 조회가 필요함 이를 도메인 모델로 매핑하는 비용을 줄이기 위해 엔티티를 직접 반환
+ *
+ * 이 2가지 이유로 헥사고널 아키텍처를 정확하게 지키기 위해서 도메인 모델 객체를 만들기보다는
+ * 의도적으로 위반하는 방향이 더 옳다고 판단했음
+ */
+public interface StockHistoryRepository {
+
+    // 체결 데이터 저장
+    StockDataEntity save(StockDataEntity dataEntity);
+
+    // 특정 종목에 대한 저장된 데이터 조회
+    List<StockDataEntity> findRecentData(String stockCode, int limit);
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/StockSnapshotRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/StockSnapshotRepository.java
@@ -22,5 +22,5 @@ public interface StockSnapshotRepository {
     List<StockPriceRedisEntity> getTopStocksByTradeValue(int limit);
 
     // 거래량 상위 N개 종목 조회
-    List<StockPriceRedisEntity> getTopStocksByTradeRate(int limit);
+    List<StockPriceRedisEntity> getTopStocksByTradeVolume(int limit);
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/StockSnapshotRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/StockSnapshotRepository.java
@@ -1,0 +1,26 @@
+package com.assetmind.server_stock.stock.domain.repository;
+
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockPriceRedisEntity;
+import java.util.List;
+
+/**
+ * 실시간 주가 데이터 스냅샷과 실시간 랭킹 정보를 다루는 행동을 정의
+ *
+ * 해당 인터페이스는 Domain 계층인데도 불구하고 편의성을 위해 Infrastructure 계층의 {@link StockPriceRedisEntity}를 의존
+ * 1. 실시간 주가 데이터는 상태 변경이 없는 객체이므로 복잡한 도메인 로직이 필요없음.
+ * 2. 실시간 주가 데이터는 초당 수백 건 이상의 저장(쓰기)가 발생함, 이를 도메인 모델로 매핑하는 비용을 줄이기 위해 엔티티를 의존
+ *
+ * 이 2가지 이유로 헥사고널 아키텍처를 정확하게 지키기 위해서 도메인 모델 객체를 만들기보다는
+ * 의도적으로 위반하는 방향이 더 옳다고 판단했음
+ */
+public interface StockSnapshotRepository {
+
+    // 실시간 스냅샷 저장
+    void save(StockPriceRedisEntity entity);
+
+    // 거래 대금 상위 N개 종목 조회
+    List<StockPriceRedisEntity> getTopStocksByTradeValue(int limit);
+
+    // 거래량 상위 N개 종목 조회
+    List<StockPriceRedisEntity> getTopStocksByTradeRate(int limit);
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockDataEntity.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockDataEntity.java
@@ -10,16 +10,18 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * 과거 주식 데이터를 저장하기 위한 영속성 객체
  */
+@Getter
 @Entity
 @Table(name = "stock_data")
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StockDataEntity {
 
@@ -40,16 +42,16 @@ public class StockDataEntity {
 
     private Double changeRate;      // 등락률
 
-    @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt; // DB 저장 시점 (데이터 수신 시점)
 
     @Builder
-    public StockDataEntity(String stockCode, Long price, String time, Long volume, Double changeRate) {
+    public StockDataEntity(String stockCode, Long price, String time, Long volume, Double changeRate, LocalDateTime createdAt) {
         this.stockCode = stockCode;
         this.price = price;
         this.time = time;
         this.volume = volume;
         this.changeRate = changeRate;
+        this.createdAt = (createdAt == null) ? LocalDateTime.now() : createdAt;
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockDataEntity.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockDataEntity.java
@@ -1,0 +1,55 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 과거 주식 데이터를 저장하기 위한 영속성 객체
+ */
+@Entity
+@Table(name = "stock_data")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockDataEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String stockCode;       // 종목 코드
+
+    @Column(nullable = false)
+    private Long price;             // 현재가
+
+    @Column(nullable = false)
+    private String time;            // 체결 시간 (HHmmss)
+
+    private Long volume;            // 누적 거래량
+
+    private Double changeRate;      // 등락률
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt; // DB 저장 시점 (데이터 수신 시점)
+
+    @Builder
+    public StockDataEntity(String stockCode, Long price, String time, Long volume, Double changeRate) {
+        this.stockCode = stockCode;
+        this.price = price;
+        this.time = time;
+        this.volume = volume;
+        this.changeRate = changeRate;
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockMetaEntity.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockMetaEntity.java
@@ -1,0 +1,31 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+/**
+ * 정적 데이터(종목명, 시장 구분 등)를 저장하기 위한 영속성 객체
+ */
+@Entity
+@Table(name = "stock_meta_data")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockMetaEntity {
+
+    @Id
+    private String stockCode; // 종목코드
+
+    private String stockName; // 종목이름
+
+    private String market; // KOSPI, KOSDAQ
+
+    @Builder
+    public StockMetaEntity(String stockCode, String stockName, String market) {
+        this.stockCode = stockCode;
+        this.stockName = stockName;
+        this.market = market;
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockPriceRedisEntity.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockPriceRedisEntity.java
@@ -1,0 +1,43 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.entity;
+
+import jakarta.persistence.Id;
+import java.io.Serializable;
+import lombok.Builder;
+import org.springframework.data.redis.core.RedisHash;
+
+/**
+ * 실시간 최신가를 빠르게 조회하기 위한 인메모리(Redis) 객체
+ */
+@RedisHash(value = "stock_snapshot", timeToLive = 600) // TTL : 10분, 실시간 데이터이므로 과거의 데이터는 오래 캐싱할 필요가 없음
+public class StockPriceRedisEntity implements Serializable {
+
+    @Id
+    private String stockCode;       // 종목 코드, Redis 각 Value의 Key 값
+
+    private String stockName;       // 종목 이름
+
+    private Long currentPrice;      // 현재가
+
+    private Long priceChange;       // 전일 대비 변동 금액
+
+    private Double changeRate;      // 등락률
+
+    private Long cumulativeAmount;  // 누적 거래 대금
+
+    private Long cumulativeVolume;  // 누적 거래량
+
+    private String time;            // 체결 시간 (HHmmss)
+
+    @Builder
+    public StockPriceRedisEntity(String stockCode, String stockName, Long currentPrice, Long priceChange,
+            Double changeRate, Long cumulativeAmount, Long cumulativeVolume, String time) {
+        this.stockCode = stockCode;
+        this.stockName = stockName;
+        this.currentPrice = currentPrice;
+        this.priceChange = priceChange;
+        this.changeRate = changeRate;
+        this.cumulativeAmount = cumulativeAmount;
+        this.cumulativeVolume = cumulativeVolume;
+        this.time = time;
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockPriceRedisEntity.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockPriceRedisEntity.java
@@ -3,11 +3,13 @@ package com.assetmind.server_stock.stock.infrastructure.persistence.entity;
 import jakarta.persistence.Id;
 import java.io.Serializable;
 import lombok.Builder;
+import lombok.Getter;
 import org.springframework.data.redis.core.RedisHash;
 
 /**
  * 실시간 최신가를 빠르게 조회하기 위한 인메모리(Redis) 객체
  */
+@Getter
 @RedisHash(value = "stock_snapshot", timeToLive = 600) // TTL : 10분, 실시간 데이터이므로 과거의 데이터는 오래 캐싱할 필요가 없음
 public class StockPriceRedisEntity implements Serializable {
 

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockPriceRedisEntity.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/StockPriceRedisEntity.java
@@ -1,9 +1,9 @@
 package com.assetmind.server_stock.stock.infrastructure.persistence.entity;
 
-import jakarta.persistence.Id;
 import java.io.Serializable;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 /**

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/StockDataJpaRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/StockDataJpaRepository.java
@@ -1,0 +1,14 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.jpa;
+
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockDataEntity;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface StockDataJpaRepository extends JpaRepository<StockDataEntity, Long> {
+
+    @Query("SELECT s FROM StockDataEntity s WHERE s.stockCode = :stockCode ORDER BY s.createdAt DESC")
+    List<StockDataEntity> findByStockCodeOrderByCreatedAtDesc(@Param("stockCode") String stockCode, Pageable pageable);
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/StockHistoryJpaAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/StockHistoryJpaAdapter.java
@@ -1,0 +1,30 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.jpa;
+
+import com.assetmind.server_stock.stock.domain.repository.StockHistoryRepository;
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockDataEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+/**
+ * {@link StockHistoryRepository}를 Jpa 기술을 사용하여 구현한 구현체
+ */
+@Repository
+@RequiredArgsConstructor
+public class StockHistoryJpaAdapter implements StockHistoryRepository {
+
+    private final StockDataJpaRepository stockDataJpaRepository;
+
+    @Override
+    public StockDataEntity save(StockDataEntity dataEntity) {
+        return stockDataJpaRepository.save(dataEntity);
+    }
+
+    @Override
+    public List<StockDataEntity> findRecentData(String stockCode, int limit) {
+        Pageable page = PageRequest.of(0, limit);
+        return stockDataJpaRepository.findByStockCodeOrderByCreatedAtDesc(stockCode, page);
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/redis/StockPriceRedisRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/redis/StockPriceRedisRepository.java
@@ -1,0 +1,14 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.redis;
+
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockPriceRedisEntity;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * 주식 실시간 스냅샷(StockPriceRedisEntity) 관리를 위한 Redis CRUD 리포지토리
+ *
+ * Spring Data Redis의 Repository 기능을 사용
+ * {@link StockPriceRedisEntity} 객체를 Redis의 Hash 자료구조로 변환하여 저장하고 조회
+ */
+public interface StockPriceRedisRepository extends CrudRepository<StockPriceRedisEntity, String> {
+
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/redis/StockSnapshotRedisAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/redis/StockSnapshotRedisAdapter.java
@@ -1,0 +1,102 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.redis;
+
+import com.assetmind.server_stock.stock.domain.repository.StockSnapshotRepository;
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockPriceRedisEntity;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * {@link StockSnapshotRepository}를 Redis 기술을 사용하여 구현한 구현체
+ */
+@Repository
+@RequiredArgsConstructor
+public class StockSnapshotRedisAdapter implements StockSnapshotRepository {
+
+    // 기본 CRUD (Hash 저장용)
+    private final StockPriceRedisRepository redisRepository;
+
+    // 랭킹 연산 (Sorted Set용)
+    // StockPriceRedisRepository는 CrudRepository를 상속받았기 때문에 Redis의 Sorted Set 기능을 지원하지 않음
+    // 그래서 따로 랭킹을 저장하기 위한 Redis Template가 필요함
+    private final StringRedisTemplate redisTemplate;
+
+    // 누적거래대금 랭킹을 위한 Key
+    private static final String RANKING_TRADE_VALUE_KEY = "ranking:trade_value";
+    // 누적거래량 랭킹을 위한 Key
+    private static final String RANKING_TRADE_VOLUME_KEY = "ranking:trade_volume";
+
+
+    @Override
+    public void save(StockPriceRedisEntity entity) {
+        // 실시간 주가 데이터 스냅샷 저장
+        redisRepository.save(entity);
+
+        // 거래대금 랭킹 업데이트
+        // Key: ranking:trade_value, Value: 종목코드, Score: 누적거래대금
+        if (entity.getCumulativeAmount() != null) {
+            redisTemplate.opsForZSet().add(RANKING_TRADE_VALUE_KEY, entity.getStockCode(), entity.getCumulativeAmount());
+        }
+
+        // 거래량 랭킹 업데이트
+        // Key: ranking:trade_volume, Value: 종목코드, Score: 누적거래량
+        if (entity.getCumulativeVolume() != null) {
+            redisTemplate.opsForZSet().add(RANKING_TRADE_VOLUME_KEY, entity.getStockCode(), entity.getCumulativeVolume());
+        }
+    }
+
+    @Override
+    public List<StockPriceRedisEntity> getTopStocksByTradeValue(int limit) {
+        // ZSET에서 Score(누적거래대금)이 높은 순으로 상위 N개 레코드 조회
+        // reverseRange: 내림차순
+        Set<String> topRecords = redisTemplate.opsForZSet()
+                .reverseRange(RANKING_TRADE_VALUE_KEY, 0, limit - 1);
+
+        if (topRecords == null || topRecords.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 조회된 상위 N개 주식 코드로 주식 상세 조회
+        Iterable<StockPriceRedisEntity> entities = redisRepository.findAllById(topRecords);
+
+        List<StockPriceRedisEntity> resultList = new ArrayList<>();
+        entities.forEach(resultList::add);
+
+        // 랭킹 순서에 맞게 재정렬
+        resultList.sort((a, b) -> {
+            long valA = a.getCumulativeAmount() == null ? 0 : a.getCumulativeAmount();
+            long valB = b.getCumulativeAmount() == null ? 0 : b.getCumulativeAmount();
+            return Long.compare(valB, valA);
+        });
+
+        return resultList;
+    }
+
+    @Override
+    public List<StockPriceRedisEntity> getTopStocksByTradeVolume(int limit) {
+        // ZSET에서 Score(누적거래량)이 높은 순으로 상위 N개 레코드 조회
+        Set<String> topRecords = redisTemplate.opsForZSet()
+                .reverseRange(RANKING_TRADE_VOLUME_KEY, 0, limit - 1);
+
+        if (topRecords == null || topRecords.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Iterable<StockPriceRedisEntity> entities = redisRepository.findAllById(topRecords);
+        List<StockPriceRedisEntity> resultList = new ArrayList<>();
+        entities.forEach(resultList::add);
+
+        // 랭킹 순서에 맞게 재정렬
+        resultList.sort((a, b) -> {
+            long valA = a.getCumulativeVolume() == null ? 0 : a.getCumulativeVolume();
+            long valB = b.getCumulativeVolume() == null ? 0 : b.getCumulativeVolume();
+            return Long.compare(valB, valA);
+        });
+
+        return resultList;
+    }
+}

--- a/apps/server-stock/src/main/resources/application-local.yml
+++ b/apps/server-stock/src/main/resources/application-local.yml
@@ -3,3 +3,27 @@ kis:
   websocket-url: "ws://ops.koreainvestment.com:31000" # [모의투자] WebSocket URL
   app-key: ${KIS_APP_KEY}
   app-secret: ${KIS_APP_SECRET_KEY}
+
+jpa:
+  hibernate:
+    ddl-auto: update
+  show-sql: true
+  properties:
+    hibernate:
+      format_sql: true
+      dialect: org.hibernate.dialect.PostgreSQLDialect
+  database: postgresql
+  database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+datasource:
+  driver-class-name: org.postgresql.Driver
+  # Auth 데이터베이스와 Stock 데이터베이스를 격리
+  url: jdbc:postgresql://${DB_HOST:localhost}:5432/${POSTGRES_DB:assetmind_stock}
+  username: ${POSTGRES_USER}
+  password: ${POSTGRES_PASSWORD}
+
+data:
+  redis:
+    host: ${REDIS_HOST:localhost}
+    port: 6379
+    database: 1  #Auth와 Stock 모듈 간 Redis 키 충돌 방지

--- a/apps/server-stock/src/main/resources/application.yml
+++ b/apps/server-stock/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: stock-service
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:local} # ???? local, ?? ? ????? ????
+    active: ${SPRING_PROFILES_ACTIVE:local} # application 설정 local
 
 kis:
-  token-expiration: 86400 # KIS Open API? access_token ???? 24??
+  token-expiration: 86400 # KIS Open API의 access_token 만료시간 24

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/StockHistoryJpaAdapterTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/StockHistoryJpaAdapterTest.java
@@ -1,0 +1,97 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.jpa;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockDataEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = Replace.NONE) // H2 대신 PostgreSQL 컨테이너 사용
+@Import(StockHistoryJpaAdapter.class)
+@TestPropertySource(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+class StockHistoryJpaAdapterTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    private StockHistoryJpaAdapter stockHistoryJpaAdapter;
+
+    @Test
+    @DisplayName("주식 데이터를 저장하고, 최신순으로 정렬하여 조회한다")
+    void givenStockData_whenSaveAndFindData_thenReturnSavedDataOrderByCreatedAt() {
+        // given
+        String stockCode = "005930";
+        LocalDateTime now = LocalDateTime.now();
+
+        // 1. 과거 데이터 (10분 전)
+        StockDataEntity oldData = createEntity(stockCode, 100L, now.minusMinutes(10));
+        // 2. 최신 데이터 (현재)
+        StockDataEntity recentData = createEntity(stockCode, 200L, now);
+        // 3. 더 옛날 데이터 (1시간 전)
+        StockDataEntity veryOldData = createEntity(stockCode, 50L, now.minusHours(1));
+
+        stockHistoryJpaAdapter.save(oldData);
+        stockHistoryJpaAdapter.save(recentData);
+        stockHistoryJpaAdapter.save(veryOldData);
+
+        // when (최신 2개만 조회 요청)
+        List<StockDataEntity> result = stockHistoryJpaAdapter.findRecentData(stockCode, 2);
+
+        // then
+        assertThat(result).hasSize(2);
+
+        // 첫 번째는 가장 최신 데이터여야 함 (200원, now)
+        assertThat(result.get(0).getPrice()).isEqualTo(200L);
+        assertThat(result.get(0).getCreatedAt()).isEqualTo(now);
+
+        // 두 번째는 그 다음 최신 데이터여야 함 (100원, 10분 전)
+        // (1시간 전 데이터는 limit에 걸려 제외되어야 함)
+        assertThat(result.get(1).getPrice()).isEqualTo(100L);
+        assertThat(result.get(1).getCreatedAt()).isEqualTo(now.minusMinutes(10));
+    }
+
+    @Test
+    @DisplayName("다른 종목의 데이터는 조회되지 않아야 한다")
+    void givenOtherStockCode_whenSaveAndFindData_thenReturnOnlySavedData() {
+        // given
+        String targetCode = "005930"; // 삼성전자
+        String otherCode = "035420";  // 네이버
+
+        stockHistoryJpaAdapter.save(createEntity(targetCode, 100L, LocalDateTime.now()));
+        stockHistoryJpaAdapter.save(createEntity(otherCode, 200L, LocalDateTime.now()));
+
+        // when
+        List<StockDataEntity> result = stockHistoryJpaAdapter.findRecentData(targetCode, 10);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getStockCode()).isEqualTo(targetCode);
+    }
+
+    private StockDataEntity createEntity(String code, Long price, LocalDateTime time) {
+        return StockDataEntity.builder()
+                .stockCode(code)
+                .price(price)
+                .time(time.toString())
+                .createdAt(time)
+                .volume(1000L)
+                .changeRate(10.0)
+                .build();
+    }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/redis/StockSnapshotRedisAdapterTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/redis/StockSnapshotRedisAdapterTest.java
@@ -1,0 +1,176 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.redis;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockPriceRedisEntity;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@DataRedisTest
+@Import(StockSnapshotRedisAdapter.class)
+@Testcontainers
+class StockSnapshotRedisAdapterTest {
+
+    @Container
+    @ServiceConnection(name = "redis")
+    static GenericContainer<?> redisContainer = new GenericContainer<>(DockerImageName.parse("redis:alpine")).withExposedPorts(6379);
+
+    @Autowired
+    private StockSnapshotRedisAdapter stockSnapshotRedisAdapter;
+
+    @Autowired
+    private StockPriceRedisRepository stockPriceRedisRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @AfterEach
+    void tearDown() {
+        RedisConnectionFactory connectionFactory = redisTemplate.getConnectionFactory();
+
+        if (connectionFactory != null) {
+            connectionFactory.getConnection().serverCommands().flushAll();
+        }
+    }
+
+    @Test
+    @DisplayName("주식 데이터를 저장하면 상세정보(Hash)와 랭킹점수(ZSet)가 모두 저장된다")
+    void givenStockData_whenSave_thenSavedStockDataAndRanking() {
+        // given
+        // 삼성전자: 거래대금 100만, 거래량 500주
+        StockPriceRedisEntity entity = createEntity("005930", "삼성전자", 1_000_000L, 500L);
+
+        // when
+        stockSnapshotRedisAdapter.save(entity);
+
+        // then
+        // 1. Redis Hash 저장 확인
+        StockPriceRedisEntity savedEntity = stockPriceRedisRepository.findById("005930").orElseThrow();
+        assertThat(savedEntity.getStockName()).isEqualTo("삼성전자");
+        assertThat(savedEntity.getCumulativeAmount()).isEqualTo(1_000_000L);
+
+        // 2. Redis ZSet (랭킹) 점수 확인
+        // 거래대금 랭킹
+        Double valueScore = redisTemplate.opsForZSet().score("ranking:trade_value", "005930");
+        assertThat(valueScore).isEqualTo(1_000_000.0);
+
+        // 거래량 랭킹
+        Double volumeScore = redisTemplate.opsForZSet().score("ranking:trade_volume", "005930");
+        assertThat(volumeScore).isEqualTo(500.0);
+    }
+
+    @Test
+    @DisplayName("거래대금(Amount) 상위 종목을 내림차순으로 정확하게 가져온다")
+    void givenLimitCount_whenGetTopStocksByTradeValue_thenReturnTradeValueRankingData() {
+        // given
+        // A: 1000원 (3등)
+        stockSnapshotRedisAdapter.save(createEntity("A", "종목A", 1000L, 0L));
+        // B: 3000원 (1등)
+        stockSnapshotRedisAdapter.save(createEntity("B", "종목B", 3000L, 0L));
+        // C: 2000원 (2등)
+        stockSnapshotRedisAdapter.save(createEntity("C", "종목C", 2000L, 0L));
+
+        // when (상위 3개 조회)
+        List<StockPriceRedisEntity> result = stockSnapshotRedisAdapter.getTopStocksByTradeValue(3);
+
+        // then
+        assertThat(result).hasSize(3);
+
+        // 1등: B
+        assertThat(result.get(0).getStockCode()).isEqualTo("B");
+        assertThat(result.get(0).getCumulativeAmount()).isEqualTo(3000L);
+
+        // 2등: C
+        assertThat(result.get(1).getStockCode()).isEqualTo("C");
+
+        // 3등: A
+        assertThat(result.get(2).getStockCode()).isEqualTo("A");
+    }
+
+    @Test
+    @DisplayName("거래량(Volume) 상위 종목을 내림차순으로 정확하게 가져온다")
+    void givenLimitCount_whenGetTopStocksByTradeVolume_thenReturnTradeVolumeRankingData() {
+        // given (거래대금 순위와 거래량 순위를 다르게 섞음)
+        // A: 대금 꼴등(100), 거래량 1등(5000)
+        stockSnapshotRedisAdapter.save(createEntity("A", "종목A", 100L, 5000L));
+
+        // B: 대금 1등(300), 거래량 3등(10)
+        stockSnapshotRedisAdapter.save(createEntity("B", "종목B", 300L, 10L));
+
+        // C: 대금 2등(200), 거래량 2등(200)
+        stockSnapshotRedisAdapter.save(createEntity("C", "종목C", 200L, 200L));
+
+        // when (상위 3개 조회)
+        List<StockPriceRedisEntity> result = stockSnapshotRedisAdapter.getTopStocksByTradeVolume(3);
+
+        // then
+        assertThat(result).hasSize(3);
+
+        // 거래량 1등은 A여야 함 (대금은 꼴등이지만)
+        assertThat(result.get(0).getStockCode()).isEqualTo("A");
+        assertThat(result.get(0).getCumulativeVolume()).isEqualTo(5000L);
+
+        // 거래량 2등 C
+        assertThat(result.get(1).getStockCode()).isEqualTo("C");
+
+        // 거래량 3등 B
+        assertThat(result.get(2).getStockCode()).isEqualTo("B");
+    }
+
+    @Test
+    @DisplayName("요청한 limit 개수만큼만 잘라서 반환한다")
+    void givenLimitCount_whenGet_thenReturnCollectLimitCountData() {
+        // given (5개 저장)
+        for (int i = 1; i <= 5; i++) {
+            stockSnapshotRedisAdapter.save(createEntity("CODE" + i, "NAME" + i, (long) (i * 100), 0L));
+        }
+
+        // when (상위 2개만 요청)
+        List<StockPriceRedisEntity> result = stockSnapshotRedisAdapter.getTopStocksByTradeValue(2);
+
+        // then
+        assertThat(result).hasSize(2);
+        // 가장 높은 값은 i=5 (500)
+        assertThat(result.get(0).getStockCode()).isEqualTo("CODE5");
+        assertThat(result.get(1).getStockCode()).isEqualTo("CODE4");
+    }
+
+    @Test
+    @DisplayName("데이터가 없을 때 빈 리스트를 반환한다")
+    void givenNoDataInRedis_whenGet_thenEmptyList() {
+        // given (데이터 없음)
+
+        // when
+        List<StockPriceRedisEntity> result = stockSnapshotRedisAdapter.getTopStocksByTradeValue(10);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    // --- Helper Method: Builder 패턴 사용 ---
+    private StockPriceRedisEntity createEntity(String code, String name, Long amount, Long volume) {
+        return StockPriceRedisEntity.builder()
+                .stockCode(code)
+                .stockName(name)
+                .cumulativeAmount(amount)
+                .cumulativeVolume(volume)
+                .currentPrice(10000L)
+                .priceChange(500L)
+                .changeRate(5.0)
+                .time("120000")
+                .build();
+    }
+}

--- a/docs/TCS/stock/TCS-JPA-001.md
+++ b/docs/TCS/stock/TCS-JPA-001.md
@@ -1,0 +1,53 @@
+# [TCS] Stock History JPA 어댑터 테스트 명세서
+
+| 문서 ID | **TCS-JPA-001**                        |
+| :--- |:---------------------------------------|
+| **문서 버전** | 1.0                                    |
+| **프로젝트** | AssetMind                              |
+| **작성자** | 이재석                                    |
+| **작성일** | 2026년 02월 10일                          |
+| **관련 모듈** | `stock/infrastructure/persistence/jpa` |
+
+## 1. 개요 (Overview)
+
+본 문서는 AssetMind Stock 시스템의 주식 체결 내역 저장소(`StockHistoryJpaAdapter`)에 대한 슬라이스 테스트 명세이다.
+`Testcontainers`를 사용하여 실제 **PostgreSQL** 환경을 도커 컨테이너로 구성하고, JPA 리포지토리가 실제 데이터베이스와 상호작용(저장, 조회, 정렬, 필터링)하는 로직을 검증한다.
+
+### 1.1. 테스트 환경
+- **Framework:** JUnit 5, AssertJ, Spring Boot Test (`@DataJpaTest`)
+- **Infrastructure:** Testcontainers (PostgreSQL 16-alpine)
+- **Target Class:** `StockHistoryJpaAdapterTest`
+- **Verification Focus:**
+    - **Persistence:** 엔티티가 DB에 정상적으로 Insert 되는지 검증
+    - **Ordering:** 시계열 데이터가 `createdAt` 기준 내림차순(최신순)으로 정렬되는지 검증
+    - **Pagination (Limit):** 요청한 개수(`limit`)만큼만 데이터를 가져오는지 검증
+    - **Isolation:** 특정 종목 코드(`stockCode`)에 해당하는 데이터만 정확히 필터링되는지 검증
+
+---
+
+## 2. Infrastructure Adapter 테스트 명세 - 주식 체결 내역
+> **대상 클래스:** `StockHistoryJpaAdapterTest`
+> **검증 목표:** `JpaRepository`와 연동하여 과거 체결 데이터를 저장하고, 비즈니스 요구사항(최신순, 개수 제한)에 맞춰 조회하는지 확인
+
+### 2.1. 저장 및 조회 (Save & Find) 검증
+
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **INF-JPA-001** | `givenStockData_`<br>`whenSaveAndFindData_`<br>`thenReturnSavedDataOrderByCreatedAt`<br>👉 **정렬 및 개수 제한 검증: 최신순 정렬과 Limit 동작 확인** | **데이터 준비**<br>1. 10분 전 데이터 (Old)<br>2. **현재 데이터 (Recent)**<br>3. 1시간 전 데이터 (VeryOld)<br>→ 순서 섞어서 저장 | **`adapter.findRecentData(CODE, 2)`**<br>(최신 2개 조회 요청) | 1. 반환된 리스트의 크기가 **2개**인지 확인.<br>2. **첫 번째:** 가장 최신 데이터(`Recent`)인지 확인.<br>3. **두 번째:** 그 다음 최신 데이터(`Old`)인지 확인.<br>4. 가장 오래된 데이터(`VeryOld`)는 포함되지 않았음을 검증. |
+| **INF-JPA-002** | `givenOtherStockCode_`<br>`whenSaveAndFindData_`<br>`thenReturnOnlySavedData`<br>👉 **필터링 검증: 타 종목 데이터 격리 확인** | **데이터 준비**<br>1. 삼성전자(`005930`) 데이터<br>2. 네이버(`035420`) 데이터<br>→ 모두 저장 | **`adapter.findRecentData("005930", 10)`**<br>(삼성전자 조회 요청) | 1. 반환된 리스트의 크기가 **1개**인지 확인.<br>2. 조회된 데이터의 종목 코드가 요청한 코드(`005930`)와 일치하는지 검증.<br>3. 타 종목(`035420`) 데이터가 섞이지 않았음을 확인. |
+
+---
+
+## 3. 테스트 결과 요약
+
+### 3.1. 수행 결과
+| 구분 | 전체 케이스 | Pass  | Fail | 비고 |
+| :--- |:------:|:-----:| :---: | :--- |
+| **Stock History (JPA)** |   2    |   2   | 0 | PostgreSQL 컨테이너 연동 성공 |
+| **합계** | **2** | **2** | **0** | **Pass** ✅ |
+
+---
+
+**💡 비고:**
+본 테스트는 `Mockito`를 사용한 Mock 테스트가 아닌, **`Testcontainers`를 활용한 슬라이스 테스트(Slice Test)**입니다.
+실제 PostgreSQL 인스턴스를 도커로 띄워 실행하므로, `ddl-auto=create-drop` 설정을 통해 스키마 생성 및 데이터 적재가 정상적으로 이루어지는지까지 포함하여 검증하였습니다.

--- a/docs/TCS/stock/TCS-REDIS-001.md
+++ b/docs/TCS/stock/TCS-REDIS-001.md
@@ -1,0 +1,56 @@
+# [TCS] Stock Snapshot Redis 어댑터 테스트 명세서
+
+| 문서 ID | **TCS-REDIS-001**                        |
+| :--- |:-----------------------------------------|
+| **문서 버전** | 1.0                                      |
+| **프로젝트** | AssetMind                                |
+| **작성자** | 이재석                                      |
+| **작성일** | 2026년 02월 10일                            |
+| **관련 모듈** | `stock/infrastructure/persistence/redis` |
+
+## 1. 개요 (Overview)
+
+본 문서는 AssetMind Stock 시스템의 실시간 주식 시세 스냅샷 및 랭킹 저장소(`StockSnapshotRedisAdapter`)에 대한 슬라이스 테스트 명세이다.
+`Testcontainers`를 사용하여 실제 **Redis** 환경을 도커 컨테이너로 구성하고, Redis Hash(상세 정보)와 ZSet(랭킹 점수) 간의 데이터 동기화 및 정렬 조회가 올바르게 동작하는지 검증한다.
+
+### 1.1. 테스트 환경
+- **Framework:** JUnit 5, AssertJ, Spring Boot Test (`@DataRedisTest`)
+- **Infrastructure:** Testcontainers (Redis:alpine)
+- **Target Class:** `StockSnapshotRedisAdapterTest`
+- **Verification Focus:**
+    - **Dual Write:** `save` 시 Hash(상세)와 ZSet(랭킹)에 동시에 데이터가 적재되는지 검증
+    - **Ranking Logic:** 거래대금(TradeValue)과 거래량(TradeVolume) 기준 내림차순 정렬 검증
+    - **Limit:** 요청한 개수만큼 상위 데이터를 잘라오는지 검증
+    - **Edge Case:** 데이터가 없을 때의 빈 리스트 반환 처리 검증
+
+---
+
+## 2. Infrastructure Adapter 테스트 명세 - 주식 스냅샷 및 랭킹
+> **대상 클래스:** `StockSnapshotRedisAdapterTest`
+> **검증 목표:** 실시간 시세 데이터의 저장 구조(Hash+ZSet) 일관성과 랭킹 조회 로직의 정확성 확인
+
+### 2.1. 저장 및 랭킹 조회 (Save & Ranking) 검증
+
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **INF-REDIS-001** | `givenStockData_`<br>`whenSave_`<br>`thenSavedStockDataAndRanking`<br>👉 **저장 검증: Hash 상세 저장 및 ZSet 점수 등록 확인** | **데이터 준비**<br>종목: 삼성전자<br>거래대금: 1,000,000<br>거래량: 500 | **`adapter.save(entity)`** | 1. **Hash:** Repository 조회 시 종목명("삼성전자")과 대금 일치 확인.<br>2. **ZSet(Value):** `ranking:trade_value` 키에 점수 1,000,000 등록 확인.<br>3. **ZSet(Volume):** `ranking:trade_volume` 키에 점수 500 등록 확인. |
+| **INF-REDIS-002** | `givenLimitCount_`<br>`whenGetTopStocksByTradeValue_`<br>`thenReturnTradeValueRankingData`<br>👉 **거래대금 랭킹 검증: 대금 기준 내림차순 정렬** | **데이터 준비**<br>A(1000원), B(3000원), C(2000원)<br>→ 순서 섞어서 저장 | **`adapter.getTopStocksByTradeValue(3)`** | 1. 반환된 리스트 크기 3 확인.<br>2. 순서가 **B(1등) -> C(2등) -> A(3등)** 인지 검증.<br>3. 각 항목의 누적 거래대금 값 일치 확인. |
+| **INF-REDIS-003** | `givenLimitCount_`<br>`whenGetTopStocksByTradeVolume_`<br>`thenReturnTradeVolumeRankingData`<br>👉 **거래량 랭킹 검증: 거래량 기준 내림차순 정렬** | **데이터 준비**<br>A(대금 3등, **거래량 1등**)<br>B(대금 1등, **거래량 3등**)<br>C(대금 2등, **거래량 2등**) | **`adapter.getTopStocksByTradeVolume(3)`** | 1. 반환된 리스트 크기 3 확인.<br>2. 대금 순위와 무관하게 **A -> C -> B** 순서로 정렬되었는지 검증. |
+| **INF-REDIS-004** | `givenLimitCount_`<br>`whenGet_`<br>`thenReturnCollectLimitCountData`<br>👉 **Limit 검증: 상위 N개 데이터 절삭** | **데이터 준비**<br>데이터 5개 저장 (CODE1 ~ CODE5) | **`adapter.getTopStocksByTradeValue(2)`** | 1. 반환된 리스트 크기가 **2개**인지 확인.<br>2. 가장 점수가 높은 상위 2개(CODE5, CODE4)만 포함되었는지 확인. |
+| **INF-REDIS-005** | `givenNoDataInRedis_`<br>`whenGet_`<br>`thenEmptyList`<br>👉 **예외 검증: 데이터 없음 처리** | **데이터 준비**<br>Redis 데이터 없음 (Empty) | **`adapter.getTopStocksByTradeValue(10)`** | 1. `null`이 아닌 **빈 리스트(`isEmpty()`)**가 반환되는지 확인. |
+
+---
+
+## 3. 테스트 결과 요약
+
+### 3.1. 수행 결과
+| 구분 | 전체 케이스 | Pass  | Fail | 비고 |
+| :--- |:------:|:-----:| :---: | :--- |
+| **Stock Snapshot (Redis)** |   5    |   5   | 0 | Testcontainers(Redis) 연동 성공 |
+| **합계** | **5** | **5** | **0** | **Pass** ✅ |
+
+---
+
+**💡 비고:**
+본 테스트는 `Mockito`를 사용하지 않고, **`Testcontainers`를 활용한 슬라이스 테스트(Slice Test)**입니다.
+실제 Redis 인스턴스를 도커로 띄워 실행하므로, `StringRedisTemplate`을 통한 ZSet 연산과 `CrudRepository`를 통한 Hash 연산이 실제 환경과 동일하게 동작함을 보장합니다.


### PR DESCRIPTION
## 📌 작업 내용
- **주식 시세/랭킹 엔티티 및 Redis 어댑터 구현:** 실시간 주가 정보를 저장하는 `StockPriceRedisEntity`와 이를 관리하는 `StockSnapshotRedisAdapter`를 구현했습니다.
- **주식 체결내역 엔티티 및 JPA 어댑터 구현:** 과거 체결 이력을 저장하는 `StockDataEntity`와 이를 최신순으로 조회하는 `StockHistoryJpaAdapter`를 구현했습니다.
- **테스트 환경 고도화 (TestContainers + Slice Test):** 무거운 통합 테스트 대신 **TestContainers**를 활용한 독립적인 슬라이스 테스트 환경을 구축했습니다.

## 🏗 기술적 의사결정 및 엔티티 설계 (Core Design)

### 1. Entity Field 설계 이유
데이터의 특성과 시스템 부하를 고려하여 필드 타입을 선정했습니다.

#### 🅰️ StockDataEntity (JPA - PostgreSQL)
> **목적:** 과거 체결 내역의 영구 저장 및 시계열 조회
- **`price` (`Long`):** 금융 데이터의 핵심인 가격은 부동소수점 오차(Floating Point Error)를 방지하기 위해 `Double` 대신 정수형 `Long`을 사용했습니다. (KRW 기준)
- **`time` (`String`):** KIS API가 제공하는 `HHmmss` 포맷을 그대로 저장합니다. 단순 조회용 필드이므로, 불필요한 `LocalTime` 파싱/변환 오버헤드를 줄여 쓰기 성능을 최적화했습니다.
- **`changeRate` (`Double`):** 등락률은 소수점 표현이 필수적이므로 `Double`을 사용했습니다.
- **`createdAt` (`LocalDateTime`):** 데이터 수신 순서 보장을 위한 정렬 기준 필드입니다. (테스트 시 조작 가능하도록 설계)

#### 🅱️ StockPriceRedisEntity (Redis - Hash)
> **목적:** 실시간 시세 스냅샷 및 랭킹 산정 (고속 조회)
- **`@Id stockCode` (`String`):** 종목 코드를 Key로 사용하여 O(1) 조회를 보장합니다.
- **`cumulativeAmount` (`Long`):** 누적 거래대금은 장 마감 시 '조' 단위까지 증가할 수 있어 `Integer` 범위를 넘으므로 `Long`으로 선언했습니다.
- **`@RedisHash(timeToLive = 600)`:** 실시간성이 중요한 데이터이므로, 10분(600초)이 지나면 자동 만료되도록 TTL을 설정하여 Redis 메모리를 효율적으로 관리합니다.

### 2. Redis ZSet을 활용한 실시간 랭킹 구현
> `CrudRepository`만으로는 실시간 변동하는 거래대금/거래량 순위를 효율적으로 가져오기 어렵습니다.
- **구현:** `StockSnapshotRedisAdapter`에서 데이터 저장 시 **Hash(상세 정보)**와 **ZSet(랭킹 점수)**에 이중으로 저장(Dual Write)하도록 구현했습니다.
- **이유:** 조회 시 `ZSet`의 `reverseRange`를 사용하여 **O(log N)**의 속도로 상위 종목을 즉시 추출하고, 상세 정보는 `Hash`에서 가져와 조합하는 방식이 가장 성능 효율적이라 판단했습니다.

### 3. TestContainers & Slice Test 전환
> `@SpringBootTest` 사용 시 외부 API 서비스 빈 로드 문제 및 DB 환경 불일치 문제를 해결해야 합니다.
- **구현:**
    - `IntegrationTestSupport` 상속을 제거하고, **`@DataRedisTest`**와 **`@DataJpaTest`**를 사용하여 각 레이어에 필요한 빈만 로드했습니다.
    - 테스트 실행 시 **Docker 컨테이너**로 `redis:alpine`과 `postgres:16-alpine`을 띄워 운영 환경과 동일한 동작을 보장했습니다.

## ✅ 주요 변경점
- **Domain Layer (Entity):**
    - `StockPriceRedisEntity`: Redis Hash 매핑, TTL 설정(600s), Builder 패턴 적용.
    - `StockDataEntity`: JPA Entity 매핑, 불변성 보장(`AccessLevel.PROTECTED`), `createdAt` 수동 주입 로직 추가.
- **Infrastructure Layer (Adapter):**
    - `StockSnapshotRedisAdapter`: `save()` 시 `opsForZSet().add()`를 통해 랭킹 점수 동기화 및 `reverseRange`를 이용한 랭킹 조회 구현.
    - `StockHistoryJpaAdapter`: `Pageable`을 적용하여 대량의 체결 내역 중 최신 N개만 효율적으로 조회.
- **Test Codes:**
    - `StockSnapshotRedisAdapterTest`: `@DataRedisTest` 적용, 거래대금/거래량 랭킹 교차 검증 로직 추가.
    - `StockHistoryJpaAdapterTest`: `@DataJpaTest` 적용, `ddl-auto=create-drop` 설정을 통해 스키마 자동 생성 및 검증.

## 📝 리뷰 포인트
- **필드 타입 적절성:** `price(Long)`와 `changeRate(Double)` 등의 타입 선정이 금융 데이터 처리에 적절한지 검토 부탁드립니다.
- **Redis 랭킹 정렬:** 거래대금과 거래량 순위가 다를 때, 각각의 기준대로 정확히 정렬되어 반환되는지 테스트 코드를 통해 확인 부탁드립니다.