### PR TITLE
[Test] Extractor Module Standardization & Unit Test Coverage

### DIFF
--- a/apps/data-pipeline/src/extractor/providers/abstract_extractor.py
+++ b/apps/data-pipeline/src/extractor/providers/abstract_extractor.py
@@ -126,7 +126,7 @@ class AbstractExtractor(IExtractor, ABC):
         Raises:
             ExtractorError: 설정이 없거나 요청이 유효하지 않은 경우.
         """
-        pass
+        pass # pragma: no cover
 
     @abstractmethod
     async def _fetch_raw_data(self, request: RequestDTO) -> Any:
@@ -143,7 +143,7 @@ class AbstractExtractor(IExtractor, ABC):
         Returns:
             Any: API로부터 받은 원본 응답 데이터.
         """
-        pass
+        pass # pragma: no cover
 
     @abstractmethod
     def _create_response(self, raw_data: Any) -> ResponseDTO:
@@ -158,4 +158,4 @@ class AbstractExtractor(IExtractor, ABC):
         Raises:
             ExtractorError: API 호출은 성공했으나 비즈니스 로직상 실패인 경우.
         """
-        pass
+        pass # pragma: no cover

--- a/apps/data-pipeline/tests/unit/extractor/adapters/test_auth.py
+++ b/apps/data-pipeline/tests/unit/extractor/adapters/test_auth.py
@@ -1,12 +1,21 @@
+import jwt
+import uuid
 import pytest
 import asyncio
+import hashlib
+from urllib.parse import urlencode
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from typing import Optional
 
 # 실제 프로젝트 경로에 맞게 임포트
-from src.extractor.adapters.auth import KISAuthStrategy
+from src.extractor.adapters.auth import KISAuthStrategy, UPBITAuthStrategy
 from src.extractor.domain.exceptions import AuthError, NetworkError
+
+# --- [Constants] 테스트용 상수 (보안 경고 방지를 위해 32바이트 이상 설정) ---
+# HS256 알고리즘은 보안상 256비트(32바이트) 이상의 키 길이를 권장합니다.
+TEST_UPBIT_SECRET = "test_secret_key_must_be_at_least_32_bytes_long_001"
+TEST_UPBIT_WRONG_SECRET = "wrong_secret_key_must_be_at_least_32_bytes_long_999"
 
 # --- [Mock Definitions] 테스트를 위한 가짜 객체 정의 ---
 class MockSecretStr:
@@ -15,12 +24,26 @@ class MockSecretStr:
     def get_secret_value(self) -> str:
         return self._value
 
-class MockConfig:
+class MockKISConfig:
+    """KIS 테스트를 위한 설정 Mock 객체"""
     def __init__(self, base_url="https://api.test.com", app_key="key", app_secret="secret"):
         self.kis = MagicMock()
         self.kis.base_url = base_url
         self.kis.app_key = MockSecretStr(app_key)
         self.kis.app_secret = MockSecretStr(app_secret)
+
+class MockUpbitConfig:
+    """UPBIT 테스트를 위한 설정 Mock 객체"""
+    def __init__(self, base_url="https://api.upbit.com", api_key="u_key", secret_key=TEST_UPBIT_SECRET, missing_secret=False):
+        self.upbit = MagicMock()
+        self.upbit.base_url = base_url
+        self.upbit.api_key = MockSecretStr(api_key)
+        
+        # [UPBIT-INIT-02] 테스트를 위해 secret_key 속성 자체를 누락시키는 옵션
+        if not missing_secret:
+            self.upbit.secret_key = MockSecretStr(secret_key)
+        else:
+            del self.upbit.secret_key
 
 # --- [Fixtures] 테스트 환경 설정 ---
 
@@ -32,9 +55,7 @@ def mock_external_dependencies():
     참조하지 못하도록 LogManager.get_logger 메서드 자체를 Mocking합니다.
     이 픽스처는 autouse=True로 설정되어 모든 테스트에 자동 적용됩니다.
     """
-    # src.common.log 모듈 경로에 유의하여 LogManager를 패치합니다.
     with patch("src.common.log.LogManager.get_logger") as mock_get_logger:
-        # 로거가 호출되면 아무 동작도 하지 않는 MagicMock을 반환
         mock_get_logger.return_value = MagicMock()
         yield
 
@@ -45,10 +66,16 @@ def mock_http_client():
     return client
 
 @pytest.fixture
-def auth_strategy(mock_http_client):
+def kis_strategy(mock_http_client):
     """기본 설정이 완료된 AuthStrategy 인스턴스를 반환합니다."""
-    config = MockConfig()
+    config = MockKISConfig()
     return KISAuthStrategy(config)
+
+@pytest.fixture
+def upbit_strategy():
+    """기본 설정이 완료된 UPBITAuthStrategy 인스턴스를 반환합니다."""
+    config = MockUpbitConfig()
+    return UPBITAuthStrategy(config)
 
 @pytest.fixture
 def valid_token_response():
@@ -60,13 +87,13 @@ def valid_token_response():
     }
 
 # ========================================================================================
-# 1. 초기화 테스트 (Initialization)
+# 1. KIS 초기화 테스트 (Initialization)
 # ========================================================================================
 
-def test_init_01_valid_config():
-    """[INIT-01] 유효한 설정으로 초기화 시 인스턴스 정상 생성"""
+def test_kis_init_01_valid_config():
+    """[KIS-INIT-01] 유효한 설정으로 초기화 시 인스턴스 정상 생성"""
     # Given
-    config = MockConfig(base_url="https://api.kis.com")
+    config = MockKISConfig(base_url="https://api.kis.com")
     
     # When
     strategy = KISAuthStrategy(config)
@@ -75,19 +102,19 @@ def test_init_01_valid_config():
     assert strategy.base_url == "https://api.kis.com"
     assert strategy._access_token is None
 
-def test_init_02_invalid_base_url():
-    """[INIT-02] base_url이 비어있으면 ValueError 발생"""
+def test_kis_init_02_invalid_base_url():
+    """[KIS-INIT-02] base_url이 비어있으면 ValueError 발생"""
     # Given
-    config = MockConfig(base_url="")
+    config = MockKISConfig(base_url="")
     
     # When & Then
     with pytest.raises(ValueError, match="missing"):
         KISAuthStrategy(config)
 
-def test_init_03_secret_handling():
-    """[INIT-03] SecretStr 타입이 내부적으로 평문으로 저장되는지 검증"""
+def test_kis_init_03_secret_handling():
+    """[KIS-INIT-03] SecretStr 타입이 내부적으로 평문으로 저장되는지 검증"""
     # Given
-    config = MockConfig(app_key="secret_key_123")
+    config = MockKISConfig(app_key="secret_key_123")
     
     # When
     strategy = KISAuthStrategy(config)
@@ -96,73 +123,73 @@ def test_init_03_secret_handling():
     assert strategy.app_key == "secret_key_123"
 
 # ========================================================================================
-# 2. 토큰 수명주기 테스트 (Lifecycle)
+# 2. KIS 토큰 수명주기 테스트 (Lifecycle)
 # ========================================================================================
 
 @pytest.mark.asyncio
-async def test_life_01_initial_fetch(auth_strategy, mock_http_client, valid_token_response):
-    """[LIFE-01] 초기 구동 시 API 호출하여 토큰 발급"""
+async def test_kis_life_01_initial_fetch(kis_strategy, mock_http_client, valid_token_response):
+    """[KIS-LIFE-01] 초기 구동 시 API 호출하여 토큰 발급"""
     # Given
     mock_http_client.post.return_value = valid_token_response
     
     # When
-    token = await auth_strategy.get_token(mock_http_client)
+    token = await kis_strategy.get_token(mock_http_client)
     
     # Then
     assert token == "Bearer test_access_token"
     mock_http_client.post.assert_called_once()
-    assert auth_strategy._access_token == "test_access_token"
+    assert kis_strategy._access_token == "test_access_token"
 
 @pytest.mark.asyncio
-async def test_life_02_valid_cache_hit(auth_strategy, mock_http_client):
-    """[LIFE-02] 토큰 유효기간이 버퍼(10분)보다 많이 남았으면 캐시 반환 (API 호출 X)"""
+async def test_kis_life_02_valid_cache_hit(kis_strategy, mock_http_client):
+    """[KIS-LIFE-02] 토큰 유효기간이 버퍼(10분)보다 많이 남았으면 캐시 반환 (API 호출 X)"""
     # Given
-    auth_strategy._access_token = "cached_token"
-    auth_strategy._expires_at = datetime.now() + timedelta(minutes=11)
+    kis_strategy._access_token = "cached_token"
+    kis_strategy._expires_at = datetime.now() + timedelta(minutes=11)
     
     # When
-    token = await auth_strategy.get_token(mock_http_client)
+    token = await kis_strategy.get_token(mock_http_client)
     
     # Then
     assert token == "Bearer cached_token"
     mock_http_client.post.assert_not_called()
 
 @pytest.mark.asyncio
-async def test_life_03_lazy_refresh_buffer_entry(auth_strategy, mock_http_client, valid_token_response):
-    """[LIFE-03] 토큰 유효기간이 9분 남음 (버퍼 10분 진입) -> 갱신 수행"""
+async def test_kis_life_03_lazy_refresh_buffer_entry(kis_strategy, mock_http_client, valid_token_response):
+    """[KIS-LIFE-03] 토큰 유효기간이 9분 남음 (버퍼 10분 진입) -> 갱신 수행"""
     # Given
-    auth_strategy._access_token = "old_token"
-    auth_strategy._expires_at = datetime.now() + timedelta(minutes=9)
+    kis_strategy._access_token = "old_token"
+    kis_strategy._expires_at = datetime.now() + timedelta(minutes=9)
     mock_http_client.post.return_value = valid_token_response
     
     # When
-    token = await auth_strategy.get_token(mock_http_client)
+    token = await kis_strategy.get_token(mock_http_client)
     
     # Then
     assert token == "Bearer test_access_token"
     mock_http_client.post.assert_called_once()
 
 @pytest.mark.asyncio
-async def test_life_04_token_expired(auth_strategy, mock_http_client, valid_token_response):
-    """[LIFE-04] 이미 만료된 토큰 -> 갱신 수행"""
+async def test_kis_life_04_token_expired(kis_strategy, mock_http_client, valid_token_response):
+    """[KIS-LIFE-04] 이미 만료된 토큰 -> 갱신 수행"""
     # Given
-    auth_strategy._access_token = "expired_token"
-    auth_strategy._expires_at = datetime.now() - timedelta(minutes=1)
+    kis_strategy._access_token = "expired_token"
+    kis_strategy._expires_at = datetime.now() - timedelta(minutes=1)
     mock_http_client.post.return_value = valid_token_response
     
     # When
-    token = await auth_strategy.get_token(mock_http_client)
+    token = await kis_strategy.get_token(mock_http_client)
     
     # Then
     mock_http_client.post.assert_called_once()
 
 # ========================================================================================
-# 3. 동시성 테스트 (Concurrency)
+# 3. KIS 동시성 테스트 (Concurrency)
 # ========================================================================================
 
 @pytest.mark.asyncio
-async def test_conc_01_concurrency_locking(auth_strategy, mock_http_client, valid_token_response):
-    """[CONC-01] 다수의 코루틴이 동시에 요청해도 API 호출은 1회만 발생 (Double-Checked Locking)"""
+async def test_kis_conc_01_concurrency_locking(kis_strategy, mock_http_client, valid_token_response):
+    """[KIS-CONC-01] 다수의 코루틴이 동시에 요청해도 API 호출은 1회만 발생 (Double-Checked Locking)"""
     # Given
     async def delayed_response(*args, **kwargs):
         await asyncio.sleep(0.1) 
@@ -171,7 +198,7 @@ async def test_conc_01_concurrency_locking(auth_strategy, mock_http_client, vali
     mock_http_client.post.side_effect = delayed_response
     
     # When
-    tasks = [auth_strategy.get_token(mock_http_client) for _ in range(5)]
+    tasks = [kis_strategy.get_token(mock_http_client) for _ in range(5)]
     results = await asyncio.gather(*tasks)
     
     # Then
@@ -179,12 +206,12 @@ async def test_conc_01_concurrency_locking(auth_strategy, mock_http_client, vali
     assert mock_http_client.post.call_count == 1
 
 # ========================================================================================
-# 4. API 응답 및 파싱 테스트 (API Interaction)
+# 4. KIS API 응답 및 파싱 테스트 (API Interaction)
 # ========================================================================================
 
 @pytest.mark.asyncio
-async def test_api_01_parsing_normal(auth_strategy, mock_http_client):
-    """[API-01] 응답 파싱 및 만료시간 설정 검증"""
+async def test_kis_api_01_parsing_normal(kis_strategy, mock_http_client):
+    """[KIS-API-01] 응답 파싱 및 만료시간 설정 검증"""
     # Given
     target_time = datetime.now().replace(microsecond=0) + timedelta(hours=1)
     expiry_str = target_time.strftime("%Y-%m-%d %H:%M:%S")
@@ -196,39 +223,39 @@ async def test_api_01_parsing_normal(auth_strategy, mock_http_client):
     mock_http_client.post.return_value = response
     
     # When
-    await auth_strategy.get_token(mock_http_client)
+    await kis_strategy.get_token(mock_http_client)
     
     # Then
-    assert auth_strategy._access_token == "new_token"
-    assert auth_strategy._expires_at == target_time
+    assert kis_strategy._access_token == "new_token"
+    assert kis_strategy._expires_at == target_time
 
 @pytest.mark.asyncio
-async def test_api_02_missing_expiry_key(auth_strategy, mock_http_client):
-    """[API-02] 만료시간 키 누락 시 기본값(12시간) 설정"""
+async def test_kis_api_02_missing_expiry_key(kis_strategy, mock_http_client):
+    """[KIS-API-02] 만료시간 키 누락 시 기본값(12시간) 설정"""
     # Given
     mock_http_client.post.return_value = {"access_token": "token_no_expiry"}
     
     # When
-    await auth_strategy.get_token(mock_http_client)
+    await kis_strategy.get_token(mock_http_client)
     
     # Then
     expected_expiry = datetime.now() + timedelta(hours=12)
-    diff = abs((auth_strategy._expires_at - expected_expiry).total_seconds())
+    diff = abs((kis_strategy._expires_at - expected_expiry).total_seconds())
     assert diff < 5
 
 @pytest.mark.asyncio
-async def test_api_03_missing_access_token(auth_strategy, mock_http_client):
-    """[API-03] access_token 키 누락 시 AuthError 발생"""
+async def test_kis_api_03_missing_access_token(kis_strategy, mock_http_client):
+    """[KIS-API-03] access_token 키 누락 시 AuthError 발생"""
     # Given
     mock_http_client.post.return_value = {"msg": "invalid response"}
     
     # When & Then
     with pytest.raises(AuthError, match="Missing access_token"):
-        await auth_strategy.get_token(mock_http_client)
+        await kis_strategy.get_token(mock_http_client)
 
 @pytest.mark.asyncio
-async def test_api_04_mcdc_invalid_date_format(auth_strategy, mock_http_client):
-    """[API-04] [MC/DC] 만료시간 포맷 오류 시 ValueError Catch 후 기본값 적용"""
+async def test_kis_api_04_mcdc_invalid_date_format(kis_strategy, mock_http_client):
+    """[KIS-API-04] [MC/DC] 만료시간 포맷 오류 시 ValueError Catch 후 기본값 적용"""
     # Given
     mock_http_client.post.return_value = {
         "access_token": "token",
@@ -236,68 +263,199 @@ async def test_api_04_mcdc_invalid_date_format(auth_strategy, mock_http_client):
     }
     
     # When
-    await auth_strategy.get_token(mock_http_client)
+    await kis_strategy.get_token(mock_http_client)
     
     # Then
     expected_expiry = datetime.now() + timedelta(hours=12)
-    diff = abs((auth_strategy._expires_at - expected_expiry).total_seconds())
+    diff = abs((kis_strategy._expires_at - expected_expiry).total_seconds())
     assert diff < 5
 
 # ========================================================================================
-# 5. 에러 처리 테스트 (Error Handling)
+# 5. KIS 에러 처리 테스트 (Error Handling)
 # ========================================================================================
 
 @pytest.mark.asyncio
-async def test_err_01_fail_fast_401(auth_strategy, mock_http_client):
-    """[ERR-01] 401 Unauthorized 발생 시 재시도 없이 AuthError 발생 (Fail-Fast)"""
+async def test_kis_err_01_fail_fast_401(kis_strategy, mock_http_client):
+    """[KIS-ERR-01] 401 Unauthorized 발생 시 재시도 없이 AuthError 발생 (Fail-Fast)"""
     # Given
     mock_http_client.post.side_effect = NetworkError("401 Unauthorized")
     
     # When & Then
     with pytest.raises(AuthError, match="Invalid Credentials"):
-        await auth_strategy.get_token(mock_http_client)
+        await kis_strategy.get_token(mock_http_client)
 
 @pytest.mark.asyncio
-async def test_err_02_fail_fast_403(auth_strategy, mock_http_client):
-    """[ERR-02] 403 Forbidden 발생 시 재시도 없이 AuthError 발생 (Fail-Fast)"""
+async def test_kis_err_02_fail_fast_403(kis_strategy, mock_http_client):
+    """[KIS-ERR-02] 403 Forbidden 발생 시 재시도 없이 AuthError 발생 (Fail-Fast)"""
     # Given
     mock_http_client.post.side_effect = NetworkError("403 Forbidden")
     
     # When & Then
     with pytest.raises(AuthError, match="Invalid Credentials"):
-        await auth_strategy.get_token(mock_http_client)
+        await kis_strategy.get_token(mock_http_client)
 
 @pytest.mark.asyncio
-async def test_err_03_unknown_exception(auth_strategy, mock_http_client):
-    """[ERR-03] 알 수 없는 예외 발생 시 AuthError로 래핑"""
+async def test_kis_err_03_unknown_exception(kis_strategy, mock_http_client):
+    """[KIS-ERR-03] 알 수 없는 예외 발생 시 AuthError로 래핑"""
     # Given
     mock_http_client.post.side_effect = KeyError("Unexpected Key")
     
     # When & Then
     with pytest.raises(AuthError, match="Error during token issuance"):
-        await auth_strategy.get_token(mock_http_client)
+        await kis_strategy.get_token(mock_http_client)
 
 @pytest.mark.asyncio
-async def test_err_04_token_none_logic(auth_strategy, mock_http_client):
-    """[ERR-04] 로직 수행 후에도 토큰이 없는 경우 AuthError (Mocking으로 강제)"""
+async def test_kis_err_04_token_none_logic(kis_strategy, mock_http_client):
+    """[KIS-ERR-04] 로직 수행 후에도 토큰이 없는 경우 AuthError (Mocking으로 강제)"""
     # Given
     # 내부 _issue_token이 호출되지만 아무 일도 안 하도록 Mocking
-    with patch.object(auth_strategy, '_issue_token', new=AsyncMock()) as mock_issue:
+    with patch.object(kis_strategy, '_issue_token', new=AsyncMock()) as mock_issue:
         # 갱신 조건 강제 만족
-        auth_strategy._access_token = None
+        kis_strategy._access_token = None
         
         # When & Then
         with pytest.raises(AuthError, match="Failed to retrieve access token"):
-            await auth_strategy.get_token(mock_http_client)
+            await kis_strategy.get_token(mock_http_client)
 
 @pytest.mark.asyncio
-async def test_err_05_retry_logic_500(auth_strategy, mock_http_client):
-    """[ERR-05] 500 에러 발생 시 NetworkError가 그대로 전파됨 (Retry 데코레이터 트리거용)"""
+async def test_kis_err_05_retry_logic_500(kis_strategy, mock_http_client):
+    """[KIS-ERR-05] 500 에러 발생 시 NetworkError가 그대로 전파됨 (Retry 데코레이터 트리거용)"""
     # Given
     mock_http_client.post.side_effect = NetworkError("500 Internal Server Error")
     
     # When & Then
-    # 여기서는 데코레이터가 Mocking된 상태일 수 있으나(로깅만 Mocking함), 
-    # _issue_token 내부 로직이 500 에러를 catch하지 않고 raise하는지를 검증함.
     with pytest.raises(NetworkError, match="500"):
-        await auth_strategy._issue_token(mock_http_client)
+        await kis_strategy._issue_token(mock_http_client)
+
+# ========================================================================================
+# 6. UPBIT 초기화 테스트 (Initialization)
+# ========================================================================================
+
+def test_upbit_init_01_invalid_base_url():
+    """[UPBIT-INIT-01] base_url이 비어있으면 ValueError 발생"""
+    # Given
+    config = MockUpbitConfig(base_url="")
+    
+    # When & Then
+    with pytest.raises(ValueError, match="base_url"):
+        UPBITAuthStrategy(config)
+
+def test_upbit_init_02_missing_secret_key_attribute():
+    """[UPBIT-INIT-02] 설정 객체에 secret_key 속성이 없으면 ValueError 발생"""
+    # Given
+    config = MockUpbitConfig(missing_secret=True)
+    
+    # When & Then
+    with pytest.raises(ValueError, match="secret_key"):
+        UPBITAuthStrategy(config)
+
+# ========================================================================================
+# 7. UPBIT 토큰 수명주기 및 데이터 무결성 (Lifecycle & Data Integrity)
+# ========================================================================================
+
+@pytest.mark.asyncio
+async def test_upbit_life_01_basic_token_structure(upbit_strategy, mock_http_client):
+    """[UPBIT-LIFE-01] 인자 없이 호출 시 기본 토큰 구조(Access Key, Nonce) 검증"""
+    # When
+    token_str = await upbit_strategy.get_token(mock_http_client)
+    
+    # Then
+    assert token_str.startswith("Bearer ")
+    raw_token = token_str.split(" ")[1]
+    
+    # JWT Decode (서명 검증 포함 - TEST_UPBIT_SECRET 사용)
+    payload = jwt.decode(raw_token, TEST_UPBIT_SECRET, algorithms=["HS256"])
+    
+    assert payload["access_key"] == "u_key"
+    assert "nonce" in payload
+    assert "query_hash" not in payload  # 쿼리가 없으므로 해시도 없어야 함
+
+@pytest.mark.asyncio
+async def test_upbit_life_02_query_hash_integrity(upbit_strategy, mock_http_client):
+    """[UPBIT-LIFE-02] 쿼리 파라미터 전달 시 SHA512 해시 무결성 검증"""
+    # Given
+    params = {"market": "KRW-BTC", "count": 1}
+    
+    # 수동 해시 계산 (검증용 Oracle)
+    query_string = urlencode(params).encode("utf-8")
+    expected_hash = hashlib.sha512(query_string).hexdigest()
+    
+    # When
+    token_str = await upbit_strategy.get_token(mock_http_client, query_params=params)
+    
+    # Then
+    raw_token = token_str.split(" ")[1]
+    payload = jwt.decode(raw_token, TEST_UPBIT_SECRET, algorithms=["HS256"])
+    
+    assert payload.get("query_hash") == expected_hash
+    assert payload.get("query_hash_alg") == "SHA512"
+
+@pytest.mark.asyncio
+async def test_upbit_data_01_empty_query_params(upbit_strategy, mock_http_client):
+    """[UPBIT-DATA-01] 빈 딕셔너리 쿼리 파라미터는 None과 동일하게 처리(해시 미생성)"""
+    # Given
+    empty_params = {}
+    
+    # When
+    token_str = await upbit_strategy.get_token(mock_http_client, query_params=empty_params)
+    
+    # Then
+    raw_token = token_str.split(" ")[1]
+    payload = jwt.decode(raw_token, TEST_UPBIT_SECRET, algorithms=["HS256"])
+    
+    assert "query_hash" not in payload
+
+@pytest.mark.asyncio
+async def test_upbit_compat_01_bytes_token_handling(upbit_strategy, mock_http_client):
+    """[UPBIT-COMPAT-01] PyJWT 구버전 호환성: jwt.encode가 bytes를 반환할 경우 str로 디코딩"""
+    # Given
+    # jwt.encode가 bytes 타입의 토큰을 반환하도록 Mocking
+    with patch("jwt.encode", return_value=b"bytes_token_mock"):
+        
+        # When
+        token_str = await upbit_strategy.get_token(mock_http_client)
+        
+        # Then
+        # 내부 로직에서 .decode("utf-8")이 호출되어 문자열로 변환되었는지 확인
+        assert token_str == "Bearer bytes_token_mock"
+
+# ========================================================================================
+# 8. UPBIT 보안 로직 검증 (Security Logic)
+# ========================================================================================
+
+@pytest.mark.asyncio
+async def test_upbit_logic_01_algorithm_check(upbit_strategy, mock_http_client):
+    """[UPBIT-LOGIC-01] 생성된 토큰의 헤더가 HS256 알고리즘을 사용하는지 확인"""
+    # When
+    token_str = await upbit_strategy.get_token(mock_http_client)
+    raw_token = token_str.split(" ")[1]
+    
+    # Then
+    header = jwt.get_unverified_header(raw_token)
+    assert header["alg"] == "HS256"
+
+@pytest.mark.asyncio
+async def test_upbit_logic_02_invalid_signature(upbit_strategy, mock_http_client):
+    """[UPBIT-LOGIC-02] 잘못된 Secret Key로 검증 시 서명 에러 발생 (위조 방지)"""
+    # Given
+    token_str = await upbit_strategy.get_token(mock_http_client)
+    raw_token = token_str.split(" ")[1]
+    
+    # When & Then
+    # 올바르지 않은 키도 길이 조건을 만족해야 경고 없이 InvalidSignatureError 검증 가능
+    with pytest.raises(jwt.InvalidSignatureError):
+        jwt.decode(raw_token, TEST_UPBIT_WRONG_SECRET, algorithms=["HS256"])
+
+@pytest.mark.asyncio
+async def test_upbit_sec_01_nonce_uniqueness(upbit_strategy, mock_http_client):
+    """[UPBIT-SEC-01] 연속 호출 시 Nonce가 매번 달라지는지 확인 (Replay Attack 방지)"""
+    # When
+    token1 = await upbit_strategy.get_token(mock_http_client)
+    token2 = await upbit_strategy.get_token(mock_http_client)
+    
+    # Then
+    payload1 = jwt.decode(token1.split(" ")[1], TEST_UPBIT_SECRET, algorithms=["HS256"])
+    payload2 = jwt.decode(token2.split(" ")[1], TEST_UPBIT_SECRET, algorithms=["HS256"])
+    
+    assert token1 != token2
+    assert payload1["nonce"] != payload2["nonce"]

--- a/apps/data-pipeline/tests/unit/extractor/providers/abstract_extractor_test.py
+++ b/apps/data-pipeline/tests/unit/extractor/providers/abstract_extractor_test.py
@@ -1,269 +1,228 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch, call, ANY
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch, call  # [Fix] call 추가
+from typing import Any
 
-# --------------------------------------------------------------------------
-# Import Real Objects (DTO) & Target Class
-# --------------------------------------------------------------------------
+# [Real Imports]
 from src.extractor.providers.abstract_extractor import AbstractExtractor
 from src.extractor.domain.dtos import RequestDTO, ResponseDTO
 from src.extractor.domain.exceptions import ExtractorError, NetworkError
 from src.extractor.domain.interfaces import IHttpClient
 from src.common.config import AppConfig
 
-# --------------------------------------------------------------------------
-# 0. Constants & Configuration
-# --------------------------------------------------------------------------
+# ========================================================================================
+# [Test Stub] 추상 클래스 테스트를 위한 구체화 (Stub)
+# ========================================================================================
 
-# 로그 매니저 경로 (파일 I/O를 유발하므로 Patch 대상)
-TARGET_LOG_MANAGER = "src.common.log.LogManager.get_logger"
+class StubExtractor(AbstractExtractor):
+    """
+    AbstractExtractor의 템플릿 메서드 로직을 검증하기 위한 테스트용 구현체.
+    각 추상 메서드는 내부의 Mock 객체에게 위임(Delegate)하여 행위를 제어합니다.
+    """
+    def __init__(self, http_client: IHttpClient, config: AppConfig):
+        super().__init__(http_client, config)
+        
+        # 행위 검증 및 제어를 위한 내부 Mock 정의
+        self.validate_mock = MagicMock()
+        self.fetch_mock = AsyncMock()
+        self.create_mock = MagicMock()
 
-# --------------------------------------------------------------------------
-# 1. Fixtures (Test Environment Setup)
-# --------------------------------------------------------------------------
-
-class ConcreteMockExtractor(AbstractExtractor):
-    """[Helper] AbstractExtractor 테스트를 위한 최소 구현체"""
     def _validate_request(self, request: RequestDTO) -> None:
-        pass
+        self.validate_mock(request)
 
-    async def _fetch_raw_data(self, request: RequestDTO) -> any:
-        return {"mock": "data"}
+    async def _fetch_raw_data(self, request: RequestDTO) -> Any:
+        return await self.fetch_mock(request)
 
-    def _create_response(self, raw_data: any) -> ResponseDTO:
-        return ResponseDTO(data=raw_data, meta={})
+    def _create_response(self, raw_data: Any) -> ResponseDTO:
+        return self.create_mock(raw_data)
+
+# ========================================================================================
+# [Fixtures] 테스트 환경 설정 및 Mocking
+# ========================================================================================
+
+@pytest.fixture(autouse=True)
+def mock_external_deps():
+    """모든 테스트에 공통적으로 적용되는 Logger Mock 설정"""
+    # 실제 모듈 경로에 맞춰 patch 적용
+    with patch("src.extractor.providers.abstract_extractor.LogManager.get_logger") as mock_logger:
+        yield mock_logger
+
+@pytest.fixture
+def mock_logger(mock_external_deps):
+    return mock_external_deps.return_value
 
 @pytest.fixture
 def mock_http_client():
-    """[IHttpClient Mock] 외부 네트워크 통신 담당"""
     return MagicMock(spec=IHttpClient)
 
 @pytest.fixture
 def mock_config():
-    """[AppConfig Mock] 파일 시스템 의존성 제거"""
-    config = MagicMock(spec=AppConfig)
-    config.extraction_policy = {"valid_job": {"active": True}}
-    return config
+    return MagicMock(spec=AppConfig)
 
 @pytest.fixture
 def extractor(mock_http_client, mock_config):
-    """
-    [System Under Test]
-    AbstractExtractor를 상속받은 ConcreteMockExtractor의 인스턴스입니다.
-    LogManager를 Patch하여 초기화 시 Disk I/O(Config Load)를 방지합니다.
-    """
-    with patch(TARGET_LOG_MANAGER) as mock_get_logger:
-        # Logger Mock 생성 및 주입
-        mock_logger_instance = MagicMock()
-        mock_get_logger.return_value = mock_logger_instance
-        
-        instance = ConcreteMockExtractor(mock_http_client, mock_config)
-        
-        # 내부 메서드 호출 감지를 위해 Spy/Mock 부착
-        # (인스턴스 메서드를 Mock으로 덮어씌워 side_effect 제어 및 호출 검증)
-        instance._validate_request = MagicMock(wraps=instance._validate_request)
-        instance._fetch_raw_data = AsyncMock(wraps=instance._fetch_raw_data)
-        instance._create_response = MagicMock(wraps=instance._create_response)
-        
-        # 테스트 코드에서 logger 호출 검증이 필요하므로 명시적 할당
-        instance.logger = mock_logger_instance
-        return instance
+    """테스트 대상 StubExtractor 인스턴스 (Happy Path 기본 설정 포함)"""
+    stub = StubExtractor(mock_http_client, mock_config)
+    stub.fetch_mock.return_value = {"raw": "data"}
+    stub.create_mock.return_value = ResponseDTO(data={"raw": "data"})
+    return stub
 
-# --------------------------------------------------------------------------
-# 2. Test Cases
-# --------------------------------------------------------------------------
+# ========================================================================================
+# 1. 초기화 및 방어 로직 테스트 (Initialization)
+# ========================================================================================
 
-class TestAbstractExtractor:
+def test_init_01_config_none(mock_http_client):
+    """[INIT-01] config가 None이면 ExtractorError 발생 (Fail-Fast)"""
+    with pytest.raises(ExtractorError, match="'AppConfig' cannot be None"):
+        StubExtractor(mock_http_client, None) # type: ignore
+
+@pytest.mark.asyncio
+async def test_init_02_request_none_handling(extractor, mock_logger):
+    """[INIT-02] request가 None일 때 로깅 안전성 및 Validate 에러 검증"""
+    # Given
+    extractor.validate_mock.side_effect = ExtractorError("Invalid Request")
     
-    # ==========================================
-    # Category: Unit (Happy Path & Logic)
-    # ==========================================
+    # When
+    with pytest.raises(ExtractorError, match="Invalid Request"):
+        await extractor.extract(None) # type: ignore
+    
+    # Then
+    mock_logger.info.assert_any_call("Starting extraction task. Job: Unknown")
 
-    @pytest.mark.asyncio
-    async def test_tc001_standard_flow(self, extractor):
-        """[TC-001] 정상 요청(valid) 시 Validate -> Fetch -> Create 순서로 실행되고 결과가 반환된다."""
-        # Given
-        request = RequestDTO(job_id="valid", params={})
-        
-        # When
-        result = await extractor.extract(request)
-        
-        # Then
-        extractor._validate_request.assert_called_once_with(request)
-        extractor._fetch_raw_data.assert_awaited_once_with(request)
-        extractor._create_response.assert_called_once()
-        assert isinstance(result, ResponseDTO)
+# ========================================================================================
+# 2. 흐름 제어 및 상태 테스트 (Flow Control & State)
+# ========================================================================================
 
-    @pytest.mark.asyncio
-    async def test_tc002_lifecycle_logging(self, extractor):
-        """[TC-002] extract 실행 시 시작(Starting)과 종료(completed) 로그가 기록된다."""
-        # Given
-        request = RequestDTO(job_id="valid", params={})
+@pytest.mark.asyncio
+async def test_flow_01_happy_path(extractor):
+    """[FLOW-01] 정상 흐름: Validate -> Fetch -> Create 순서 호출 확인"""
+    # Given
+    request = RequestDTO(job_id="job_123")
+    
+    # When
+    result = await extractor.extract(request)
+    
+    # Then
+    extractor.validate_mock.assert_called_once_with(request)
+    extractor.fetch_mock.assert_called_once_with(request)
+    extractor.create_mock.assert_called_once()
+    assert isinstance(result, ResponseDTO)
 
-        # When
+@pytest.mark.asyncio
+async def test_flow_02_validation_failure_stops_execution(extractor):
+    """[FLOW-02] Validate 실패 시 Fetch 단계로 넘어가지 않아야 함 (Flow Control)"""
+    # Given
+    extractor.validate_mock.side_effect = ExtractorError("Validation Failed")
+    request = RequestDTO(job_id="job_fail")
+    
+    # When
+    with pytest.raises(ExtractorError, match="Validation Failed"):
         await extractor.extract(request)
+    
+    # Then
+    extractor.fetch_mock.assert_not_called()
+    extractor.create_mock.assert_not_called()
 
-        # Then
-        info_calls = [args[0][0] for args in extractor.logger.info.call_args_list]
-        assert any("Starting" in log for log in info_calls)
-        assert any("completed" in log for log in info_calls)
+@pytest.mark.asyncio
+async def test_flow_03_statelessness(extractor):
+    """[FLOW-03] 단일 인스턴스로 여러 요청 처리 시 상태 독립성 유지"""
+    # Given
+    req1 = RequestDTO(job_id="job_A")
+    req2 = RequestDTO(job_id="job_B")
+    
+    # Side effect: 호출마다 다른 데이터 반환
+    extractor.fetch_mock.side_effect = ["data_A", "data_B"]
+    
+    # When
+    await extractor.extract(req1)
+    await extractor.extract(req2)
+    
+    # Then
+    assert extractor.fetch_mock.call_count == 2
+    # [Fix] pytest.call -> call (unittest.mock)
+    extractor.fetch_mock.assert_has_calls([call(req1), call(req2)])
 
-    # ==========================================
-    # Category: Unit (Config Validation)
-    # ==========================================
+# ========================================================================================
+# 3. 에러 핸들링 테스트 (Error Handling)
+# ========================================================================================
 
-    def test_tc003_init_fail_missing_config(self, mock_http_client):
-        """[TC-003] Config가 None으로 주입되면 초기화 단계에서 ExtractorError가 발생한다."""
-        # Given
-        config = None
-
-        # When & Then
-        with patch(TARGET_LOG_MANAGER):
-            with pytest.raises(ExtractorError, match="'AppConfig' cannot be None"):
-                ConcreteMockExtractor(mock_http_client, config)
-
-    def test_tc004_init_success(self, mock_http_client, mock_config):
-        """[TC-004] 유효한 Client와 Config 주입 시 인스턴스가 정상 생성된다."""
-        # Given
-        config = mock_config
-
-        # When
-        with patch(TARGET_LOG_MANAGER):
-            instance = ConcreteMockExtractor(mock_http_client, config)
-        
-        # Then
-        assert instance.config == config
-        assert instance.http_client == mock_http_client
-
-    # ==========================================
-    # Category: Boundary & Null Safety
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc005_null_request_safety(self, extractor):
-        """[TC-005] Request 객체가 None일 때 발생하는 에러를 ExtractorError로 래핑하여 안전하게 처리한다."""
-        # Given
-        request = None
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="Extraction failed"):
-            await extractor.extract(request)
-
-    @pytest.mark.asyncio
-    async def test_tc006_empty_raw_data(self, extractor):
-        """[TC-006] _fetch 단계에서 None이 반환되어도 에러 없이 _create 단계로 전달된다."""
-        # Given
-        request = RequestDTO(job_id="valid", params={})
-        extractor._fetch_raw_data.return_value = None
-
-        # When
+@pytest.mark.asyncio
+async def test_err_01_network_error_wrapping(extractor, mock_logger):
+    """[ERR-01] NetworkError 발생 시 로그 ERROR 기록 및 ExtractorError 래핑"""
+    # Given
+    extractor.fetch_mock.side_effect = NetworkError("Connection Timeout")
+    request = RequestDTO(job_id="job_net")
+    
+    # When
+    with pytest.raises(ExtractorError) as exc_info:
         await extractor.extract(request)
+    
+    # Then
+    assert "Network failure" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, NetworkError)
+    mock_logger.error.assert_called_with("Network error during extraction: Connection Timeout")
 
-        # Then
-        extractor._create_response.assert_called_once_with(None)
-
-    # ==========================================
-    # Category: Exception (Request & Policy)
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc007_validation_error_reraise(self, extractor):
-        """[TC-007] _validate 단계에서 ExtractorError 발생 시 경고 로그 후 재발생(Re-raise)시킨다."""
-        # Given
-        request = RequestDTO(job_id="invalid", params={})
-        extractor._validate_request.side_effect = ExtractorError("Policy Violation")
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="Policy Violation"):
-            await extractor.extract(request)
-        
-        # Then (Isolation Check)
-        extractor._fetch_raw_data.assert_not_called()
-        extractor.logger.warning.assert_called()
-
-    @pytest.mark.asyncio
-    async def test_tc008_network_error_isolation(self, extractor):
-        """[TC-008] _fetch 중 NetworkError 발생 시 ExtractorError로 변환하고 에러 로그를 남긴다."""
-        # Given
-        request = RequestDTO(job_id="valid", params={})
-        network_error = NetworkError("Connection Refused")
-        extractor._fetch_raw_data.side_effect = network_error
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="Network failure") as exc_info:
-            await extractor.extract(request)
-
-        # Then (Chaining Check)
-        assert exc_info.value.__cause__ is network_error
-        extractor.logger.error.assert_called()
-
-    # ==========================================
-    # Category: Exception (Response Logic)
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc009_packaging_error_reraise(self, extractor):
-        """[TC-009] _create 중 ExtractorError 발생 시 경고 로그 후 재발생시킨다."""
-        # Given
-        request = RequestDTO(job_id="valid", params={})
-        extractor._create_response.side_effect = ExtractorError("Packaging Failed")
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="Packaging Failed"):
-            await extractor.extract(request)
-        
-        # Then
-        extractor.logger.warning.assert_called()
-
-    @pytest.mark.asyncio
-    async def test_tc010_uncaught_exception_safety(self, extractor):
-        """[TC-010] 예상치 못한 버그(ValueError) 발생 시 Stack Trace와 함께 ExtractorError로 래핑한다."""
-        # Given
-        request = RequestDTO(job_id="bug", params={})
-        extractor._fetch_raw_data.side_effect = ValueError("Unexpected Bug")
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="Extraction failed"):
-            await extractor.extract(request)
-
-        # Then
-        args, kwargs = extractor.logger.error.call_args
-        assert kwargs.get('exc_info') is True
-
-    # ==========================================
-    # Category: Resource & State
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc011_config_immutability(self, extractor):
-        """[TC-011] extract 실행 도중 주입된 Config 객체의 내용이 변경되지 않음을 보장한다."""
-        # Given
-        request = RequestDTO(job_id="valid", params={})
-        original_policy = extractor.config.extraction_policy.copy()
-
-        # When
+@pytest.mark.asyncio
+async def test_err_02_domain_error_propagation(extractor, mock_logger):
+    """[ERR-02] ExtractorError 발생 시 로그 WARNING 기록 및 그대로 전파"""
+    # Given
+    origin_error = ExtractorError("Business Logic Fail")
+    extractor.fetch_mock.side_effect = origin_error
+    request = RequestDTO(job_id="job_biz")
+    
+    # When
+    with pytest.raises(ExtractorError) as exc_info:
         await extractor.extract(request)
+    
+    # Then
+    assert exc_info.value is origin_error
+    mock_logger.warning.assert_called_with("Extraction logic failed: Business Logic Fail")
 
-        # Then
-        assert extractor.config.extraction_policy == original_policy
-
-    @pytest.mark.asyncio
-    async def test_tc012_execution_sequence(self, extractor):
-        """[TC-012] Validate가 성공하면 즉시 Fetch가 호출되는 실행 순서를 보장한다."""
-        # Given
-        request = RequestDTO(job_id="valid", params={})
-        
-        manager = MagicMock()
-        manager.attach_mock(extractor._validate_request, 'validate')
-        manager.attach_mock(extractor._fetch_raw_data, 'fetch')
-        manager.attach_mock(extractor._create_response, 'create')
-
-        # When
+@pytest.mark.asyncio
+async def test_err_03_unknown_exception_handling(extractor, mock_logger):
+    """[ERR-03] 알 수 없는 예외(KeyError 등) 발생 시 로그 ERROR(Stack Trace) 및 래핑"""
+    # Given
+    extractor.fetch_mock.side_effect = KeyError("Unexpected Key")
+    request = RequestDTO(job_id="job_bug")
+    
+    # When
+    with pytest.raises(ExtractorError, match="Extraction failed"):
         await extractor.extract(request)
+    
+    # Then
+    mock_logger.error.assert_called_with(
+        "Unexpected error during extraction: 'Unexpected Key'", 
+        exc_info=True
+    )
 
-        # Then
-        expected_calls = [
-            call.validate(request),
-            call.fetch(request),
-            call.create(ANY)
-        ]
-        manager.assert_has_calls(expected_calls, any_order=False)
+# ========================================================================================
+# 4. 데이터 검증 및 로깅 테스트 (Data & Logging)
+# ========================================================================================
+
+@pytest.mark.asyncio
+async def test_data_01_response_packaging(extractor):
+    """[DATA-01] _create_response가 반환한 DTO가 최종 반환되는지 확인"""
+    # Given
+    expected_response = ResponseDTO(data={"valid": True})
+    extractor.create_mock.return_value = expected_response
+    request = RequestDTO(job_id="job_data")
+    
+    # When
+    result = await extractor.extract(request)
+    
+    # Then
+    assert result is expected_response
+    assert result.data == {"valid": True}
+
+@pytest.mark.asyncio
+async def test_log_01_logging_sequence(extractor, mock_logger):
+    """[LOG-01] 정상 실행 시 시작/종료 로그가 INFO 레벨로 기록되는지 확인"""
+    # Given
+    request = RequestDTO(job_id="job_log")
+    
+    # When
+    await extractor.extract(request)
+    
+    # Then
+    mock_logger.info.assert_any_call("Starting extraction task. Job: job_log")
+    mock_logger.info.assert_any_call("Extraction completed successfully. Job: job_log")

--- a/apps/data-pipeline/tests/unit/extractor/providers/ecos_extractor_test.py
+++ b/apps/data-pipeline/tests/unit/extractor/providers/ecos_extractor_test.py
@@ -1,284 +1,255 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Dict
 
-# --------------------------------------------------------------------------
-# Import Real Objects (DTO) & Target Class
-# --------------------------------------------------------------------------
+# [Target Modules]
 from src.extractor.providers.ecos_extractor import ECOSExtractor
 from src.extractor.domain.dtos import RequestDTO, ResponseDTO
 from src.extractor.domain.exceptions import ExtractorError
 from src.extractor.domain.interfaces import IHttpClient
-from src.common.config import AppConfig 
+from src.common.config import AppConfig
 
-# --------------------------------------------------------------------------
-# 0. Constants & Configuration
-# --------------------------------------------------------------------------
+# ========================================================================================
+# [Mocks & Stubs] 외부 의존성 격리를 위한 모의 객체
+# ========================================================================================
 
-# 로그 매니저 경로 (AbstractExtractor 초기화 시 파일 I/O 유발 방지)
-TARGET_LOG_MANAGER = "src.extractor.providers.abstract_extractor.LogManager"
+class MockSecretStr:
+    """Pydantic SecretStr 동작 모방"""
+    def __init__(self, value: str):
+        self._value = value
+    
+    def get_secret_value(self) -> str:
+        return self._value
 
-# --------------------------------------------------------------------------
-# 1. Fixtures (Test Environment Setup)
-# --------------------------------------------------------------------------
+class MockJobPolicy:
+    """Config 내 JobPolicy 객체 모방"""
+    def __init__(self, provider: str = "ECOS", path: str = "StatisticSearch", params: Dict = None):
+        self.provider = provider
+        self.path = path
+        self.params = params or {
+            "stat_code": "100Y",
+            "cycle": "D",
+            "item_code1": "0001"
+        }
+
+# ========================================================================================
+# [Fixtures] 테스트 환경 설정
+# ========================================================================================
+
+@pytest.fixture(autouse=True)
+def mock_logger():
+    """LogManager 초기화 시 전역 Config 참조 방지 및 데코레이터 Pass-through 처리"""
+    with patch("src.common.log.LogManager.get_logger") as mock_get_logger, \
+         patch("src.extractor.providers.ecos_extractor.log_decorator") as mock_log_dec, \
+         patch("src.extractor.providers.ecos_extractor.retry") as mock_retry_dec, \
+         patch("src.extractor.providers.ecos_extractor.rate_limit") as mock_rate_dec:
+        
+        mock_get_logger.return_value = MagicMock()
+        passthrough = lambda *args, **kwargs: lambda func: func
+        mock_log_dec.side_effect = passthrough
+        mock_retry_dec.side_effect = passthrough
+        mock_rate_dec.side_effect = passthrough
+        yield
 
 @pytest.fixture
 def mock_http_client():
-    """[IHttpClient Mock] 외부 네트워크 통신 담당"""
     client = MagicMock(spec=IHttpClient)
     client.get = AsyncMock()
     return client
 
 @pytest.fixture
 def mock_config():
-    """[AppConfig Mock] 파일 시스템 의존성 제거 및 ECOS 설정 주입"""
-    # Critical Fix: spec=AppConfig 제거. 
-    # spec을 사용하면 동적으로 속성(ecos)을 추가할 때 AttributeError가 발생할 수 있습니다.
-    config = MagicMock() 
-    
-    # ECOS 기본 설정 (Base URL, API Key)
-    # MagicMock은 속성에 처음 접근할 때 자동으로 자식 Mock을 생성합니다.
-    config.ecos.base_url = "http://api.ecos.bok.or.kr"
-    config.ecos.api_key.get_secret_value.return_value = "TEST_API_KEY"
-    
-    # 기본 정책 설정 (Happy Path용)
-    valid_policy = MagicMock()
-    valid_policy.provider = "ECOS"
-    valid_policy.path = "/StatisticSearch"
-    valid_policy.params = {
-        "stat_code": "100Y",
-        "cycle": "D",
-        "item_code1": "0001"
-    }
-    
+    config = MagicMock(spec=AppConfig)
+    config.ecos = MagicMock()
+    config.ecos.base_url = "https://ecos.bok.or.kr/api"
+    config.ecos.api_key = MockSecretStr("test_api_key")
     config.extraction_policy = {
-        "ecos_job": valid_policy
+        "job_valid": MockJobPolicy(),
+        "job_kis": MockJobPolicy(provider="KIS"),
     }
     return config
 
 @pytest.fixture
 def extractor(mock_http_client, mock_config):
-    """
-    [System Under Test]
-    ECOSExtractor의 인스턴스입니다.
-    부모 클래스(AbstractExtractor)의 LogManager를 Patch하여 초기화 시 로깅 로직을 무력화합니다.
-    """
-    with patch(TARGET_LOG_MANAGER) as MockLogManager:
-        # Logger Mock 생성 (호출 검증용)
-        mock_logger_instance = MagicMock()
-        MockLogManager.get_logger.return_value = mock_logger_instance
-        
-        # 인스턴스 생성
-        instance = ECOSExtractor(mock_http_client, mock_config)
-        return instance
+    return ECOSExtractor(mock_http_client, mock_config)
 
-# --------------------------------------------------------------------------
-# 2. Test Cases
-# --------------------------------------------------------------------------
+# ========================================================================================
+# [INIT] 초기화 테스트 (Initialization)
+# ========================================================================================
 
-class TestECOSExtractor:
-    
-    # ==========================================
-    # Category: Unit (Happy Path & Logic)
-    # ==========================================
+def test_init_01_base_url_empty(mock_http_client, mock_config):
+    """[INIT-01] ecos.base_url이 비어있는 설정 객체 -> ExtractorError"""
+    mock_config.ecos.base_url = ""
+    with pytest.raises(ExtractorError, match="'ecos.base_url' is empty"):
+        ECOSExtractor(mock_http_client, mock_config)
 
-    @pytest.mark.asyncio
-    async def test_tc001_happy_path_success(self, extractor, mock_http_client):
-        """[TC-001] 정상 Config, 유효 Policy, 정상 응답 -> INFO-000 성공 처리 및 DTO 반환"""
-        # Given
-        request = RequestDTO(
-            job_id="ecos_job", 
-            params={"start_date": "20240101", "end_date": "20240102"}
-        )
-        
-        # ECOS 정상 응답 구조 (Service Name -> RESULT -> CODE)
-        mock_response = {
-            "StatisticSearch": {
-                "list_total_count": 5,
-                "row": [{"TIME": "20240101", "DATA_VALUE": "100"}],
-                "RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."}
-            }
+def test_init_02_api_key_missing(mock_http_client, mock_config):
+    """[INIT-02] ecos.api_key가 없는 설정 객체 -> ExtractorError"""
+    mock_config.ecos.api_key = None
+    with pytest.raises(ExtractorError, match="'ecos.api_key' is missing"):
+        ECOSExtractor(mock_http_client, mock_config)
+
+def test_init_03_valid_init(extractor):
+    """[INIT-03] 유효한 설정(URL, Key 포함) 객체 -> 인스턴스 정상 생성"""
+    assert isinstance(extractor, ECOSExtractor)
+
+# ========================================================================================
+# [REQ] 요청 검증 테스트 (Validation - MC/DC)
+# ========================================================================================
+
+def test_req_01_missing_job_id(extractor):
+    """[REQ-01] job_id가 없는 요청 객체 -> ExtractorError"""
+    request = RequestDTO(job_id=None) # type: ignore
+    with pytest.raises(ExtractorError, match="'job_id' is mandatory"):
+        extractor._validate_request(request)
+
+def test_req_02_policy_not_found(extractor):
+    """[REQ-02] 설정 파일에 정의되지 않은 job_id 요청 -> ExtractorError"""
+    request = RequestDTO(job_id="job_unknown")
+    with pytest.raises(ExtractorError, match="Policy not found"):
+        extractor._validate_request(request)
+
+def test_req_03_provider_mismatch(extractor):
+    """[REQ-03] Provider가 'KIS'로 설정된 정책 요청 -> ExtractorError"""
+    request = RequestDTO(job_id="job_kis")
+    with pytest.raises(ExtractorError, match="Provider Mismatch"):
+        extractor._validate_request(request)
+
+def test_req_04_missing_date_params(extractor):
+    """[REQ-04] start_date 파라미터가 누락됨 -> ExtractorError"""
+    request = RequestDTO(job_id="job_valid", params={"end_date": "20230101"})
+    with pytest.raises(ExtractorError, match="'start_date' and 'end_date' are mandatory"):
+        extractor._validate_request(request)
+
+# ========================================================================================
+# [FLOW] 정상 흐름 테스트 (Functional)
+# ========================================================================================
+
+@pytest.mark.asyncio
+async def test_flow_01_happy_path(extractor, mock_http_client):
+    """[FLOW-01] 정상 정책, 서비스 내 INFO-000 응답 -> ResponseDTO 반환 및 URL 검증"""
+    # Given
+    request = RequestDTO(job_id="job_valid", params={"start_date": "20230101", "end_date": "20230131"})
+    mock_response = {
+        "StatisticSearch": {
+            "list_total_count": 1,
+            "row": [{"TIME": "2023", "DATA_VALUE": "100"}],
+            "RESULT": {"CODE": "INFO-000", "MESSAGE": "Success"}
         }
-        mock_http_client.get.return_value = mock_response
+    }
+    mock_http_client.get.return_value = mock_response
+    
+    # When
+    response = await extractor.extract(request)
+    
+    # Then
+    assert isinstance(response, ResponseDTO)
+    assert response.data == mock_response
+    assert response.meta["job_id"] == "job_valid"
+    
+    # ECOS Path Variable URL Construction Check
+    expected_url = (
+        "https://ecos.bok.or.kr/api/StatisticSearch/"
+        "test_api_key/json/kr/1/100000/"
+        "100Y/D/20230101/20230131/0001"
+    )
+    mock_http_client.get.assert_called_once_with(expected_url)
 
-        # When
-        response = await extractor.extract(request)
+# ========================================================================================
+# [DATA] 데이터 안정성 및 응답 구조 테스트 (Data Parsing)
+# ========================================================================================
 
-        # Then
-        assert response.meta["status"] == "success"
-        assert response.meta["source"] == "ECOS"
-        assert response.data == mock_response
-        mock_http_client.get.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_tc002_url_construction_strict_path(self, extractor, mock_http_client):
-        """[TC-002] ECOS URL Path 조립 로직 검증 (순서 엄격 준수: Key/Type/Lang/Start/End/...)"""
-        # Given
-        request = RequestDTO(
-            job_id="ecos_job", 
-            params={"start_date": "20240101", "end_date": "20240131"}
-        )
-        # 응답은 성공으로 가정 (URL 확인이 주 목적)
-        mock_http_client.get.return_value = {"StatisticSearch": {"RESULT": {"CODE": "INFO-000"}}}
-
-        # When
+@pytest.mark.asyncio
+async def test_data_01_root_level_failure(extractor, mock_http_client):
+    """[DATA-01] Root 레벨에 RESULT.CODE='INFO-200' -> ExtractorError"""
+    mock_response = {"RESULT": {"CODE": "INFO-200", "MESSAGE": "Limit Exceeded"}}
+    mock_http_client.get.return_value = mock_response
+    request = RequestDTO(job_id="job_valid", params={"start_date": "20230101", "end_date": "20230102"})
+    
+    with pytest.raises(ExtractorError, match="ECOS API Failed"):
         await extractor.extract(request)
 
-        # Then
-        # Expected Format: {Base}/{Path}/{Key}/json/kr/1/100000/{Stat}/{Cycle}/{Start}/{End}/{Item}
-        expected_url = (
-            "http://api.ecos.bok.or.kr/StatisticSearch/"
-            "TEST_API_KEY/json/kr/1/100000/"
-            "100Y/D/20240101/20240131/0001"
-        )
-        
-        actual_url = mock_http_client.get.call_args[0][0] # get 메서드의 첫 번째 인자(url) 확인
-        assert actual_url == expected_url
+@pytest.mark.asyncio
+async def test_data_02_service_key_missing(extractor, mock_http_client):
+    """[DATA-02] Root에 정책 경로(StatisticSearch) 없음 -> ExtractorError"""
+    mock_response = {"WrongServiceKey": {"row": []}}
+    mock_http_client.get.return_value = mock_response
+    request = RequestDTO(job_id="job_valid", params={"start_date": "20230101", "end_date": "20230102"})
+    
+    with pytest.raises(ExtractorError, match="Invalid ECOS Response"):
+        await extractor.extract(request)
 
-    # ==========================================
-    # Category: Unit (Config Validation)
-    # ==========================================
+@pytest.mark.asyncio
+async def test_data_03_inner_level_failure(extractor, mock_http_client):
+    """[DATA-03] 서비스 내 RESULT.CODE='INFO-200' -> ExtractorError"""
+    mock_response = {"StatisticSearch": {"RESULT": {"CODE": "INFO-200", "MESSAGE": "No Data"}}}
+    mock_http_client.get.return_value = mock_response
+    request = RequestDTO(job_id="job_valid", params={"start_date": "20230101", "end_date": "20230102"})
+    
+    with pytest.raises(ExtractorError, match="ECOS API Failed"):
+        await extractor.extract(request)
 
-    def test_tc003_config_empty_base_url(self, mock_http_client, mock_config):
-        """[TC-003] Config의 base_url이 비어있으면 초기화 시 ExtractorError가 발생한다."""
-        # Given
-        mock_config.ecos.base_url = ""
-
-        # When & Then
-        with patch(TARGET_LOG_MANAGER):
-            with pytest.raises(ExtractorError, match="Critical Config Error.*base_url"):
-                ECOSExtractor(mock_http_client, mock_config)
-
-    def test_tc004_config_missing_api_key(self, mock_http_client, mock_config):
-        """[TC-004] Config의 api_key가 누락되면 초기화 시 ExtractorError가 발생한다."""
-        # Given
-        mock_config.ecos.api_key = None
-
-        # When & Then
-        with patch(TARGET_LOG_MANAGER):
-            with pytest.raises(ExtractorError, match="Critical Config Error.*api_key"):
-                ECOSExtractor(mock_http_client, mock_config)
-
-    # ==========================================
-    # Category: Exception (Request Validation)
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc005_invalid_request_missing_job_id(self, extractor):
-        """[TC-005] job_id가 누락되면 ExtractorError가 발생한다."""
-        # Given
-        request = RequestDTO(job_id=None)
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="Invalid Request: 'job_id' is mandatory"):
-            await extractor.extract(request)
-
-    @pytest.mark.asyncio
-    async def test_tc006_invalid_request_missing_start_date(self, extractor):
-        """[TC-006] start_date 파라미터가 누락되면 ExtractorError가 발생한다 (ECOS 필수)."""
-        # Given
-        request = RequestDTO(job_id="ecos_job", params={"end_date": "20240101"})
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="mandatory for ECOS"):
-            await extractor.extract(request)
-
-    @pytest.mark.asyncio
-    async def test_tc007_invalid_request_missing_end_date(self, extractor):
-        """[TC-007] end_date 파라미터가 누락되면 ExtractorError가 발생한다 (ECOS 필수)."""
-        # Given
-        request = RequestDTO(job_id="ecos_job", params={"start_date": "20240101"})
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="mandatory for ECOS"):
-            await extractor.extract(request)
-
-    # ==========================================
-    # Category: Exception (Policy Validation)
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc008_config_unknown_policy(self, extractor):
-        """[TC-008] 요청한 job_id가 Config 정책에 없으면 ExtractorError가 발생한다."""
-        # Given
-        request = RequestDTO(job_id="unknown_job", params={"start_date": "2024", "end_date": "2024"})
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="Policy not found"):
-            await extractor.extract(request)
-
-    @pytest.mark.asyncio
-    async def test_tc009_config_provider_mismatch(self, extractor, mock_config):
-        """[TC-009] 해당 Policy의 Provider가 ECOS가 아니면 ExtractorError가 발생한다."""
-        # Given
-        kis_policy = MagicMock()
-        kis_policy.provider = "KIS"
-        mock_config.extraction_policy["kis_job"] = kis_policy
-        
-        request = RequestDTO(job_id="kis_job")
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="Provider Mismatch"):
-            await extractor.extract(request)
-
-    # ==========================================
-    # Category: Exception (Response Handling)
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc010_api_root_failure(self, extractor, mock_http_client):
-        """[TC-010] API 응답 Root 레벨 에러(인증 실패 등) 발생 시 ExtractorError로 처리한다."""
-        # Given
-        request = RequestDTO(job_id="ecos_job", params={"start_date": "2024", "end_date": "2024"})
-        # 인증 에러 예시: 서비스 키가 없을 때 Root에 바로 RESULT가 옴
-        mock_http_client.get.return_value = {
-            "RESULT": {"CODE": "INFO-200", "MESSAGE": "해당하는 데이터가 없습니다."}
+@pytest.mark.asyncio
+async def test_data_04_root_result_success_ignored(extractor, mock_http_client):
+    """[DATA-04] Root RESULT 존재하나 성공(INFO-000) -> 정상 반환 (방어 로직)"""
+    # Given: Root에 성공 코드가 있고, 실제 데이터도 존재하는 복합 응답
+    request = RequestDTO(job_id="job_valid", params={"start_date": "20230101", "end_date": "20230131"})
+    mock_response = {
+        "RESULT": {"CODE": "INFO-000", "MESSAGE": "Root Success"},
+        "StatisticSearch": {
+            "list_total_count": 1,
+            "row": [{"TIME": "2023", "DATA_VALUE": "100"}],
+            "RESULT": {"CODE": "INFO-000", "MESSAGE": "Success"}
         }
+    }
+    mock_http_client.get.return_value = mock_response
 
-        # When & Then
-        with pytest.raises(ExtractorError, match="ECOS API Failed"):
-            await extractor.extract(request)
+    # When
+    response = await extractor.extract(request)
 
-    @pytest.mark.asyncio
-    async def test_tc011_api_business_failure(self, extractor, mock_http_client):
-        """[TC-011] API 응답 서비스 레벨 에러(데이터 없음 등) 발생 시 ExtractorError로 처리한다."""
-        # Given
-        request = RequestDTO(job_id="ecos_job", params={"start_date": "2024", "end_date": "2024"})
-        # 서비스 키 내부에 에러가 있는 경우
-        mock_http_client.get.return_value = {
-            "StatisticSearch": {
-                "RESULT": {"CODE": "INFO-200", "MESSAGE": "No Data"}
-            }
+    # Then
+    assert response.data == mock_response
+    assert response.meta["status"] == "success"
+
+@pytest.mark.asyncio
+async def test_data_05_inner_result_missing(extractor, mock_http_client):
+    """[DATA-05] 서비스 내 RESULT 키 자체가 누락됨 -> 정상 반환 (암시적 성공)"""
+    # Given: 필수 메타데이터인 RESULT가 누락되었으나 데이터는 있는 상황
+    request = RequestDTO(job_id="job_valid", params={"start_date": "20230101", "end_date": "20230131"})
+    mock_response = {
+        "StatisticSearch": {
+            "list_total_count": 1,
+            "row": [{"TIME": "2023", "DATA_VALUE": "100"}]
+            # RESULT key missing
         }
+    }
+    mock_http_client.get.return_value = mock_response
 
-        # When & Then
-        with pytest.raises(ExtractorError, match="ECOS API Failed"):
-            await extractor.extract(request)
+    # When
+    response = await extractor.extract(request)
 
-    @pytest.mark.asyncio
-    async def test_tc012_invalid_response_structure(self, extractor, mock_http_client):
-        """[TC-012] API 응답에 예상된 서비스명(Key)이 없으면 구조 불일치로 ExtractorError가 발생한다."""
-        # Given
-        request = RequestDTO(job_id="ecos_job", params={"start_date": "2024", "end_date": "2024"})
-        # Policy path는 'StatisticSearch'인데 엉뚱한 키가 온 경우
-        mock_http_client.get.return_value = {
-            "WrongServiceKey": {"row": []}
-        }
+    # Then
+    assert response.data == mock_response
 
-        # When & Then
-        with pytest.raises(ExtractorError, match="Invalid ECOS Response"):
-            await extractor.extract(request)
+# ========================================================================================
+# [ERR] 예외 처리 테스트 (Exceptions)
+# ========================================================================================
 
-    # ==========================================
-    # Category: Resource & State
-    # ==========================================
+@pytest.mark.asyncio
+async def test_err_01_system_error_wrapping(extractor, mock_http_client):
+    """[ERR-01] HTTP 클라이언트가 ValueError 발생 -> ExtractorError로 래핑"""
+    mock_http_client.get.side_effect = ValueError("Network Timeout")
+    request = RequestDTO(job_id="job_valid", params={"start_date": "20230101", "end_date": "20230102"})
+    
+    with pytest.raises(ExtractorError, match="System Error"):
+        await extractor.extract(request)
 
-    @pytest.mark.asyncio
-    async def test_tc013_system_error_network(self, extractor, mock_http_client):
-        """[TC-013] HttpClient에서 네트워크 예외 발생 시 System Error로 래핑하여 던진다."""
-        # Given
-        request = RequestDTO(job_id="ecos_job", params={"start_date": "2024", "end_date": "2024"})
-        mock_http_client.get.side_effect = Exception("Connection Refused")
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="System Error: Connection Refused"):
-            await extractor.extract(request)
+@pytest.mark.asyncio
+async def test_err_02_reraise_extractor_error(extractor, mock_http_client):
+    """[ERR-02] 내부 로직에서 ExtractorError 발생 -> 그대로 전파"""
+    mock_http_client.get.side_effect = ExtractorError("Parsing Failed")
+    request = RequestDTO(job_id="job_valid", params={"start_date": "20230101", "end_date": "20230102"})
+    
+    with pytest.raises(ExtractorError, match="Parsing Failed"):
+        await extractor.extract(request)

--- a/apps/data-pipeline/tests/unit/extractor/providers/fred_extractor_test.py
+++ b/apps/data-pipeline/tests/unit/extractor/providers/fred_extractor_test.py
@@ -1,237 +1,247 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
-from datetime import datetime
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch, ANY
 
+# [Target Modules] 테스트 대상 및 의존성
+from src.extractor.providers.fred_extractor import FREDExtractor
 from src.extractor.domain.dtos import RequestDTO, ResponseDTO
 from src.extractor.domain.exceptions import ExtractorError
-from src.extractor.providers.fred_extractor import FREDExtractor
 
-# -------------------------------------------------------------------------
-# Mocks & Fixtures
-# -------------------------------------------------------------------------
+# ========================================================================================
+# [Fixtures] Common Test Environment Setup
+# ========================================================================================
+
+@pytest.fixture(autouse=True)
+def mock_logger():
+    """
+    [Auto-use Fixture]
+    LogManager 초기화 시 전역 Config를 로딩하는 부작용(Side Effect)을 차단합니다.
+    """
+    with patch("src.common.log.LogManager.get_logger") as mock_get:
+        mock_get.return_value = MagicMock()
+        yield mock_get
 
 @pytest.fixture
 def mock_http_client():
-    """IHttpClient Mock: 실제 네트워크 요청 차단 및 파라미터 검증용"""
+    """
+    [Dependency Mock] 비동기 HTTP 클라이언트 모방.
+    """
     client = MagicMock()
-    client.get = AsyncMock()
+    client.get = AsyncMock() # 비동기 메서드 모방
     return client
 
 @pytest.fixture
 def mock_config():
-    """AppConfig Mock: FRED 전용 설정 및 정책 주입"""
+    """
+    [Config Mock] 별도의 Helper Class 없이 MagicMock으로 복잡한 설정 객체를 모방합니다.
+    """
     config = MagicMock()
     
-    # 1. FRED 기본 설정 (Base URL & API Key)
-    config.fred.base_url = "https://api.stlouisfed.org"
-    # SecretStr 동작 모방: get_secret_value() 호출 시 평문 반환
-    config.fred.api_key.get_secret_value.return_value = "TEST_FRED_KEY"
+    # 1. FRED 섹션 설정 (기본값 주입)
+    config.fred.base_url = "https://api.stlouisfed.org/fred"
+    config.fred.api_key.get_secret_value.return_value = "test_key" # SecretStr 동작 모방
     
-    # 2. 정책(Policy) 설정
-    # Case A: Normal Policy (series_id included)
-    normal_policy = MagicMock()
-    normal_policy.provider = "FRED"
-    normal_policy.path = "/fred/series/observations"
-    normal_policy.params = {"series_id": "GDP", "frequency": "q"} # Default Params
-    
-    # Case B: Policy without series_id (to test request injection)
-    flexible_policy = MagicMock()
-    flexible_policy.provider = "FRED"
-    flexible_policy.path = "/fred/series/observations"
-    flexible_policy.params = {"frequency": "m"} # series_id missing here
-    
-    # Case C: Provider Mismatch
-    kis_policy = MagicMock()
-    kis_policy.provider = "KIS" # Not FRED
-    
-    config.extraction_policy = {
-        "valid_job": normal_policy,
-        "flex_job": flexible_policy,
-        "kis_job": kis_policy
+    # 2. Policy 설정 (Dictionary 동작 에뮬레이션)
+    # 팩토리 함수로 Mock Policy 객체 생성
+    def make_policy(provider="FRED", params=None):
+        p = MagicMock()
+        p.provider = provider
+        p.params = params or {}
+        p.path = "/series/observations"
+        return p
+
+    # 테스트 시나리오별 정책 정의
+    policies = {
+        "JOB_01": make_policy(params={"series_id": "GDP"}),
+        "JOB_NO_PARAM": make_policy(params={}),
+        "JOB_KIS": make_policy(provider="KIS")
     }
+    
+    # 객체를 딕셔너리처럼 조회(.get, []) 할 수 있도록 side_effect 설정
+    config.extraction_policy.__getitem__.side_effect = policies.__getitem__
+    config.extraction_policy.get.side_effect = policies.get
+    
     return config
 
 @pytest.fixture
-def extractor(mock_http_client, mock_config):
-    """FREDExtractor 인스턴스 생성 (LogManager 의존성 제거)"""
-    
-    # Critical Fix: KIS 테스트와 동일하게 부모 클래스의 LogManager 호출을 무력화
-    with patch("src.extractor.providers.abstract_extractor.LogManager") as MockLogManager:
-        MockLogManager.get_logger.return_value = MagicMock()
-        
-        # FRED는 AuthStrategy가 필요 없으므로 http_client와 config만 주입
-        extractor_instance = FREDExtractor(mock_http_client, mock_config)
-        return extractor_instance
+def fred_extractor(mock_http_client, mock_config):
+    """[SUT] System Under Test: 테스트 대상 인스턴스"""
+    return FREDExtractor(mock_http_client, mock_config)
 
-# -------------------------------------------------------------------------
-# Test Cases (TC-001 ~ TC-013)
-# -------------------------------------------------------------------------
+# ========================================================================================
+# 1. 초기화 테스트 (Initialization & Configuration)
+# ========================================================================================
+
+def test_init_01_empty_base_url(mock_http_client, mock_config):
+    """[INIT-01] base_url이 비어있으면 초기화 단계에서 즉시 에러 발생 (Fail-Fast)"""
+    # Given: 잘못된 설정 (URL 누락)
+    mock_config.fred.base_url = ""
+    
+    # When & Then: 인스턴스 생성 시 예외 발생 검증
+    with pytest.raises(ExtractorError, match="base_url.*empty"):
+        FREDExtractor(mock_http_client, mock_config)
+
+def test_init_02_missing_api_key(mock_http_client, mock_config):
+    """[INIT-02] api_key가 None이면 초기화 실패"""
+    # Given: 잘못된 설정 (Key 누락)
+    mock_config.fred.api_key = None
+    
+    # When & Then
+    with pytest.raises(ExtractorError, match="api_key.*missing"):
+        FREDExtractor(mock_http_client, mock_config)
+
+def test_init_03_valid_init(fred_extractor):
+    """[INIT-03] 유효한 설정인 경우 인스턴스가 정상적으로 생성됨"""
+    # Then: Config가 정상적으로 주입되었는지 확인
+    assert fred_extractor.config.fred.base_url == "https://api.stlouisfed.org/fred"
+
+# ========================================================================================
+# 2. 유효성 검증 테스트 (Validation - Logic & MC/DC)
+# ========================================================================================
+
+def test_val_00_missing_job_id(fred_extractor):
+    """[VAL-00] Request에 job_id가 없는 경우 유효성 검증 실패 (Coverage Hole Patch)"""
+    # Given: Job ID가 없는 요청
+    request = RequestDTO(job_id="", params={})
+    
+    # When & Then: 필수 필드 누락 에러 확인
+    with pytest.raises(ExtractorError, match="'job_id' is mandatory"):
+        fred_extractor._validate_request(request)
+
+def test_val_01_policy_missing(fred_extractor):
+    """[VAL-01] Config에 정의되지 않은 job_id 요청 시 실패"""
+    # Given: 알 수 없는 Job ID
+    request = RequestDTO(job_id="UNKNOWN_JOB", params={})
+    
+    # When & Then: 정책 미존재 에러 확인
+    with pytest.raises(ExtractorError, match="Policy not found"):
+        fred_extractor._validate_request(request)
+
+def test_val_02_provider_mismatch(fred_extractor):
+    """[VAL-02] 해당 Policy의 Provider가 'FRED'가 아닌 경우 실패"""
+    # Given: KIS용 Job을 FRED 수집기에 요청
+    request = RequestDTO(job_id="JOB_KIS", params={})
+    
+    # When & Then: 제공자 불일치 에러 확인
+    with pytest.raises(ExtractorError, match="Provider Mismatch"):
+        fred_extractor._validate_request(request)
 
 @pytest.mark.asyncio
-async def test_tc_001_happy_path_success(extractor, mock_http_client):
-    """[TC-001] 정상 Config, Policy, 응답(No Error Msg) -> 성공"""
-    # Given
-    request = RequestDTO(job_id="valid_job")
-    mock_data = {"realtime_start": "2024-01-01", "observations": [{"value": "100"}]}
-    mock_http_client.get.return_value = mock_data
-
-    # When
-    response = await extractor.extract(request)
-
-    # Then
-    assert response.data == mock_data
-    assert response.meta["source"] == "FRED"
-    assert response.meta["status_code"] == "200" # FRED는 명시적 코드가 없으므로 200 가정
-    assert response.meta["job_id"] == "valid_job"
+async def test_val_03_mcdc_series_id_in_policy(fred_extractor, mock_http_client):
+    """[VAL-03] [MC/DC] series_id가 Policy에만 존재하는 경우 -> 성공"""
+    # Given: Policy에는 "GDP"가 있고, Request에는 없음
+    request = RequestDTO(job_id="JOB_01", params={})
+    mock_http_client.get.return_value = {"observations": []}
+    
+    # When: 추출 실행
+    await fred_extractor.extract(request)
+    
+    # Then: 에러 없이 API 호출이 발생했는지 확인
     mock_http_client.get.assert_called_once()
 
 @pytest.mark.asyncio
-async def test_tc_002_logic_param_merge_distinct(extractor, mock_http_client):
-    """[TC-002] Policy Param과 Request Param 병합 확인"""
+async def test_val_04_mcdc_series_id_in_request(fred_extractor, mock_http_client):
+    """[VAL-04] [MC/DC] series_id가 Request에만 존재하는 경우 -> 성공"""
+    # Given: Policy(JOB_NO_PARAM)에는 없고, Request 파라미터로 "CPI" 전달
+    request = RequestDTO(job_id="JOB_NO_PARAM", params={"series_id": "CPI"})
+    mock_http_client.get.return_value = {"observations": []}
+    
+    # When: 추출 실행
+    await fred_extractor.extract(request)
+    
+    # Then: 실제 API 호출 시 Request의 "CPI"가 사용되었는지 확인
+    call_kwargs = mock_http_client.get.call_args.kwargs
+    assert call_kwargs['params']['series_id'] == "CPI"
+
+def test_val_05_mcdc_series_id_missing(fred_extractor):
+    """[VAL-05] [MC/DC] series_id가 Policy와 Request 어디에도 없는 경우 -> 실패"""
+    # Given: 양쪽 모두 series_id 없음
+    request = RequestDTO(job_id="JOB_NO_PARAM", params={})
+    
+    # When & Then: 필수 파라미터 누락 에러 확인
+    with pytest.raises(ExtractorError, match="'series_id' is required"):
+        fred_extractor._validate_request(request)
+
+# ========================================================================================
+# 3. 실행 및 병합 테스트 (Execution & Data Merging)
+# ========================================================================================
+
+@pytest.mark.asyncio
+async def test_exec_01_param_merging(fred_extractor, mock_http_client):
+    """
+    [EXEC-01] 파라미터 병합 로직 검증
+    1. Request 파라미터가 Policy 파라미터보다 우선순위가 높은가?
+    2. 시스템 필수 파라미터(api_key, file_type)가 강제 주입되는가?
+    """
     # Given
-    # Policy: {'series_id': 'GDP', 'frequency': 'q'}
-    request = RequestDTO(job_id="valid_job", params={"observation_start": "2020-01-01"})
+    # Policy(JOB_01) params: {series_id: GDP}
+    # Request params: {frequency: m}
+    request = RequestDTO(job_id="JOB_01", params={"frequency": "m"})
     mock_http_client.get.return_value = {}
 
     # When
-    await extractor.extract(request)
+    await fred_extractor.extract(request)
 
     # Then
-    call_params = mock_http_client.get.call_args[1]["params"]
-    assert call_params["series_id"] == "GDP"
-    assert call_params["frequency"] == "q"
-    assert call_params["observation_start"] == "2020-01-01"
+    call_params = mock_http_client.get.call_args.kwargs['params']
+    assert call_params["series_id"] == "GDP"   # Policy 값 유지
+    assert call_params["frequency"] == "m"     # Request 값 병합됨
+    assert call_params["file_type"] == "json"  # 시스템 강제 주입 확인
+    assert call_params["api_key"] == "test_key" # API Key 주입 확인
 
 @pytest.mark.asyncio
-async def test_tc_003_logic_forced_json_injection(extractor, mock_http_client):
-    """[TC-003] Request가 xml을 요청해도 시스템이 json을 강제해야 함"""
+async def test_exec_02_metadata_injection(fred_extractor, mock_http_client):
+    """[EXEC-02] extract 메서드 오버라이딩을 통해 ResponseDTO에 job_id가 주입되는지 확인"""
     # Given
-    request = RequestDTO(job_id="valid_job", params={"file_type": "xml"})
-    mock_http_client.get.return_value = {}
+    request = RequestDTO(job_id="JOB_01", params={})
+    mock_http_client.get.return_value = {"observations": []}
 
     # When
-    await extractor.extract(request)
+    response = await fred_extractor.extract(request)
 
     # Then
-    call_params = mock_http_client.get.call_args[1]["params"]
-    assert call_params["file_type"] == "json" # Override Check
+    assert response.meta["job_id"] == "JOB_01"
+    assert response.meta["source"] == "FRED"
+
+# ========================================================================================
+# 4. 에러 처리 테스트 (Error Handling & Reliability)
+# ========================================================================================
 
 @pytest.mark.asyncio
-async def test_tc_004_logic_api_key_injection(extractor, mock_http_client):
-    """[TC-004] Config의 SecretKey가 평문으로 Query Param에 주입되어야 함"""
-    # Given
-    request = RequestDTO(job_id="valid_job")
-    mock_http_client.get.return_value = {}
-
-    # When
-    await extractor.extract(request)
-
-    # Then
-    call_params = mock_http_client.get.call_args[1]["params"]
-    assert call_params["api_key"] == "TEST_FRED_KEY"
-
-@pytest.mark.asyncio
-async def test_tc_005_boundary_series_id_in_request(extractor, mock_http_client):
-    """[TC-005] Policy에 series_id가 없어도 Request에 있으면 성공"""
-    # Given
-    # 'flex_job' policy has no series_id
-    request = RequestDTO(job_id="flex_job", params={"series_id": "CPI"})
-    mock_http_client.get.return_value = {}
-
-    # When
-    await extractor.extract(request)
-
-    # Then
-    call_params = mock_http_client.get.call_args[1]["params"]
-    assert call_params["series_id"] == "CPI"
-
-@pytest.mark.asyncio
-async def test_tc_006_boundary_empty_request_params(extractor, mock_http_client):
-    """[TC-006] Request Params가 비어있으면 Policy 기본값 사용"""
-    # Given
-    request = RequestDTO(job_id="valid_job", params={})
-    mock_http_client.get.return_value = {}
-
-    # When
-    await extractor.extract(request)
-
-    # Then
-    call_params = mock_http_client.get.call_args[1]["params"]
-    assert call_params["series_id"] == "GDP"
-
-def test_tc_007_config_empty_base_url(mock_http_client, mock_config):
-    """[TC-007] Config의 base_url이 비어있으면 초기화 시 에러"""
-    # Given
-    mock_config.fred.base_url = ""
-
-    # When & Then
-    with patch("src.extractor.providers.abstract_extractor.LogManager") as MockLogManager:
-        MockLogManager.get_logger.return_value = MagicMock()
-        with pytest.raises(ExtractorError, match="Critical Config Error"):
-            FREDExtractor(mock_http_client, mock_config)
-
-@pytest.mark.asyncio
-async def test_tc_008_error_missing_job_id(extractor):
-    """[TC-008] job_id 누락 시 ExtractorError"""
-    # Given
-    request = RequestDTO(job_id=None)
-
-    # When & Then
-    with pytest.raises(ExtractorError, match="Invalid Request: 'job_id' is mandatory"):
-        await extractor.extract(request)
-
-@pytest.mark.asyncio
-async def test_tc_009_error_unknown_policy(extractor):
-    """[TC-009] Config에 없는 job_id 요청 시 ExtractorError"""
-    # Given
-    request = RequestDTO(job_id="unknown_job")
-
-    # When & Then
-    with pytest.raises(ExtractorError, match="Policy not found"):
-        await extractor.extract(request)
-
-@pytest.mark.asyncio
-async def test_tc_010_error_provider_mismatch(extractor):
-    """[TC-010] Policy Provider가 FRED가 아님 -> ExtractorError"""
-    # Given
-    request = RequestDTO(job_id="kis_job") # Provider is KIS
-
-    # When & Then
-    with pytest.raises(ExtractorError, match="Provider Mismatch"):
-        await extractor.extract(request)
-
-@pytest.mark.asyncio
-async def test_tc_011_error_missing_series_id(extractor):
-    """[TC-011] Policy와 Request 모두 series_id 누락 -> ExtractorError"""
-    # Given
-    # 'flex_job' has no series_id in policy
-    request = RequestDTO(job_id="flex_job", params={}) 
-
-    # When & Then
-    with pytest.raises(ExtractorError, match="Missing Parameter: 'series_id' is required"):
-        await extractor.extract(request)
-
-@pytest.mark.asyncio
-async def test_tc_012_error_fred_business_failure(extractor, mock_http_client):
-    """[TC-012] HTTP 200이지만 Body에 error_message 포함 -> ExtractorError"""
-    # Given
-    request = RequestDTO(job_id="valid_job")
+async def test_err_01_logical_error_in_body(fred_extractor, mock_http_client):
+    """[ERR-01] HTTP 200 OK이지만 Body에 에러 메시지가 포함된 경우 (Logical Error)"""
+    # Given: FRED API 특유의 에러 응답 포맷
+    request = RequestDTO(job_id="JOB_01", params={})
     mock_http_client.get.return_value = {
         "error_code": 400,
-        "error_message": "Bad Request. The value for variable series_id cannot be found."
+        "error_message": "Bad Request"
     }
 
-    # When & Then
-    with pytest.raises(ExtractorError, match="FRED API Failed: Bad Request"):
-        await extractor.extract(request)
+    # When & Then: ExtractorError로 변환되어 던져지는지 확인
+    with pytest.raises(ExtractorError, match="FRED API Failed"):
+        await fred_extractor.extract(request)
 
 @pytest.mark.asyncio
-async def test_tc_013_error_system_failure(extractor, mock_http_client):
-    """[TC-013] HttpClient 네트워크 예외 발생 -> System Error로 래핑"""
-    # Given
-    request = RequestDTO(job_id="valid_job")
-    mock_http_client.get.side_effect = Exception("Connection Timeout")
+async def test_err_02_unexpected_exception_wrapping(fred_extractor, mock_http_client):
+    """[ERR-02] 내부 로직 수행 중 예상치 못한 시스템 에러 발생 시 래핑 처리"""
+    # Given: 예상치 못한 KeyError 발생
+    request = RequestDTO(job_id="JOB_01", params={})
+    mock_http_client.get.side_effect = KeyError("Unexpected")
 
-    # When & Then
-    with pytest.raises(ExtractorError, match="System Error: Connection Timeout"):
-        await extractor.extract(request)
+    # When & Then: System Error 메시지로 래핑 확인
+    with pytest.raises(ExtractorError, match="System Error"):
+        await fred_extractor.extract(request)
+
+@pytest.mark.asyncio
+async def test_err_03_retry_decorator_trigger(fred_extractor, mock_http_client):
+    """[ERR-03] 네트워크 타임아웃 발생 시 @retry 데코레이터 작동 여부 검증"""
+    # Given: 항상 실패하는 API 호출
+    request = RequestDTO(job_id="JOB_01", params={})
+    mock_http_client.get.side_effect = Exception("Network Timeout")
+    
+    # When & Then: 최종적으로 에러가 발생해야 함
+    with pytest.raises(ExtractorError, match="System Error"):
+        await fred_extractor.extract(request)
+    
+    # Assert: 재시도로 인해 호출 횟수가 1회 초과인지 확인
+    assert mock_http_client.get.call_count > 1

--- a/apps/data-pipeline/tests/unit/extractor/providers/kis_extractor_test.py
+++ b/apps/data-pipeline/tests/unit/extractor/providers/kis_extractor_test.py
@@ -1,235 +1,289 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
-from datetime import datetime
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch, ANY
+from typing import Dict, Any, Optional
 
+# [Target Modules] 테스트 대상 및 의존성 모듈
+from src.extractor.providers.kis_extractor import KISExtractor
 from src.extractor.domain.dtos import RequestDTO, ResponseDTO
 from src.extractor.domain.exceptions import ExtractorError
-from src.extractor.providers.kis_extractor import KISExtractor
+from src.extractor.domain.interfaces import IHttpClient, IAuthStrategy
+from src.common.config import AppConfig
 
-# -------------------------------------------------------------------------
-# Mocks & Fixtures
-# -------------------------------------------------------------------------
+# ========================================================================================
+# [Mocks & Stubs] 외부 의존성 격리를 위한 모의 객체 정의
+# ========================================================================================
+
+class MockSecretStr:
+    """Pydantic SecretStr 동작 모방을 위한 Stub (보안 필드 테스트용)"""
+    def __init__(self, value: str):
+        self._value = value
+    
+    def get_secret_value(self) -> str:
+        return self._value
+
+class MockJobPolicy:
+    """Config 내 JobPolicy 객체 모방 (설정 주입용 Stub)"""
+    def __init__(self, provider: str = "KIS", path: str = "/uapi/test", 
+                 params: Dict = None, tr_id: str = "TR_123"):
+        self.provider = provider
+        self.path = path
+        self.params = params or {}
+        self.tr_id = tr_id
+
+# ========================================================================================
+# [Fixtures] 테스트 환경 설정 및 의존성 주입
+# ========================================================================================
+
+@pytest.fixture(autouse=True)
+def mock_logger():
+    """
+    [Core Fix] 
+    LogManager가 초기화될 때 전역 AppConfig를 참조하여 발생하는 RuntimeError를 근본적으로 방지합니다.
+    LogManager.get_logger 메서드 자체를 Mocking하여 설정 로딩 프로세스를 우회합니다.
+    """
+    # src.common.log.LogManager.get_logger를 패치하여 실제 로거 초기화(Config 참조)를 막음
+    with patch("src.common.log.LogManager.get_logger") as mock_get_logger, \
+         patch("src.extractor.providers.kis_extractor.log_decorator") as mock_dec:
+        
+        # 1. 로거 호출 시 아무 동작도 하지 않는 MagicMock 반환
+        mock_get_logger.return_value = MagicMock()
+        
+        # 2. 데코레이터가 함수 실행을 방해하지 않도록 Pass-through(투명) 처리
+        # @log_decorator(...) 호출 시 -> 래퍼 함수 반환 -> 원본 함수 실행
+        mock_dec.side_effect = lambda *args, **kwargs: lambda func: func
+        
+        yield
 
 @pytest.fixture
 def mock_http_client():
-    """IHttpClient Mock: 실제 네트워크 요청 차단"""
-    client = MagicMock()
+    """비동기 HTTP 요청을 모방하는 Mock Client"""
+    client = MagicMock(spec=IHttpClient)
     client.get = AsyncMock()
     return client
 
 @pytest.fixture
 def mock_auth_strategy():
-    """IAuthStrategy Mock: 토큰 발급 로직 격리"""
-    strategy = MagicMock()
-    strategy.get_token = AsyncMock(return_value="Bearer TEST_TOKEN")
+    """인증 토큰 발급을 모방하는 Mock Strategy"""
+    strategy = MagicMock(spec=IAuthStrategy)
+    strategy.get_token = AsyncMock(return_value="Bearer test_token")
     return strategy
 
 @pytest.fixture
 def mock_config():
-    """AppConfig Mock: Pydantic 모델 대신 MagicMock 사용"""
-    config = MagicMock()
+    """정상 상태의 Config 객체 (Happy Path 기준)"""
+    config = MagicMock(spec=AppConfig)
     
-    # KIS 기본 설정
+    # KIS 섹션 설정
+    config.kis = MagicMock()
     config.kis.base_url = "https://api.kis.com"
-    config.kis.app_key.get_secret_value.return_value = "TEST_APP_KEY"
-    config.kis.app_secret.get_secret_value.return_value = "TEST_APP_SECRET"
+    config.kis.app_key = MockSecretStr("secret_key")
+    config.kis.app_secret = MockSecretStr("secret_val")
     
-    # 기본 정책 설정 (Happy Path용)
-    valid_policy = MagicMock()
-    valid_policy.provider = "KIS"
-    valid_policy.path = "/uapi/test"
-    valid_policy.tr_id = "TR1234"
-    valid_policy.params = {"count": 10} # Default Params
-    
+    # Extraction Policy (Dict 접근 허용)
     config.extraction_policy = {
-        "valid_job": valid_policy
+        "job_valid": MockJobPolicy(params={"static": "A"}),
+        "job_fred": MockJobPolicy(provider="FRED"),
+        "job_no_tr": MockJobPolicy(tr_id=None),  # type: ignore
     }
     return config
 
 @pytest.fixture
 def extractor(mock_http_client, mock_auth_strategy, mock_config):
-    """KISExtractor 인스턴스 생성 (LogManager 의존성 제거 포함)"""
-    
-    # Critical Fix: 
-    # AbstractExtractor가 초기화될 때 LogManager를 호출하면서 Global Config를 체크하는 것을 방지합니다.
-    # src.extractor.providers.abstract_extractor 모듈 내의 LogManager를 Mocking 합니다.
-    with patch("src.extractor.providers.abstract_extractor.LogManager") as MockLogManager:
-        # get_logger 호출 시 빈 MagicMock을 반환하여 로깅 로직을 무력화
-        MockLogManager.get_logger.return_value = MagicMock()
-        
-        # 의존성이 제거된 상태에서 인스턴스 생성
-        extractor_instance = KISExtractor(mock_http_client, mock_auth_strategy, mock_config)
-        return extractor_instance
+    """테스트 대상 인스턴스 (SUT: System Under Test)"""
+    return KISExtractor(mock_http_client, mock_auth_strategy, mock_config)
 
-# -------------------------------------------------------------------------
-# Test Cases (TC-001 ~ TC-013)
-# -------------------------------------------------------------------------
+# ========================================================================================
+# 1. 초기화 테스트 (Initialization)
+# ========================================================================================
+
+def test_init_01_critical_config_error(mock_http_client, mock_auth_strategy, mock_config):
+    """[INIT-01] kis.base_url이 비어있으면 초기화 단계에서 즉시 실패 (Fail-Fast)"""
+    # Given: 잘못된 설정 주입 (Base URL 누락)
+    mock_config.kis.base_url = ""
+    
+    # When & Then: 인스턴스 생성 시도 시 예외 발생 검증
+    with pytest.raises(ExtractorError, match="Critical Config Error"):
+        KISExtractor(mock_http_client, mock_auth_strategy, mock_config)
+
+# ========================================================================================
+# 2. 요청 검증 테스트 (Validation - MC/DC)
+# ========================================================================================
+
+def test_req_01_missing_job_id(extractor):
+    """[REQ-01] Request에 job_id가 없는 경우 유효성 검증 실패"""
+    # Given: job_id가 None인 잘못된 요청
+    request = RequestDTO(job_id=None) # type: ignore
+    
+    # When & Then: validate 수행 시 예외 발생
+    with pytest.raises(ExtractorError, match="'job_id' is mandatory"):
+        extractor._validate_request(request)
+
+def test_req_02_policy_not_found(extractor):
+    """[REQ-02] Config에 정의되지 않은 job_id 요청 시 실패"""
+    # Given: 정책에 없는 Job ID
+    request = RequestDTO(job_id="job_unknown")
+    
+    # When & Then: 정책 조회 실패 예외 확인
+    with pytest.raises(ExtractorError, match="Policy not found"):
+        extractor._validate_request(request)
+
+def test_req_03_provider_mismatch(extractor):
+    """[REQ-03] Provider가 KIS가 아닌 경우 (예: FRED) 요청 거부"""
+    # Given: Provider가 "FRED"로 설정된 Job
+    request = RequestDTO(job_id="job_fred")
+    
+    # When & Then: Provider 불일치 예외 확인
+    with pytest.raises(ExtractorError, match="Provider Mismatch"):
+        extractor._validate_request(request)
+
+def test_req_04_missing_tr_id(extractor):
+    """[REQ-04] 정책에 필수 필드 tr_id가 누락된 경우 실패"""
+    # Given: tr_id가 없는 Job Policy
+    request = RequestDTO(job_id="job_no_tr")
+    
+    # When & Then: 필수 설정 누락 예외 확인
+    with pytest.raises(ExtractorError, match="'tr_id' is missing"):
+        extractor._validate_request(request)
+
+# ========================================================================================
+# 3. 정상 흐름 및 기능 테스트 (Functional & Flow)
+# ========================================================================================
 
 @pytest.mark.asyncio
-async def test_tc_001_happy_path_success(extractor, mock_http_client):
-    """[TC-001] 정상 Config, 유효 토큰, 정상 API 응답(rt_cd='0') -> 성공"""
-    # Given
-    request = RequestDTO(job_id="valid_job")
-    mock_data = {"rt_cd": "0", "msg1": "Success", "output": [1, 2, 3]}
-    mock_http_client.get.return_value = mock_data
-
-    # When
+async def test_flow_01_happy_path_e2e(extractor, mock_http_client):
+    """[FLOW-01] 정상 요청 -> 토큰 획득 -> API 호출 -> 응답 생성 확인 (Happy Path)"""
+    # Given: 정상 요청 및 Mock 응답 준비
+    request = RequestDTO(job_id="job_valid")
+    mock_response = {"rt_cd": "0", "msg1": "Success", "output": []}
+    mock_http_client.get.return_value = mock_response
+    
+    # When: 추출 실행
     response = await extractor.extract(request)
-
-    # Then
-    assert response.data == mock_data
-    assert response.meta["status_code"] == "0"
-    assert response.meta["source"] == "KIS"
+    
+    # Then: 응답 객체 구조 및 데이터 일치 여부 검증
+    assert isinstance(response, ResponseDTO)
+    assert response.data == mock_response
+    assert response.meta["job_id"] == "job_valid"
     mock_http_client.get.assert_called_once()
 
 @pytest.mark.asyncio
-async def test_tc_002_logic_param_merge_distinct(extractor, mock_http_client, mock_config):
-    """[TC-002] Policy Param과 Request Param 키가 다를 때 -> 병합됨"""
-    # Given
-    request = RequestDTO(job_id="valid_job", params={"date": "20240101"})
+async def test_flow_02_param_priority(extractor, mock_http_client):
+    """[FLOW-02] 파라미터 병합 시 Request Params가 Static Policy보다 우선순위 가짐"""
+    # Given: Policy={"static": "A"}, Request={"static": "B", "dynamic": "C"}
+    request = RequestDTO(job_id="job_valid", params={"static": "B", "dynamic": "C"})
     mock_http_client.get.return_value = {"rt_cd": "0"}
-
-    # When
-    await extractor.extract(request)
-
-    # Then
-    # call_args[1]은 kwargs (params=...)
-    call_params = mock_http_client.get.call_args[1]["params"]
-    assert call_params == {"count": 10, "date": "20240101"}
-
-@pytest.mark.asyncio
-async def test_tc_003_edge_param_override(extractor, mock_http_client):
-    """[TC-003] Policy Param과 Request Param 키가 같을 때 -> Request 우선"""
-    # Given
-    request = RequestDTO(job_id="valid_job", params={"count": 50})
-    mock_http_client.get.return_value = {"rt_cd": "0"}
-
-    # When
-    await extractor.extract(request)
-
-    # Then
-    call_params = mock_http_client.get.call_args[1]["params"]
-    assert call_params == {"count": 50}
-
-@pytest.mark.asyncio
-async def test_tc_004_edge_empty_request_params(extractor, mock_http_client):
-    """[TC-004] Request Params가 비어있음 -> Policy Param 사용"""
-    # Given
-    request = RequestDTO(job_id="valid_job", params={})
-    mock_http_client.get.return_value = {"rt_cd": "0"}
-
-    # When
-    await extractor.extract(request)
-
-    # Then
-    call_params = mock_http_client.get.call_args[1]["params"]
-    assert call_params == {"count": 10}
-
-@pytest.mark.asyncio
-async def test_tc_005_valid_missing_job_id(extractor):
-    """[TC-005] job_id 누락 -> ExtractorError"""
-    # Given
-    request = RequestDTO(job_id=None)
-
-    # When & Then
-    with pytest.raises(ExtractorError, match="Invalid Request: 'job_id' is mandatory"):
-        await extractor.extract(request)
-
-@pytest.mark.asyncio
-async def test_tc_006_edge_missing_rt_cd(extractor, mock_http_client):
-    """[TC-006] 응답 JSON에 rt_cd 필드 없음 -> ExtractorError"""
-    # Given
-    request = RequestDTO(job_id="valid_job")
-    mock_http_client.get.return_value = {"msg1": "ok", "output": []}
-
-    # When & Then
-    with pytest.raises(ExtractorError, match="KIS API Failed"):
-        await extractor.extract(request)
-
-def test_tc_007_config_empty_base_url(mock_http_client, mock_auth_strategy, mock_config):
-    """[TC-007] Config의 base_url이 비어있음 -> 초기화 시 ExtractorError"""
-    # Given
-    mock_config.kis.base_url = "" # Empty URL
-
-    # When & Then
-    # 여기서도 __init__ 호출 시 LogManager가 터지지 않도록 Patch 필요
-    with patch("src.extractor.providers.abstract_extractor.LogManager") as MockLogManager:
-        MockLogManager.get_logger.return_value = MagicMock()
-        
-        with pytest.raises(ExtractorError, match="Critical Config Error"):
-            KISExtractor(mock_http_client, mock_auth_strategy, mock_config)
-
-@pytest.mark.asyncio
-async def test_tc_008_config_unknown_policy(extractor):
-    """[TC-008] 요청한 job_id가 Config에 없음 -> ExtractorError"""
-    # Given
-    request = RequestDTO(job_id="unknown_job")
-
-    # When & Then
-    with pytest.raises(ExtractorError, match="Policy not found"):
-        await extractor.extract(request)
-
-@pytest.mark.asyncio
-async def test_tc_009_config_provider_mismatch(extractor, mock_config):
-    """[TC-009] Policy Provider가 KIS가 아님 -> ExtractorError"""
-    # Given
-    fred_policy = MagicMock()
-    fred_policy.provider = "FRED"
-    mock_config.extraction_policy["fred_job"] = fred_policy
     
-    request = RequestDTO(job_id="fred_job")
-
-    # When & Then
-    with pytest.raises(ExtractorError, match="Provider Mismatch"):
-        await extractor.extract(request)
-
-@pytest.mark.asyncio
-async def test_tc_010_config_missing_tr_id(extractor, mock_config):
-    """[TC-010] Policy에 tr_id 누락 -> ExtractorError"""
-    # Given
-    broken_policy = MagicMock()
-    broken_policy.provider = "KIS"
-    broken_policy.tr_id = None 
-    mock_config.extraction_policy["no_tr_id"] = broken_policy
-
-    request = RequestDTO(job_id="no_tr_id")
-
-    # When & Then
-    with pytest.raises(ExtractorError, match="'tr_id' is missing"):
-        await extractor.extract(request)
+    # When: 추출 실행
+    await extractor.extract(request)
+    
+    # Then: 실제 호출된 파라미터가 덮어씌워졌는지(Override) 확인
+    call_args = mock_http_client.get.call_args
+    merged_params = call_args.kwargs['params']
+    assert merged_params["static"] == "B"  # Policy 값 "A"가 "B"로 교체됨
+    assert merged_params["dynamic"] == "C" # 새로운 파라미터 추가됨
 
 @pytest.mark.asyncio
-async def test_tc_011_biz_api_failure(extractor, mock_http_client):
-    """[TC-011] API 응답이 rt_cd='1' (실패) -> ExtractorError"""
-    # Given
-    request = RequestDTO(job_id="valid_job")
-    mock_http_client.get.return_value = {"rt_cd": "1", "msg1": "Limit Exceeded"}
+async def test_flow_03_url_construction(extractor, mock_http_client, mock_config):
+    """[FLOW-03] Base URL과 Policy Path가 결합되어 완전한 URL 호출"""
+    # Given: 특정 URL 설정
+    mock_config.kis.base_url = "https://api.test.com"
+    mock_config.extraction_policy["job_valid"].path = "/v1/stock"
+    request = RequestDTO(job_id="job_valid")
+    mock_http_client.get.return_value = {"rt_cd": "0"}
+    
+    # When: 추출 실행
+    await extractor.extract(request)
+    
+    # Then: 결합된 URL로 호출되었는지 검증
+    expected_url = "https://api.test.com/v1/stock"
+    mock_http_client.get.assert_called_with(expected_url, headers=ANY, params=ANY)
 
-    # When & Then
-    with pytest.raises(ExtractorError) as exc_info:
+# ========================================================================================
+# 4. 보안 및 인증 테스트 (Security)
+# ========================================================================================
+
+@pytest.mark.asyncio
+async def test_sec_01_secret_decoding(extractor, mock_http_client):
+    """[SEC-01] SecretStr 타입의 키가 헤더에는 평문으로 복호화되어 주입됨"""
+    # Given: SecretStr로 감싸진 앱 키 설정 (Fixture 참조)
+    request = RequestDTO(job_id="job_valid")
+    mock_http_client.get.return_value = {"rt_cd": "0"}
+    
+    # When: 추출 실행
+    await extractor.extract(request)
+    
+    # Then: 헤더에 평문이 주입되었는지 확인
+    call_headers = mock_http_client.get.call_args.kwargs['headers']
+    assert call_headers["appkey"] == "secret_key"
+    assert call_headers["appsecret"] == "secret_val"
+    assert not isinstance(call_headers["appkey"], MockSecretStr)
+
+@pytest.mark.asyncio
+async def test_sec_02_token_injection(extractor, mock_http_client):
+    """[SEC-02] AuthStrategy에서 발급받은 토큰이 Authorization 헤더에 주입됨"""
+    # Given: 정상 요청
+    request = RequestDTO(job_id="job_valid")
+    mock_http_client.get.return_value = {"rt_cd": "0"}
+    
+    # When: 추출 실행
+    await extractor.extract(request)
+    
+    # Then: Authorization 헤더 검증
+    call_headers = mock_http_client.get.call_args.kwargs['headers']
+    assert call_headers["authorization"] == "Bearer test_token"
+
+# ========================================================================================
+# 5. 데이터 안정성 및 견고성 테스트 (Robustness & Data)
+# ========================================================================================
+
+@pytest.mark.asyncio
+async def test_data_01_business_failure(extractor, mock_http_client):
+    """[DATA-01] API 응답 rt_cd가 '0'이 아닌 경우 Business Failure 처리"""
+    # Given: 실패 코드('1')를 포함한 응답
+    mock_response = {"rt_cd": "1", "msg1": "Account Number Error"}
+    mock_http_client.get.return_value = mock_response
+    request = RequestDTO(job_id="job_valid")
+    
+    # When & Then: 커스텀 예외 및 에러 메시지 전파 확인
+    with pytest.raises(ExtractorError) as exc:
         await extractor.extract(request)
     
-    assert "Limit Exceeded" in str(exc_info.value)
-    assert "Code: 1" in str(exc_info.value)
+    assert "KIS API Failed" in str(exc.value)
+    assert "Account Number Error" in str(exc.value)
 
 @pytest.mark.asyncio
-async def test_tc_012_error_auth_failure(extractor, mock_auth_strategy):
-    """[TC-012] AuthStrategy 예외 발생 -> System Error로 래핑"""
-    # Given
-    request = RequestDTO(job_id="valid_job")
-    mock_auth_strategy.get_token.side_effect = Exception("Auth Server Down")
-
-    # When & Then
-    with pytest.raises(ExtractorError, match="System Error: Auth Server Down"):
+async def test_data_02_missing_rt_cd(extractor, mock_http_client):
+    """[DATA-02] 응답에 필수 필드 rt_cd가 없는 경우 견고성 테스트"""
+    # Given: 비표준 응답 포맷
+    mock_response = {"data": "invalid_structure"}
+    mock_http_client.get.return_value = mock_response
+    request = RequestDTO(job_id="job_valid")
+    
+    # When & Then: 알 수 없는 에러로 처리
+    with pytest.raises(ExtractorError, match="Unknown Error"):
         await extractor.extract(request)
+
+# ========================================================================================
+# 6. 예외 처리 및 데코레이터 테스트 (Exception & Decorators)
+# ========================================================================================
 
 @pytest.mark.asyncio
-async def test_tc_013_error_network_failure(extractor, mock_http_client):
-    """[TC-013] HttpClient 네트워크 예외 발생 -> System Error로 래핑"""
-    # Given
-    request = RequestDTO(job_id="valid_job")
-    mock_http_client.get.side_effect = Exception("Connection Timeout")
-
-    # When & Then
-    with pytest.raises(ExtractorError, match="System Error: Connection Timeout"):
+async def test_err_01_system_error_wrapping(extractor, mock_http_client):
+    """[ERR-01] 실행 중 예상치 못한 에러(ValueError) 발생 시 ExtractorError로 래핑"""
+    # Given: HTTP 클라이언트 레벨의 시스템 에러 발생
+    mock_http_client.get.side_effect = ValueError("Parsing Error")
+    request = RequestDTO(job_id="job_valid")
+    
+    # When & Then: 도메인 예외로 래핑되어 던져지는지 확인
+    with pytest.raises(ExtractorError, match="System Error"):
         await extractor.extract(request)
+
+def test_dec_01_decorator_application(extractor):
+    """[DEC-01] _fetch_raw_data 메서드에 데코레이터가 적용되어 있는지 검증"""
+    # Given: 테스트 대상 메서드
+    method = extractor._fetch_raw_data
+    
+    # When & Then: __wrapped__ 속성 존재 여부로 데코레이터 적용 확인
+    # NOTE: 실제 런타임에서는 데코레이터가 중첩되므로 __wrapped__가 연쇄적으로 존재함
+    assert hasattr(method, "__wrapped__"), "Decorators should be applied to _fetch_raw_data"

--- a/apps/data-pipeline/tests/unit/extractor/providers/upbit_extractor_test.py
+++ b/apps/data-pipeline/tests/unit/extractor/providers/upbit_extractor_test.py
@@ -1,303 +1,288 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch, ANY
+from typing import Dict, Any, Optional
 
-# --------------------------------------------------------------------------
-# Import Real Objects (DTO) & Target Class
-# --------------------------------------------------------------------------
+# [Target Modules] 테스트 대상 및 의존성 모듈
 from src.extractor.providers.upbit_extractor import UPBITExtractor
 from src.extractor.domain.dtos import RequestDTO, ResponseDTO
 from src.extractor.domain.exceptions import ExtractorError
 from src.extractor.domain.interfaces import IHttpClient, IAuthStrategy
 from src.common.config import AppConfig
 
-# --------------------------------------------------------------------------
-# 0. Constants & Configuration
-# --------------------------------------------------------------------------
+# ========================================================================================
+# [Mocks & Stubs] 외부 의존성 격리를 위한 모의 객체 정의
+# ========================================================================================
 
-# 로그 매니저 경로 (AbstractExtractor 초기화 시 파일 I/O 유발 방지)
-TARGET_LOG_MANAGER = "src.extractor.providers.abstract_extractor.LogManager"
+class MockJobPolicy:
+    """Config 내 JobPolicy 객체 모방 (설정 주입용 Stub)"""
+    def __init__(self, provider: str = "UPBIT", path: str = "/v1/candles/minutes/1", 
+                 params: Dict = None):
+        self.provider = provider
+        self.path = path
+        self.params = params or {}
 
-# --------------------------------------------------------------------------
-# 1. Fixtures (Test Environment Setup)
-# --------------------------------------------------------------------------
+# ========================================================================================
+# [Fixtures] 테스트 환경 설정 및 의존성 주입
+# ========================================================================================
+
+@pytest.fixture(autouse=True)
+def mock_logger():
+    """
+    [Core Fix] 
+    LogManager가 초기화될 때 전역 AppConfig를 참조하여 발생하는 RuntimeError를 방지합니다.
+    kis_extractor_test.py와 동일한 전략으로 로거 생성을 우회합니다.
+    """
+    with patch("src.common.log.LogManager.get_logger") as mock_get_logger, \
+         patch("src.extractor.providers.upbit_extractor.log_decorator") as mock_dec:
+        
+        # 1. 로거 호출 시 MagicMock 반환 (메서드 호출 추적 가능)
+        mock_logger_instance = MagicMock()
+        mock_get_logger.return_value = mock_logger_instance
+        
+        # 2. 데코레이터 Pass-through 처리
+        mock_dec.side_effect = lambda *args, **kwargs: lambda func: func
+        
+        yield mock_logger_instance
 
 @pytest.fixture
 def mock_http_client():
-    """[IHttpClient Mock] 외부 네트워크 통신 담당"""
+    """비동기 HTTP 요청을 모방하는 Mock Client"""
     client = MagicMock(spec=IHttpClient)
     client.get = AsyncMock()
     return client
 
 @pytest.fixture
 def mock_auth_strategy():
-    """[IAuthStrategy Mock] 인증 토큰 발급 담당"""
+    """인증 토큰 발급을 모방하는 Mock Strategy"""
     strategy = MagicMock(spec=IAuthStrategy)
-    strategy.get_token = AsyncMock()
+    strategy.get_token = AsyncMock(return_value="Bearer test_token")
     return strategy
 
 @pytest.fixture
 def mock_config():
-    """[AppConfig Mock] 파일 시스템 의존성 제거 및 UPBIT 설정 주입"""
-    config = MagicMock()
+    """정상 상태의 Config 객체 (Happy Path 기준)"""
+    config = MagicMock(spec=AppConfig)
     
-    # UPBIT 기본 설정 (Base URL)
-    config.upbit.base_url = "https://api.upbit.com/v1"
+    # UPBIT 섹션 설정
+    config.upbit = MagicMock()
+    config.upbit.base_url = "https://api.upbit.com"
     
-    # 기본 정책 설정 (Happy Path용)
-    valid_policy = MagicMock()
-    valid_policy.provider = "UPBIT"
-    valid_policy.path = "/candles/minutes/1"
-    valid_policy.params = {
-        "market": "KRW-BTC",
-        "count": 1
-    }
-    
+    # Extraction Policy 설정
     config.extraction_policy = {
-        "upbit_job": valid_policy
+        "job_valid": MockJobPolicy(params={"market": "KRW-BTC"}),
+        "job_param_override": MockJobPolicy(params={"cnt": 1}),
+        "job_kis": MockJobPolicy(provider="KIS"),  # Provider Mismatch 테스트용
+        "job_no_params": MockJobPolicy(params={}), # 파라미터 경고 테스트용
     }
     return config
 
 @pytest.fixture
 def extractor(mock_http_client, mock_auth_strategy, mock_config):
-    """
-    [System Under Test]
-    UPBITExtractor의 인스턴스입니다.
-    부모 클래스(AbstractExtractor)의 LogManager를 Patch하여 초기화 시 로깅 로직을 무력화합니다.
-    """
-    with patch(TARGET_LOG_MANAGER) as MockLogManager:
-        # Logger Mock 생성 (호출 검증용)
-        mock_logger_instance = MagicMock()
-        MockLogManager.get_logger.return_value = mock_logger_instance
-        
-        # 인스턴스 생성
-        instance = UPBITExtractor(mock_http_client, mock_auth_strategy, mock_config)
-        return instance
+    """테스트 대상 인스턴스 (SUT: System Under Test)"""
+    return UPBITExtractor(mock_http_client, mock_auth_strategy, mock_config)
 
-# --------------------------------------------------------------------------
-# 2. Test Cases
-# --------------------------------------------------------------------------
+# ========================================================================================
+# 1. 초기화 테스트 (Initialization)
+# ========================================================================================
 
-class TestUPBITExtractor:
+def test_init_01_critical_config_error(mock_http_client, mock_auth_strategy, mock_config):
+    """[INIT-01] upbit.base_url이 비어있으면 초기화 단계에서 즉시 실패 (Fail-Fast)"""
+    # Given: 잘못된 설정 주입 (Base URL 누락)
+    mock_config.upbit.base_url = ""
+    
+    # When & Then: 인스턴스 생성 시도 시 예외 발생 검증
+    with pytest.raises(ExtractorError, match="Critical Config Error"):
+        UPBITExtractor(mock_http_client, mock_auth_strategy, mock_config)
 
-    # ==========================================
-    # Category: Unit (Config Validation)
-    # ==========================================
+# ========================================================================================
+# 2. 요청 검증 테스트 (Validation - MC/DC)
+# ========================================================================================
 
-    def test_tc001_config_empty_base_url(self, mock_http_client, mock_auth_strategy, mock_config):
-        """[TC-001] Config의 base_url이 비어있으면 초기화 시 ExtractorError가 발생한다."""
-        # Given
-        mock_config.upbit.base_url = ""
+def test_req_01_missing_job_id(extractor):
+    """[REQ-01] Request에 job_id가 없는 경우 유효성 검증 실패"""
+    # Given: job_id가 None인 잘못된 요청
+    request = RequestDTO(job_id=None) # type: ignore
+    
+    # When & Then: 예외 발생
+    with pytest.raises(ExtractorError, match="'job_id' is mandatory"):
+        extractor._validate_request(request)
 
-        # When & Then
-        with patch(TARGET_LOG_MANAGER):
-            with pytest.raises(ExtractorError, match="Critical Config Error.*base_url"):
-                UPBITExtractor(mock_http_client, mock_auth_strategy, mock_config)
+def test_req_02_policy_not_found(extractor):
+    """[REQ-02] Config에 정의되지 않은 job_id 요청 시 실패"""
+    # Given: 정책에 없는 Job ID
+    request = RequestDTO(job_id="job_unknown")
+    
+    # When & Then: 정책 조회 실패 예외 확인
+    with pytest.raises(ExtractorError, match="Policy not found"):
+        extractor._validate_request(request)
 
-    # ==========================================
-    # Category: Unit (Happy Path)
-    # ==========================================
+def test_req_03_provider_mismatch(extractor):
+    """[REQ-03] Provider가 UPBIT가 아닌 경우 (예: KIS) 요청 거부"""
+    # Given: Provider가 "KIS"로 설정된 Job
+    request = RequestDTO(job_id="job_kis")
+    
+    # When & Then: Provider 불일치 예외 확인
+    with pytest.raises(ExtractorError, match="Provider Mismatch"):
+        extractor._validate_request(request)
 
-    @pytest.mark.asyncio
-    async def test_tc002_happy_path_success(self, extractor, mock_http_client, mock_auth_strategy):
-        """[TC-002] 정상 Config, 유효 Policy, 인증 토큰 존재 -> OK 상태 및 DTO 반환"""
-        # Given
-        request = RequestDTO(job_id="upbit_job", params={"to": "2024-01-01 00:00:00"})
-        mock_auth_strategy.get_token.return_value = "Bearer TEST_TOKEN"
-        
-        # UPBIT 정상 응답 (예: 캔들 데이터 리스트)
-        mock_response = [{"market": "KRW-BTC", "trade_price": 50000000}]
-        mock_http_client.get.return_value = mock_response
+def test_req_04_missing_params_warning(extractor, mock_logger):
+    """[REQ-04] [MC/DC] 정책/요청에 market, markets 모두 없으면 Warning 로그 기록"""
+    # Given: 필수 파라미터가 없는 Job Policy
+    request = RequestDTO(job_id="job_no_params") # params={}
+    
+    # When: 검증 수행 (예외는 발생하지 않음)
+    extractor._validate_request(request)
+    
+    # Then: Logger.warning 호출 여부 검증
+    mock_logger.warning.assert_called_with(ANY)
+    # 구체적인 메시지 내용 검증 (Optional)
+    assert "Parameter Warning" in str(mock_logger.warning.call_args)
 
-        # When
-        response = await extractor.extract(request)
+# ========================================================================================
+# 3. 정상 흐름 및 기능 테스트 (Functional & Flow)
+# ========================================================================================
 
-        # Then
-        assert response.meta["status_code"] == "OK"
-        assert response.meta["source"] == "UPBIT"
-        assert response.data == mock_response
-        mock_http_client.get.assert_called_once()
+@pytest.mark.asyncio
+async def test_flow_01_param_override(extractor, mock_http_client):
+    """[FLOW-01] 파라미터 병합 시 Request Params가 Static Policy보다 우선순위 가짐"""
+    # Given: Policy={"cnt": 1}, Request={"cnt": 10}
+    request = RequestDTO(job_id="job_param_override", params={"cnt": 10})
+    mock_http_client.get.return_value = {"market": "KRW-BTC"}
+    
+    # When: 추출 실행
+    await extractor.extract(request)
+    
+    # Then: 실제 호출된 파라미터가 덮어씌워졌는지(Override) 확인
+    call_args = mock_http_client.get.call_args
+    merged_params = call_args.kwargs['params']
+    assert merged_params["cnt"] == 10  # Policy 값 1이 10으로 교체됨
 
-    @pytest.mark.asyncio
-    async def test_tc003_url_header_construction(self, extractor, mock_http_client, mock_auth_strategy):
-        """[TC-003] URL, Header, Params가 정확한 순서와 값으로 조립되어 호출되는지 검증"""
-        # Given
-        request = RequestDTO(job_id="upbit_job")
-        mock_auth_strategy.get_token.return_value = "Bearer TEST_TOKEN"
-        mock_http_client.get.return_value = []
+@pytest.mark.asyncio
+async def test_flow_02_url_construction(extractor, mock_http_client, mock_config):
+    """[FLOW-02] Base URL과 Policy Path가 결합되어 완전한 URL 호출"""
+    # Given: 특정 URL 및 Path 설정
+    mock_config.upbit.base_url = "https://api.upbit-test.com"
+    mock_config.extraction_policy["job_valid"].path = "/v1/test/candles"
+    
+    request = RequestDTO(job_id="job_valid")
+    mock_http_client.get.return_value = [{"market": "KRW-BTC"}]
+    
+    # When: 추출 실행
+    await extractor.extract(request)
+    
+    # Then: 결합된 URL로 호출되었는지 검증
+    expected_url = "https://api.upbit-test.com/v1/test/candles"
+    mock_http_client.get.assert_called_with(expected_url, headers=ANY, params=ANY)
 
-        # When
+# ========================================================================================
+# 4. 보안 및 인증 테스트 (Security)
+# ========================================================================================
+
+@pytest.mark.asyncio
+async def test_sec_01_token_injection(extractor, mock_http_client, mock_auth_strategy):
+    """[SEC-01] AuthStrategy가 토큰을 반환하면 Authorization 헤더에 주입됨"""
+    # Given: AuthStrategy가 유효 토큰 반환 (Default Mock Behavior)
+    request = RequestDTO(job_id="job_valid")
+    mock_http_client.get.return_value = [{"market": "KRW-BTC"}]
+    
+    # When: 추출 실행
+    await extractor.extract(request)
+    
+    # Then: Authorization 헤더 검증
+    call_headers = mock_http_client.get.call_args.kwargs['headers']
+    assert call_headers["authorization"] == "Bearer test_token"
+
+@pytest.mark.asyncio
+async def test_sec_02_no_token_public_api(extractor, mock_http_client, mock_auth_strategy):
+    """[SEC-02] AuthStrategy가 None을 반환(Public API)하면 헤더에 포함되지 않음"""
+    # Given: 토큰 없음 설정
+    mock_auth_strategy.get_token.return_value = None
+    request = RequestDTO(job_id="job_valid")
+    mock_http_client.get.return_value = [{"market": "KRW-BTC"}]
+    
+    # When: 추출 실행
+    await extractor.extract(request)
+    
+    # Then: Authorization 헤더 부재 확인
+    call_headers = mock_http_client.get.call_args.kwargs['headers']
+    assert "authorization" not in call_headers
+
+# ========================================================================================
+# 5. 데이터 안정성 및 견고성 테스트 (Robustness & Data)
+# ========================================================================================
+
+@pytest.mark.asyncio
+async def test_data_01_api_error_response(extractor, mock_http_client):
+    """[DATA-01] API 응답 본문에 'error' 키가 존재하면 ExtractorError 발생"""
+    # Given: UPBIT 에러 응답 포맷
+    mock_response = {"error": {"name": "invalid_query", "message": "query param error"}}
+    mock_http_client.get.return_value = mock_response
+    request = RequestDTO(job_id="job_valid")
+    
+    # When & Then: 비즈니스 예외 발생 검증
+    with pytest.raises(ExtractorError, match="UPBIT API Failed"):
         await extractor.extract(request)
 
-        # Then
-        expected_url = "https://api.upbit.com/v1/candles/minutes/1"
-        expected_headers = {
-            "accept": "application/json",
-            "authorization": "Bearer TEST_TOKEN"
-        }
+@pytest.mark.asyncio
+async def test_data_02_success_response_mapping(extractor, mock_http_client):
+    """[DATA-02] 정상 JSON 응답 시 ResponseDTO 매핑 및 메타데이터 검증"""
+    # Given: 정상 응답
+    mock_data = [{"market": "KRW-BTC", "price": 50000}]
+    mock_http_client.get.return_value = mock_data
+    request = RequestDTO(job_id="job_valid")
+    
+    # When: 추출 실행
+    response = await extractor.extract(request)
+    
+    # Then: DTO 구조 및 메타데이터 확인
+    assert isinstance(response, ResponseDTO)
+    assert response.data == mock_data
+    assert response.meta["source"] == "UPBIT"
+    assert response.meta["job_id"] == "job_valid"
+    assert response.meta["status_code"] == "OK"
+
+# ========================================================================================
+# 6. 예외 처리 및 데코레이터 테스트 (Exception & Decorators)
+# ========================================================================================
+
+@pytest.mark.asyncio
+async def test_err_01_auth_exception_propagation(extractor, mock_auth_strategy):
+    """[ERR-01] AuthStrategy에서 발생한 ExtractorError는 그대로 상위 전파"""
+    # Given: 인증 과정에서 ExtractorError 발생
+    mock_auth_strategy.get_token.side_effect = ExtractorError("Auth Failed")
+    request = RequestDTO(job_id="job_valid")
+    
+    # When & Then: 재포장 없이 그대로 전파되는지 확인
+    with pytest.raises(ExtractorError, match="Auth Failed"):
+        await extractor.extract(request)
+
+@pytest.mark.asyncio
+async def test_err_02_system_error_wrapping(extractor, mock_http_client):
+    """[ERR-02] 실행 중 예상치 못한 에러(KeyError 등) 발생 시 ExtractorError로 래핑"""
+    # Given: 로직 내부에서 예상치 못한 에러 발생
+    mock_http_client.get.side_effect = KeyError("Unexpected Key")
+    request = RequestDTO(job_id="job_valid")
+    
+    # When & Then: System Error로 래핑 확인
+    with pytest.raises(ExtractorError, match="System Error"):
+        await extractor.extract(request)
+
+@pytest.mark.asyncio
+async def test_err_03_logic_exception_propagation(extractor, mock_http_client):
+    """[ERR-03] 내부 로직 검증 중 발생한 ExtractorError는 래핑되지 않고 전파"""
+    # Given: 강제로 ExtractorError 발생시키기 위해 validate_request 모킹
+    with patch.object(extractor, '_validate_request', side_effect=ExtractorError("Validation Fail")):
+        request = RequestDTO(job_id="job_valid")
         
-        # Call arguments 확인
-        args, kwargs = mock_http_client.get.call_args
-        assert args[0] == expected_url
-        assert kwargs["headers"] == expected_headers
-        assert "market" in kwargs["params"] # Policy param check
-
-    # ==========================================
-    # Category: Unit (Logic)
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc004_public_api_no_auth_header(self, extractor, mock_http_client, mock_auth_strategy):
-        """[TC-004] AuthStrategy가 None을 반환(Public API)하면 Header에 Authorization이 없어야 한다."""
-        # Given
-        request = RequestDTO(job_id="upbit_job")
-        mock_auth_strategy.get_token.return_value = None # No Token Needed
-        mock_http_client.get.return_value = []
-
-        # When
-        await extractor.extract(request)
-
-        # Then
-        _, kwargs = mock_http_client.get.call_args
-        headers = kwargs["headers"]
-        assert "authorization" not in headers
-        assert headers["accept"] == "application/json"
-
-    @pytest.mark.asyncio
-    async def test_tc005_param_merge_priority(self, extractor, mock_http_client):
-        """[TC-005] Policy Params와 Request Params 충돌 시 Request Params가 우선순위를 가진다."""
-        # Given
-        # Policy: count=1 (Fixture 설정)
-        # Request: count=100
-        request = RequestDTO(job_id="upbit_job", params={"count": 100})
-        mock_http_client.get.return_value = []
-
-        # When
-        await extractor.extract(request)
-
-        # Then
-        _, kwargs = mock_http_client.get.call_args
-        actual_params = kwargs["params"]
-        assert actual_params["count"] == 100 # Request override confirmed
-
-    @pytest.mark.asyncio
-    async def test_tc006_warning_log_missing_market(self, extractor, mock_config):
-        """[TC-006] Request와 Policy 모두 market 파라미터가 없으면 Warning 로그를 기록한다."""
-        # Given
-        # Policy에서 market 제거
-        mock_config.extraction_policy["upbit_job"].params = {"count": 1}
-        request = RequestDTO(job_id="upbit_job", params={}) # No market in request either
-
-        # 로거 Mock 가져오기 (초기화 시 생성된 self.logger)
-        mock_logger = extractor.logger
-
-        # When (실행 시 에러는 안 나지만 로그가 찍혀야 함)
-        await extractor.extract(request)
-
-        # Then
-        mock_logger.warning.assert_called_with("Parameter Warning: 'market' might be missing in policy 'upbit_job'.")
-
-    @pytest.mark.asyncio
-    async def test_tc007_list_response_handling(self, extractor, mock_http_client):
-        """[TC-007] API가 Dict가 아닌 List를 반환해도 에러 없이 정상 처리된다."""
-        # Given
-        request = RequestDTO(job_id="upbit_job")
-        mock_list_response = [{"candle_acc_trade_price": 100}, {"candle_acc_trade_price": 200}]
-        mock_http_client.get.return_value = mock_list_response
-
-        # When
-        response = await extractor.extract(request)
-
-        # Then
-        assert isinstance(response.data, list)
-        assert len(response.data) == 2
-
-    # ==========================================
-    # Category: Exception (Request Validation)
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc008_invalid_request_missing_job_id(self, extractor):
-        """[TC-008] job_id가 누락되면 ExtractorError가 발생한다."""
-        # Given
-        request = RequestDTO(job_id=None)
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="Invalid Request: 'job_id' is mandatory"):
+        # When & Then: 래핑 없이 원본 에러 전파 확인
+        with pytest.raises(ExtractorError, match="Validation Fail"):
             await extractor.extract(request)
 
-    # ==========================================
-    # Category: Exception (Policy Validation)
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc009_config_unknown_policy(self, extractor):
-        """[TC-009] 요청한 job_id가 Config 정책에 없으면 ExtractorError가 발생한다."""
-        # Given
-        request = RequestDTO(job_id="unknown_job")
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="Policy not found"):
-            await extractor.extract(request)
-
-    @pytest.mark.asyncio
-    async def test_tc010_config_provider_mismatch(self, extractor, mock_config):
-        """[TC-010] 해당 Policy의 Provider가 UPBIT가 아니면 ExtractorError가 발생한다."""
-        # Given
-        kis_policy = MagicMock()
-        kis_policy.provider = "KIS"
-        mock_config.extraction_policy["kis_job"] = kis_policy
-        
-        request = RequestDTO(job_id="kis_job")
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="Provider Mismatch"):
-            await extractor.extract(request)
-
-    # ==========================================
-    # Category: Exception (Response Handling)
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc011_api_business_failure_standard(self, extractor, mock_http_client):
-        """[TC-011] API 응답에 error 객체가 포함되면 ExtractorError로 처리한다."""
-        # Given
-        request = RequestDTO(job_id="upbit_job")
-        # Upbit Error Format
-        mock_http_client.get.return_value = {
-            "error": {
-                "name": "invalid_query_param",
-                "message": "query parameter error"
-            }
-        }
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="UPBIT API Failed: query parameter error"):
-            await extractor.extract(request)
-
-    @pytest.mark.asyncio
-    async def test_tc012_api_business_failure_malformed(self, extractor, mock_http_client):
-        """[TC-012] error 객체 내부에 상세 정보가 없어도 기본 메시지로 예외 처리한다."""
-        # Given
-        request = RequestDTO(job_id="upbit_job")
-        mock_http_client.get.return_value = {
-            "error": {} # Empty error object
-        }
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="UPBIT API Failed: No message provided"):
-            await extractor.extract(request)
-
-    # ==========================================
-    # Category: Resource & State
-    # ==========================================
-
-    @pytest.mark.asyncio
-    async def test_tc013_system_error_network(self, extractor, mock_http_client):
-        """[TC-013] HttpClient에서 네트워크 예외 발생 시 System Error로 래핑하여 던진다."""
-        # Given
-        request = RequestDTO(job_id="upbit_job")
-        mock_http_client.get.side_effect = Exception("Connection Refused")
-
-        # When & Then
-        with pytest.raises(ExtractorError, match="System Error: Connection Refused"):
-            await extractor.extract(request)
+def test_dec_01_decorator_application(extractor):
+    """[DEC-01] _fetch_raw_data 메서드에 데코레이터가 적용되어 있는지 검증"""
+    # Given: 테스트 대상 메서드
+    method = extractor._fetch_raw_data
+    
+    # When & Then: __wrapped__ 속성 존재 여부로 데코레이터 적용 확인
+    assert hasattr(method, "__wrapped__"), "Decorators should be applied to _fetch_raw_data"

--- a/docs/TCS/data-pipeline/TCS-AUTH-001.md
+++ b/docs/TCS/data-pipeline/TCS-AUTH-001.md
@@ -1,17 +1,20 @@
-# 2단계. 정식 테스트 명세서 (수정본)
+# Auth 테스트 명세서
 
-## 2-1. 문서 정보 및 전략
+## 1. 문서 정보 및 전략
 
-- **대상 모듈:** `auth.KISAuthStrategy`
-- **복잡도 수준:** **최상 (Critical)** (금융 거래를 위한 인증 및 상태 관리)
-- **커버리지 목표:** **분기 커버리지(Branch Coverage) 100%**, 구문 커버리지 100%
+- **대상 모듈:** `auth.KISAuthStrategy`, `auth.UPBITAuthStrategy`
+- **복잡도 수준:** **최상 (Critical)** (금융 거래 인증, 자산 접근 권한 관리)
+- **커버리지 목표:** 분기 커버리지 100%, 구문 커버리지 100%
 - **적용 전략:**
-  - [x] **경계값 분석 (BVA):** 토큰 만료 버퍼 시간(10분) 전후의 경계 검증.
-  - [x] **MC/DC (수정 조건/결정 커버리지):** `_should_refresh` 진입 조건 및 에러 처리 분기의 독립적 검증.
-  - [x] **상태 전이 (State Transition):** 토큰 수명주기 (없음 -> 유효 -> 만료 -> 갱신).
-  - [x] **동시성 (Concurrency):** 비동기 락(Async Lock) 및 이중 검사 잠금(Double-checked Locking) 패턴 검증.
+  - [x] **경계값 분석 (BVA):** 토큰 만료 시간(KIS), 파라미터 유무(UPBIT).
+  - [x] **MC/DC (수정 조건/결정 커버리지):** 갱신 로직의 조건 분기(KIS), 설정값 검증 분기(UPBIT).
+  - [x] **상태 전이 (State Transition):** 토큰 수명주기 관리(KIS).
+  - [x] **동시성 (Concurrency):** Async Lock 검증(KIS).
+  - [x] **암호화 무결성 (Crypto Integrity):** JWT 서명(UPBIT), Payload 구성(UPBIT), SHA512 해시 일치 여부 검증(UPBIT).
 
-## 2-2. 로직 흐름도 (참조)
+## 2. 로직 흐름도 (참조)
+
+### 2-1. KISAuthStrategy (Stateful Manager)
 
 ```
 stateDiagram-v2
@@ -50,7 +53,26 @@ stateDiagram-v2
     ReturnToken --> [*]
 ```
 
-## 2-3. BDD 테스트 시나리오 (전체 목록)
+### 2-2. UPBITAuthStrategy (Stateless Manufacturer)
+
+## 3. BDD 테스트 시나리오
+
+### 3-1. KISAuthStrategy (Stateful Manager)
+
+```
+flowchart LR
+    Start([get_token]) --> Init[Init Payload & Generate Nonce]
+    Init --> CheckQuery{Query params exist?}
+
+    CheckQuery -- Yes --> Hash[SHA512 Hashing]
+    Hash --> Append[Add query_hash to Payload]
+
+    CheckQuery -- No --> Sign
+    Append --> Sign[JWT Sign (HS256)]
+
+    Sign --> Format["Bearer {Token}"]
+    Format --> End([Return])
+```
 
 **시나리오 요약:**
 
@@ -60,22 +82,45 @@ stateDiagram-v2
 - **API 상호작용 (API Interaction):** 4건 (응답 파싱 및 검증)
 - **에러 처리 (Error Handling):** 5건 (조기 실패, 재시도, 예외 래핑, 침묵 실패 방지)
 
-|  테스트 ID  | 분류 |   기법   | 전제 조건 (Given)                           | 수행 (When)                               | 검증 (Then)                                                                        | 입력 데이터 / 상황          |
-| :---------: | :--: | :------: | :------------------------------------------ | :---------------------------------------- | :--------------------------------------------------------------------------------- | :-------------------------- |
-| **INIT-01** | 단위 |   표준   | 유효한 `AppConfig` 객체                     | `KISAuthStrategy(config)` 초기화          | 인스턴스 정상 생성 및 `base_url` 매핑 확인                                         | `base_url="https://api..."` |
-| **INIT-02** | 단위 |   BVA    | `base_url`이 비어있는 설정                  | `KISAuthStrategy(config)` 초기화          | `ValueError` 발생 (방어 로직 작동)                                                 | `base_url=""` 또는 `None`   |
-| **INIT-03** | 단위 |   보안   | `SecretStr` 타입의 키/비밀값                | `KISAuthStrategy(config)` 초기화          | 내부 변수(`self.app_key`)에는 **평문(str)**으로 복호화되어 저장됨                  | `app_key=SecretStr("xyz")`  |
-| **LIFE-01** | 단위 |   상태   | `_access_token`이 `None` (초기 구동)        | `get_token(client)` 호출                  | 1. API 호출 발생<br>2. 토큰 및 만료시간 갱신<br>3. 유효한 토큰 문자열 반환         | Mock API: `200 OK`          |
-| **LIFE-02** | 단위 |   BVA    | 토큰 유효, 만료 **11분** 남음 (버퍼 초과)   | `get_token(client)` 호출                  | **API 호출 없음** (메모리 캐시 반환)                                               | `expires_at = 현재 + 11분`  |
-| **LIFE-03** | 단위 |   BVA    | 토큰 유효, 만료 **9분** 남음 (버퍼 진입)    | `get_token(client)` 호출                  | 1. API 호출 발생 (지연 갱신)<br>2. 새로운 토큰으로 교체됨                          | `expires_at = 현재 + 9분`   |
-| **LIFE-04** | 단위 |   상태   | 토큰 존재하나, 시간상 **이미 만료됨**       | `get_token(client)` 호출                  | 1. API 호출 발생<br>2. 새로운 토큰으로 교체됨                                      | `expires_at = 현재 - 1분`   |
-| **CONC-01** | 통합 |  동시성  | 토큰 만료 상태, 5개 코루틴 대기 중          | `asyncio.gather(get_token * 5)` 동시 실행 | 1. **실제 API 호출 횟수 == 1** (Locking 작동)<br>2. 5개 요청 모두 동일한 토큰 반환 | `Tasks = 5`                 |
-| **API-01**  | 단위 |   표준   | 표준 응답 (토큰 + 만료시간 포함)            | `_update_state(response)` 실행            | `_expires_at`이 응답값(`KIS_DATE_FORMAT`)에 맞춰 파싱됨                            | `expired="2025-12-31..."`   |
-| **API-02**  | 단위 |  견고성  | 응답에 `access_token_token_expired` 키 누락 | `_update_state(response)` 실행            | 1. 에러 없음<br>2. `_expires_at` = 현재 + 12시간 (기본값 설정)                     | `expired=None`              |
-| **API-03**  | 단위 |  견고성  | HTTP 200이나 본문에 `access_token` 없음     | `_validate_response(response)` 실행       | `AuthError` 발생 (유효성 검증 실패)                                                | Body: `{"msg": "실패"}`     |
-| **API-04**  | 단위 |  MC/DC   | 만료시간이 **비표준 형식** 문자열           | `_update_state(response)` 실행            | 1. `ValueError` 내부 처리(Catch)<br>2. 기본값(12시간) 적용                         | `expired="Invalid-Date"`    |
-| **ERR-01**  | 예외 | 조기실패 | API가 **401 Unauthorized** 응답             | `get_token(client)` 호출                  | 1. `AuthError` 발생<br>2. `NetworkError`로 감싸지지 않음 (재시도 중단)             | Mock API: `401 Error`       |
-| **ERR-02**  | 예외 | 조기실패 | API가 **403 Forbidden** 응답                | `get_token(client)` 호출                  | 1. `AuthError` 발생<br>2. 로그에 "Permanent Auth Failure" 기록                     | Mock API: `403 Error`       |
-| **ERR-03**  | 예외 |  견고성  | `_issue_token` 중 알 수 없는 예외 발생      | `get_token(client)` 호출                  | `AuthError`로 래핑되어 전파 (문맥 보존)                                            | Mock: `raise KeyError`      |
-| **ERR-04**  | 예외 |   로직   | `_issue_token` 수행 후에도 토큰이 `None`    | `get_token(client)` 호출                  | `AuthError("Failed to retrieve...")` 발생                                          | Mock: `_access_token=None`  |
-| **ERR-05**  | 예외 |  재시도  | API가 **500 Internal Error** 응답           | `_issue_token(client)` 직접 호출          | `NetworkError`가 **그대로 전파됨** (AuthError 변환 안 함 -> 재시도 트리거)         | Mock API: `500 Error`       |
+|     테스트 ID      | 분류 |   기법   | 전제 조건 (Given)                           | 수행 (When)                               | 검증 (Then)                                                                        | 입력 데이터 / 상황          |
+| :----------------: | :--: | :------: | :------------------------------------------ | :---------------------------------------- | :--------------------------------------------------------------------------------- | :-------------------------- |
+|  **KIS-INIT-01**   | 단위 |   표준   | 유효한 `AppConfig` 객체                     | `KISAuthStrategy(config)` 초기화          | 인스턴스 정상 생성 및 `base_url` 매핑 확인                                         | `base_url="https://api..."` |
+|  **KIS-INIT-02**   | 단위 |   BVA    | `base_url`이 비어있는 설정                  | `KISAuthStrategy(config)` 초기화          | `ValueError` 발생 (방어 로직 작동)                                                 | `base_url=""` 또는 `None`   |
+|  **KIS-INIT-03**   | 단위 |   보안   | `SecretStr` 타입의 키/비밀값                | `KISAuthStrategy(config)` 초기화          | 내부 변수(`self.app_key`)에는 **평문(str)**으로 복호화되어 저장됨                  | `app_key=SecretStr("xyz")`  |
+|  **KIS-LIFE-01**   | 단위 |   상태   | `_access_token`이 `None` (초기 구동)        | `get_token(client)` 호출                  | 1. API 호출 발생<br>2. 토큰 및 만료시간 갱신<br>3. 유효한 토큰 문자열 반환         | Mock API: `200 OK`          |
+|  **KIS-LIFE-02**   | 단위 |   BVA    | 토큰 유효, 만료 **11분** 남음 (버퍼 초과)   | `get_token(client)` 호출                  | **API 호출 없음** (메모리 캐시 반환)                                               | `expires_at = 현재 + 11분`  |
+|  **KIS-LIFE-03**   | 단위 |   BVA    | 토큰 유효, 만료 **9분** 남음 (버퍼 진입)    | `get_token(client)` 호출                  | 1. API 호출 발생 (지연 갱신)<br>2. 새로운 토큰으로 교체됨                          | `expires_at = 현재 + 9분`   |
+|  **KIS-LIFE-04**   | 단위 |   상태   | 토큰 존재하나, 시간상 **이미 만료됨**       | `get_token(client)` 호출                  | 1. API 호출 발생<br>2. 새로운 토큰으로 교체됨                                      | `expires_at = 현재 - 1분`   |
+|  **KIS-CONC-01**   | 통합 |  동시성  | 토큰 만료 상태, 5개 코루틴 대기 중          | `asyncio.gather(get_token * 5)` 동시 실행 | 1. **실제 API 호출 횟수 == 1** (Locking 작동)<br>2. 5개 요청 모두 동일한 토큰 반환 | `Tasks = 5`                 |
+| **KIS-KIS-API-01** | 단위 |   표준   | 표준 응답 (토큰 + 만료시간 포함)            | `_update_state(response)` 실행            | `_expires_at`이 응답값(`KIS_DATE_FORMAT`)에 맞춰 파싱됨                            | `expired="2025-12-31..."`   |
+|   **KIS-API-02**   | 단위 |  견고성  | 응답에 `access_token_token_expired` 키 누락 | `_update_state(response)` 실행            | 1. 에러 없음<br>2. `_expires_at` = 현재 + 12시간 (기본값 설정)                     | `expired=None`              |
+|   **KIS-API-03**   | 단위 |  견고성  | HTTP 200이나 본문에 `access_token` 없음     | `_validate_response(response)` 실행       | `AuthError` 발생 (유효성 검증 실패)                                                | Body: `{"msg": "실패"}`     |
+|   **KIS-API-04**   | 단위 |  MC/DC   | 만료시간이 **비표준 형식** 문자열           | `_update_state(response)` 실행            | 1. `ValueError` 내부 처리(Catch)<br>2. 기본값(12시간) 적용                         | `expired="Invalid-Date"`    |
+|   **KIS-ERR-01**   | 예외 | 조기실패 | API가 **401 Unauthorized** 응답             | `get_token(client)` 호출                  | 1. `AuthError` 발생<br>2. `NetworkError`로 감싸지지 않음 (재시도 중단)             | Mock API: `401 Error`       |
+|   **KIS-ERR-02**   | 예외 | 조기실패 | API가 **403 Forbidden** 응답                | `get_token(client)` 호출                  | 1. `AuthError` 발생<br>2. 로그에 "Permanent Auth Failure" 기록                     | Mock API: `403 Error`       |
+|   **KIS-ERR-03**   | 예외 |  견고성  | `_issue_token` 중 알 수 없는 예외 발생      | `get_token(client)` 호출                  | `AuthError`로 래핑되어 전파 (문맥 보존)                                            | Mock: `raise KeyError`      |
+|   **KIS-ERR-04**   | 예외 |   로직   | `_issue_token` 수행 후에도 토큰이 `None`    | `get_token(client)` 호출                  | `AuthError("Failed to retrieve...")` 발생                                          | Mock: `_access_token=None`  |
+|   **KIS-ERR-05**   | 예외 |  재시도  | API가 **500 Internal Error** 응답           | `_issue_token(client)` 직접 호출          | `NetworkError`가 **그대로 전파됨** (AuthError 변환 안 함 -> 재시도 트리거)         | Mock API: `500 Error`       |
+
+### 3-2. UPBITAuthStrategy (Stateless Manufacturer) - [신규 추가]
+
+**시나리오 요약:**
+
+- **초기화 (Initialization):** 2건 (설정 누락 및 속성 부재 방어)
+- **토큰 수명주기 및 무결성 (Lifecycle & Integrity):** 2건 (기본 토큰, 쿼리 해시 포함 토큰)
+- **데이터 견고성 (Robustness):** 1건 (빈 파라미터 처리)
+- **호환성 (Compatibility):** 1건 (PyJWT 라이브러리 버전별 반환 타입 대응)
+- **보안 로직 (Security Logic):** 2건 (서명 알고리즘, 키 검증)
+- **상태 및 보안 (State & Security):** 1건 (Nonce 유일성 - Replay Attack 방지)
+
+|      테스트 ID      | 분류 |  기법  | 전제 조건 (Given)                          | 수행 (When)                                       | 검증 (Then)                                                                        | 입력 데이터 / 상황               |
+| :-----------------: | :--: | :----: | :----------------------------------------- | :------------------------------------------------ | :--------------------------------------------------------------------------------- | :------------------------------- |
+|  **UPBIT-INIT-01**  | 단위 |  BVA   | `base_url`이 비어있는 설정                 | `UPBITAuthStrategy(config)` 초기화                | `ValueError` 발생 (필수 설정 누락 방어)                                            | `base_url=""`                    |
+|  **UPBIT-INIT-02**  | 단위 | 견고성 | 설정 객체에 `secret_key` 속성 자체가 없음  | `UPBITAuthStrategy(config)` 초기화                | `ValueError` 발생 (AttributeError 방지 및 명시적 에러)                             | Config without `secret_key` attr |
+|  **UPBIT-LIFE-01**  | 단위 |  표준  | 정상 설정 완료                             | `get_token(client)` 호출 (인자 없음)              | 1. `Bearer {Token}` 형식 반환<br>2. Payload에 `access_key`, `nonce` 포함 확인      | `kwargs={}`                      |
+|  **UPBIT-LIFE-02**  | 단위 | 무결성 | 쿼리 파라미터가 존재하는 요청              | `get_token(..., query_params=params)` 호출        | 1. Payload에 `query_hash` 필드 존재<br>2. **SHA512 해시값**이 실제 파라미터와 일치 | `params={'market': 'KRW-BTC'}`   |
+|  **UPBIT-DATA-01**  | 단위 |  BVA   | 쿼리 파라미터가 비어있는 딕셔너리          | `get_token(..., query_params={})` 호출            | Payload에 `query_hash` 필드가 **포함되지 않음** (None과 동일 처리)                 | `params={}`                      |
+| **UPBIT-COMPAT-01** | 단위 |  분기  | `jwt.encode`가 **bytes 타입**을 반환(Mock) | `get_token(client)` 호출                          | 내부적으로 `utf-8` 디코딩이 수행되어 최종적으로 **str 타입**의 토큰 반환           | `return_value=b"token"`          |
+| **UPBIT-LOGIC-01**  | 단위 |  보안  | 토큰 생성 완료                             | JWT 헤더 디코딩                                   | 서명 알고리즘(`alg`)이 `HS256`으로 설정되어 있음                                   | `jwt.get_unverified_header()`    |
+| **UPBIT-LOGIC-02**  | 단위 |  보안  | 서로 다른 Secret Key 사용                  | 생성된 토큰을 **잘못된 Key**로 디코딩 시도        | `jwt.InvalidSignatureError` 발생 (올바른 Key로 서명되었음을 역검증)                | `decode(token, wrong_key)`       |
+|  **UPBIT-SEC-01**   | 단위 |  보안  | 정상 설정 완료                             | `get_token`을 **연속 2회** 호출하여 토큰 2개 확보 | 두 토큰의 Payload 내 **`nonce` 값이 서로 다름** (Replay Attack 방지)               | `token1 != token2`               |

--- a/docs/TCS/data-pipeline/TCS-ETL-001.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-001.md
@@ -1,28 +1,71 @@
-# Test Specification: Abstract Extractor
+# AbstractExtractor 테스트 명세서
 
-## 1. 개요
+## 1. 문서 정보 및 전략
 
-- **Target Module:** `data_collection.extraction.abstract_extractor.AbstractExtractor`
-- **Objective:** 설정 주도 ETL 파이프라인의 제어 흐름 및 예외 정책 검증.
+- **대상 모듈:** `extractor.AbstractExtractor`
+- **복잡도 수준:** **높음 (High)** (모든 수집기의 기반이 되는 템플릿 메서드 및 에러 처리 표준 정의)
+- **커버리지 목표:** **분기 커버리지(Branch Coverage) 100%**, 구문 커버리지 100%
+- **적용 전략:**
+  - [x] **상태 전이 (State Transition):** 템플릿 메서드의 실행 순서(Validate -> Fetch -> Create) 검증.
+  - [x] **결함 주입 (Fault Injection):** NetworkError, ExtractorError, Unhandled Exception 등 다양한 에러 상황 시뮬레이션.
+  - [x] **Stubbing & Mocking:** 추상 클래스 테스트를 위한 구현체(Stub) 정의 및 로거/Config 모의 객체 사용.
+  - [x] **Null Safety:** 요청 객체 누락 등 방어 코드 검증.
 
-## 2. 테스트 환경
+## 2. 로직 흐름도
 
-- **Implementation:** `ConcreteMockExtractor` (추상 클래스 테스트용)
-- **Mocking:** `IHttpClient`, `AppConfig`, `Logger`
+```mermaid
+stateDiagram-v2
+    [*] --> Start: extract(request)
 
-## 3. 테스트 케이스 명세
+    state "Template Method Execution" as TME {
+        Start --> Validate: _validate_request()
 
-|  Test ID   | Category  | Given (Preconditions)                  | When (Action)                            | Then (Expected Outcome)                                               | Input Data              |
-| :--------: | :-------: | :------------------------------------- | :--------------------------------------- | :-------------------------------------------------------------------- | :---------------------- |
-| **TC-001** |   Unit    | 정상적인 Client, Config, 구현체 준비됨 | `extract(request)` 호출                  | 1. `_validate` -> `_fetch` -> `_create` 실행<br>2. `ResponseDTO` 반환 | `RequestDTO("valid")`   |
-| **TC-002** |   Unit    | `extract` 실행 준비됨                  | `extract(request)` 호출                  | 시작 및 종료 `logger.info` 기록                                       | `RequestDTO("valid")`   |
-| **TC-003** |   Unit    | `config`가 `None`인 상황               | `AbstractExtractor(client, None)` 생성   | `ExtractorError` 발생 (초기화 실패)                                   | `config=None`           |
-| **TC-004** |   Unit    | 유효한 `client`와 `config` 준비됨      | `AbstractExtractor(client, config)` 생성 | 정상 생성 및 `self.config` 주입 확인                                  | `AppConfig(...)`        |
-| **TC-005** | Exception | `request` 객체가 `None`                | `extract(None)` 호출                     | `ExtractorError`로 래핑되어 발생                                      | `request=None`          |
-| **TC-006** | Boundary  | `_fetch`가 `None` 반환                 | `extract(request)` 호출                  | 에러 없이 `_create(None)` 호출                                        | `Fetch returns None`    |
-| **TC-007** | Exception | `_validate`에서 `ExtractorError` 발생  | `extract(request)` 호출                  | 1. `ExtractorError` 재발생 (Re-raise)<br>2. `_fetch` 미실행 확인      | `RequestDTO("invalid")` |
-| **TC-008** | Exception | `_fetch` 중 `NetworkError` 발생        | `extract(request)` 호출                  | `ExtractorError`로 변환 발생 (Chaining)                               | `NetworkError(...)`     |
-| **TC-009** | Exception | `_create` 중 `ExtractorError` 발생     | `extract(request)` 호출                  | `ExtractorError` 재발생 (Re-raise)                                    | `ExtractorError(...)`   |
-| **TC-010** | Exception | `_fetch` 중 `ValueError` (버그) 발생   | `extract(request)` 호출                  | `ExtractorError`로 래핑 및 Stack Trace 기록                           | `ValueError(...)`       |
-| **TC-011** | Resource  | `extract` 실행 완료                    | Config 객체 상태 확인                    | 실행 전후 Config 객체 불변성 검증                                     | `RequestDTO("valid")`   |
-| **TC-012** |   Unit    | `_validate` 성공 설정                  | `extract(request)` 호출                  | `_validate` 직후 `_fetch` 호출 순서 검증                              | `RequestDTO("valid")`   |
+        state "Exception Handling" as EH {
+            Validate --> Fetch: Success
+            Fetch --> Create: _fetch_raw_data() Success
+
+            Fetch --> HandleNetwork: NetworkError raised
+            Fetch --> HandleDomain: ExtractorError raised
+            Fetch --> HandleUnknown: Exception raised
+        }
+
+        Create --> End: _create_response() Success
+    }
+
+    HandleNetwork --> LogError: Log ERROR
+    LogError --> RaiseWrapped: Raise ExtractorError (from e)
+
+    HandleDomain --> LogWarn: Log WARNING
+    LogWarn --> Reraise: Reraise ExtractorError (as is)
+
+    HandleUnknown --> LogTrace: Log ERROR with StackTrace
+    LogTrace --> RaiseWrapped: Raise ExtractorError (from e)
+
+    End --> [*]: Return ResponseDTO
+    RaiseWrapped --> [*]
+    Reraise --> [*]
+```
+
+## 3. BDD 테스트 시나리오 (전체 목록)
+
+**시나리오 요약:**
+
+- **초기화 (Initialization):** 2건 (설정 주입 방어, 요청 객체 방어)
+- **정상 흐름 (Happy Path):** 1건 (템플릿 메서드 순서)
+- **흐름 제어 (Flow Control):** 2건 (검증 실패 시 중단, 상태 비저장성)
+- **에러 핸들링 (Error Handling):** 3건 (네트워크, 도메인, 미확인 에러)
+- **데이터 검증 (Data Verification):** 1건 (DTO 포장)
+- **로깅 (Logging):** 1건 (정상 로그 기록)
+
+|  테스트 ID  | 분류 |   기법   | 전제 조건 (Given)                      | 수행 (When)                                | 검증 (Then)                                                                          | 입력 데이터 / 상황          |
+| :---------: | :--: | :------: | :------------------------------------- | :----------------------------------------- | :----------------------------------------------------------------------------------- | :-------------------------- |
+| **INIT-01** | 단위 |   BVA    | `config` 객체가 `None`인 상태          | `StubExtractor(client, None)` 초기화       | `ExtractorError` 발생 (메시지: "AppConfig cannot be None")                           | `config=None`               |
+| **INIT-02** | 단위 |   보안   | `extract(None)` 호출 (요청 객체 누락)  | `extract(None)` 실행                       | 1. 로깅 시 job_id="Unknown" 처리 (Crash 없음)<br>2. `_validate`에서 에러 발생        | `request=None`              |
+| **FLOW-01** | 단위 |   상태   | 모든 단계가 성공하는 `StubExtractor`   | `extract(request)` 호출                    | 1. `_validate` -> `_fetch` -> `_create` 순서 호출 확인<br>2. 최종 `ResponseDTO` 반환 | `request=RequestDTO(...)`   |
+| **FLOW-02** | 단위 |   상태   | `_validate`에서 에러 발생하도록 설정   | `extract(request)` 호출                    | 1. `_validate` 호출됨<br>2. **`_fetch`는 호출되지 않음** (흐름 중단 확인)            | Stub: `validate` raises Err |
+| **FLOW-03** | 단위 |   상태   | 하나의 인스턴스 재사용                 | `extract(req1)`, `extract(req2)` 연속 호출 | 두 호출이 독립적으로 성공하며, 내부 상태(맴버 변수)가 공유/오염되지 않음             | `req1`, `req2`              |
+| **ERR-01**  | 예외 | 결함주입 | `_fetch` 중 `NetworkError` 발생        | `extract(request)` 호출                    | 1. `ExtractorError`로 래핑되어 발생<br>2. 로그 레벨 **ERROR** 기록                   | Raise `NetworkError`        |
+| **ERR-02**  | 예외 | 결함주입 | `_fetch` 중 `ExtractorError` 발생      | `extract(request)` 호출                    | 1. 원본 `ExtractorError` 그대로 발생 (래핑 X)<br>2. 로그 레벨 **WARNING** 기록       | Raise `ExtractorError`      |
+| **ERR-03**  | 예외 |  견고성  | `_fetch` 중 알 수 없는 `KeyError` 발생 | `extract(request)` 호출                    | 1. `ExtractorError`로 래핑되어 발생<br>2. 로그에 **Stack Trace** 포함 확인           | Raise `KeyError`            |
+| **DATA-01** | 단위 |   표준   | `_create` 단계 정상 수행               | `extract(request)` 결과 확인               | 반환된 객체가 `ResponseDTO` 타입이며, Stub 데이터가 올바르게 매핑됨                  | Stub Return Data            |
+| **LOG-01**  | 단위 |   표준   | 정상 흐름 실행                         | `extract(request)` 완료 후 로그 검사       | "Starting..." 및 "Completed..." 로그가 **INFO** 레벨로 기록됨                        | `job_id="test_job"`         |

--- a/docs/TCS/data-pipeline/TCS-ETL-001.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-001.md
@@ -2,7 +2,7 @@
 
 ## 1. 문서 정보 및 전략
 
-- **대상 모듈:** `extractor.AbstractExtractor`
+- **대상 모듈:** `extractor.providers.AbstractExtractor`
 - **복잡도 수준:** **높음 (High)** (모든 수집기의 기반이 되는 템플릿 메서드 및 에러 처리 표준 정의)
 - **커버리지 목표:** 분기 커버리지 100%, 구문 커버리지 100%
 - **적용 전략:**

--- a/docs/TCS/data-pipeline/TCS-ETL-001.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-001.md
@@ -4,7 +4,7 @@
 
 - **대상 모듈:** `extractor.AbstractExtractor`
 - **복잡도 수준:** **높음 (High)** (모든 수집기의 기반이 되는 템플릿 메서드 및 에러 처리 표준 정의)
-- **커버리지 목표:** **분기 커버리지(Branch Coverage) 100%**, 구문 커버리지 100%
+- **커버리지 목표:** 분기 커버리지 100%, 구문 커버리지 100%
 - **적용 전략:**
   - [x] **상태 전이 (State Transition):** 템플릿 메서드의 실행 순서(Validate -> Fetch -> Create) 검증.
   - [x] **결함 주입 (Fault Injection):** NetworkError, ExtractorError, Unhandled Exception 등 다양한 에러 상황 시뮬레이션.

--- a/docs/TCS/data-pipeline/TCS-ETL-002.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-002.md
@@ -4,7 +4,7 @@
 
 - **대상 모듈:** `extractor.kis_extractor.KISExtractor`
 - **복잡도 수준:** **최상 (Critical)** (외부 금융 API 연동 및 민감 정보 처리)
-- **커버리지 목표:** 분기 커버리지(Branch Coverage) 100%, 구문 커버리지 100%
+- **커버리지 목표:** 분기 커버리지 100%, 구문 커버리지 100%
 - **적용 전략:**
   - [x] **MC/DC (수정 조건/결정 커버리지):** `_validate_request` 내 다중 검증 조건(Job ID, Policy, Provider, TR_ID)의 독립적 결함 유발 검증.
   - [x] **Fail-Fast (조기 실패):** 설정 오류나 필수 파라미터 누락 시 즉각적인 예외 발생 여부 검증.

--- a/docs/TCS/data-pipeline/TCS-ETL-002.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-002.md
@@ -2,7 +2,7 @@
 
 ## 1. 문서 정보 및 전략
 
-- **대상 모듈:** `extractor.kis_extractor.KISExtractor`
+- **대상 모듈:** `extractor.providers.kis_extractor.KISExtractor`
 - **복잡도 수준:** **최상 (Critical)** (외부 금융 API 연동 및 민감 정보 처리)
 - **커버리지 목표:** 분기 커버리지 100%, 구문 커버리지 100%
 - **적용 전략:**

--- a/docs/TCS/data-pipeline/TCS-ETL-002.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-002.md
@@ -1,31 +1,79 @@
-# KIS Extractor Test Specification (Fixed)
+# KIS Extractor 테스트 명세서
 
-## 1. 개요 (Overview)
+## 1. 문서 정보 및 전략
 
-- **대상 모듈:** `kis_extractor.py` (KISExtractor 클래스)
-- **테스트 목적:** KIS 데이터 수집기의 설정 로딩, 요청 검증, 파라미터 병합 로직, 외부 API 호출, 응답 처리 및 모든 예외 상황에 대한 방어 로직 검증.
-- **테스트 범위:** `__init__`, `extract`, `_validate_request`, `_fetch_raw_data`, `_create_response` 메서드 전체.
+- **대상 모듈:** `extractor.kis_extractor.KISExtractor`
+- **복잡도 수준:** **최상 (Critical)** (외부 금융 API 연동 및 민감 정보 처리)
+- **커버리지 목표:** 분기 커버리지(Branch Coverage) 100%, 구문 커버리지 100%
+- **적용 전략:**
+  - [x] **MC/DC (수정 조건/결정 커버리지):** `_validate_request` 내 다중 검증 조건(Job ID, Policy, Provider, TR_ID)의 독립적 결함 유발 검증.
+  - [x] **Fail-Fast (조기 실패):** 설정 오류나 필수 파라미터 누락 시 즉각적인 예외 발생 여부 검증.
+  - [x] **Mocking & Stubbing:** `IHttpClient`, `IAuthStrategy`, `AppConfig`의 완벽한 제어를 통한 외부 의존성 격리.
+  - [x] **Data Integrity:** 파라미터 병합 우선순위 및 응답 코드(`rt_cd`) 기반의 무결성 검증.
 
-## 2. 테스트 환경 및 전략 (Environment & Strategy)
+## 2. 로직 흐름도
 
-- **Test Runner:** Pytest (Asyncio plugin required)
-- **Mocking:** `IHttpClient`, `IAuthStrategy`, `AppConfig` (Pydantic Model)
-- **Coverage:** 13 Scenarios (Happy Path, Boundary, Null/Type, Logical Exception, Resource/State)
+```mermaid
+stateDiagram-v2
+    [*] --> Init: __init__(config)
 
-## 3. 테스트 케이스 명세 (Test Cases)
+    state "Validation Phase" as VP {
+        Init --> CheckConfig: Check kis.base_url
+        CheckConfig --> Ready: Valid
+        CheckConfig --> Error_Init: Empty URL
 
-|  Test ID   |   Category    | Source Scenario | Given (Preconditions)                                                                                                                    | When (Action)                         | Then (Expected Outcome)                                                                 | Input Data             | Priority |
-| :--------: | :-----------: | :-------------: | :--------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------ | :-------------------------------------------------------------------------------------- | :--------------------- | :------: |
-| **TC-001** | Unit (Happy)  |      SC-01      | 1. 정상 Config(KIS Provider, 필수값 포함) 로드됨.<br>2. AuthStrategy가 유효 토큰 반환.<br>3. HttpClient가 `rt_cd: "0"`인 정상 JSON 응답. | `extract(request)` 호출               | 1. `ResponseDTO` 반환.<br>2. `data`가 Mock 응답과 일치.<br>3. `meta.status_code`가 "0". | `job_id="valid_job"`   |   High   |
-| **TC-002** | Unit (Logic)  |      SC-02      | 1. Policy에 `{count: 10}` 존재.<br>2. Request에 `{date: '20240101'}` 존재 (서로 다른 키).                                                | `extract(request)` 호출               | 1. HttpClient 호출 시 파라미터가 `{count: 10, date: '20240101'}`로 병합됨.              | `params={'date':...}`  |  Medium  |
-| **TC-003** |  Unit (Edge)  |      SC-03      | 1. Policy에 `{count: 10}` 존재.<br>2. Request에 `{count: 50}` 존재 (동일 키).                                                            | `extract(request)` 호출               | 1. HttpClient 호출 시 파라미터가 `{count: 50}`으로 Request 값이 우선 적용됨.            | `params={'count': 50}` |  Medium  |
-| **TC-004** |  Unit (Edge)  |      SC-04      | 1. Policy에 `{count: 10}` 존재.<br>2. Request params가 비어있음(Empty Dict).                                                             | `extract(request)` 호출               | 1. HttpClient 호출 시 Policy 파라미터 `{count: 10}`이 그대로 사용됨.                    | `params={}`            |  Medium  |
-| **TC-005** | Unit (Valid)  |      SC-05      | 1. 정상 Config 로드됨.                                                                                                                   | `extract(request)` 호출 (job_id 누락) | `ExtractorError` 발생 ("Invalid Request: 'job_id' is mandatory").                       | `job_id=None`          |   High   |
-| **TC-006** |  Unit (Edge)  |      SC-06      | 1. HttpClient가 `rt_cd` 키가 없는 정상 JSON(`{"msg": "ok"}`)을 반환.                                                                     | `extract(request)` 호출               | `ExtractorError` 발생 (rt_cd="0"이 아니므로 실패로 간주).                               | `job_id="valid_job"`   |   Low    |
-| **TC-007** | Unit (Config) |      SC-07      | 1. `kis.base_url`이 비어있는(`""`) Config 객체 준비.                                                                                     | `KISExtractor` 인스턴스 생성 시도     | 생성자(`__init__`) 실행 중 `ExtractorError` 발생 ("Critical Config Error...").          | `base_url=""`          |   High   |
-| **TC-008** | Unit (Config) |      SC-08      | 1. 요청한 `job_id`가 Config의 `extraction_policy` 딕셔너리에 없음.                                                                       | `extract(request)` 호출               | `ExtractorError` 발생 ("Policy not found...").                                          | `job_id="unknown"`     |  Medium  |
-| **TC-009** | Unit (Config) |      SC-09      | 1. 해당 `job_id`의 Policy Provider가 "FRED"로 설정됨.                                                                                    | `extract(request)` 호출               | `ExtractorError` 발생 ("Provider Mismatch...").                                         | `job_id="fred_job"`    |  Medium  |
-| **TC-010** | Unit (Config) |      SC-10      | 1. 해당 `job_id`의 Policy가 존재하나, `tr_id` 필드가 누락됨(None).                                                                       | `extract(request)` 호출               | `ExtractorError` 발생 ("'tr_id' is missing...").                                        | `job_id="no_tr_id"`    |  Medium  |
-| **TC-011** |  Unit (Biz)   |      SC-11      | 1. HttpClient가 `rt_cd: "1"` (실패) 및 에러 메시지(`msg1`)를 반환.                                                                       | `extract(request)` 호출               | `ExtractorError` 발생 (메시지에 API 응답 `msg1` 내용 포함).                             | `rt_cd="1"`            |   High   |
-| **TC-012** | Unit (Error)  |      SC-12      | 1. `auth_strategy.get_token()` 메서드가 `Exception`을 발생시킴.                                                                          | `extract(request)` 호출               | `ExtractorError`로 래핑되어 발생 ("System Error...").                                   | `job_id="valid_job"`   |  Medium  |
-| **TC-013** | Unit (Error)  |      SC-13      | 1. `http_client.get()` 호출 시 네트워크 에러(Timeout 등) 발생.                                                                           | `extract(request)` 호출               | `ExtractorError`로 래핑되어 발생 ("System Error...").                                   | `Exception(...)`       |   High   |
+        Ready --> ValidateReq: extract(request)
+        ValidateReq --> CheckJobID: Has JobID?
+        CheckJobID --> CheckPolicy: JobID in Config?
+        CheckPolicy --> CheckProvider: Provider == 'KIS'?
+        CheckProvider --> CheckTRID: Has TR_ID?
+    }
+
+    state "Execution Phase" as EP {
+        CheckTRID --> GetToken: Success
+        GetToken --> BuildReq: Merge Params & Headers
+        BuildReq --> CallAPI: HTTP GET (Async)
+
+        CallAPI --> CheckStatus: Response Received
+        CheckStatus --> Success: rt_cd == "0"
+        CheckStatus --> Fail_Biz: rt_cd != "0"
+    }
+
+    Error_Init --> [*]: Raise ExtractorError
+    ValidateReq --> Error_Valid: Validation Failed
+    Error_Valid --> [*]: Raise ExtractorError
+    Fail_Biz --> [*]: Raise ExtractorError (Biz Logic)
+    Success --> [*]: Return ResponseDTO
+```
+
+## 3. BDD 테스트 시나리오 (전체 목록)
+
+**시나리오 요약:**
+
+- **초기화 (Initialization):** 1건 (설정 검증)
+- **요청 검증 (Validation):** 4건 (MC/DC 적용 - JobID, Policy, Provider, TR_ID)
+- **정상 흐름 (Functional):** 3건 (E2E, 파라미터 병합, URL 구성)
+- **보안 (Security):** 2건 (헤더 내 평문 키/토큰 주입 확인)
+- **데이터 안정성 (Robustness):** 2건 (비즈니스 응답 코드 검증)
+- **예외 및 데코레이터 (Exception):** 2건 (래핑 로직, 재시도/제한 적용)
+
+|  테스트 ID  | 분류 |  기법  | 전제 조건 (Given)                       | 수행 (When)                          | 검증 (Then)                                                        | 입력 데이터 / 상황                |
+| :---------: | :--: | :----: | :-------------------------------------- | :----------------------------------- | :----------------------------------------------------------------- | :-------------------------------- |
+| **INIT-01** | 단위 |  BVA   | `kis.base_url`이 비어있는 설정 객체     | `KISExtractor(config)` 초기화        | `ExtractorError` 발생 (Critical Config Error)                      | `base_url=""`                     |
+| **REQ-01**  | 단위 | MC/DC  | `job_id`가 없는 요청 객체               | `extract(request)` 호출              | `ExtractorError` 발생 (Invalid Request)                            | `job_id=None`                     |
+| **REQ-02**  | 단위 | MC/DC  | 설정 파일에 정의되지 않은 `job_id` 요청 | `extract(request)` 호출              | `ExtractorError` 발생 (Policy not found)                           | `job_id="UNKNOWN"`                |
+| **REQ-03**  | 단위 | MC/DC  | Provider가 'FRED'로 설정된 정책 요청    | `extract(request)` 호출              | `ExtractorError` 발생 (Provider Mismatch)                          | `provider="FRED"`                 |
+| **REQ-04**  | 단위 | MC/DC  | 정책에 필수 필드 `tr_id`가 누락됨       | `extract(request)` 호출              | `ExtractorError` 발생 (Missing tr_id)                              | `tr_id=None`                      |
+| **FLOW-01** | 단위 |  표준  | 유효한 설정, 정책, 토큰, 정상 응답      | `extract(request)` 호출              | 1. API 호출 성공<br>2. `ResponseDTO` 반환<br>3. `job_id` 일치 확인 | `params={"a": 1}`                 |
+| **FLOW-02** | 단위 |  BVA   | 정책 파라미터와 요청 파라미터 중복      | `extract(request)` 호출              | **요청 파라미터가 우선순위**를 가져 정책값을 덮어씀                | Policy:`{p:1}`, Req:`{p:2}`       |
+| **FLOW-03** | 단위 |  표준  | `base_url`과 `path`가 설정됨            | `_fetch_raw_data` 내부 호출 URL 확인 | 두 문자열이 결합된 **완전한 URL**로 호출됨                         | `url="host/path"`                 |
+| **SEC-01**  | 단위 |  보안  | `SecretStr` 타입의 앱 키/시크릿         | `_fetch_raw_data` 헤더 검사          | 헤더에는 `get_secret_value()`로 복호화된 **평문**이 주입됨         | `headers["appkey"]`               |
+| **SEC-02**  | 단위 |  보안  | `AuthStrategy`가 유효 토큰 반환         | `_fetch_raw_data` 헤더 검사          | `authorization` 헤더에 토큰 값이 포함됨                            | `headers["authorization"]`        |
+| **DATA-01** | 단위 |  BVA   | API 응답 `rt_cd`가 "1" (실패)           | `extract(request)` 호출              | `ExtractorError` 발생 (메시지: msg1 내용 포함)                     | `{"rt_cd": "1", "msg1": "Error"}` |
+| **DATA-02** | 단위 | 견고성 | API 응답에 `rt_cd` 필드 없음            | `extract(request)` 호출              | `ExtractorError` 발생 (Unknown Error)                              | `{"data": []}`                    |
+| **ERR-01**  | 예외 |  래핑  | 수집 중 예상치 못한 `ValueError` 발생   | `extract(request)` 호출              | `ExtractorError`로 래핑되어 던져짐 (System Error)                  | Raise `ValueError`                |
+| **DEC-01**  | 단위 |  메타  | `@retry`, `@rate_limit` 데코레이터 적용 | `_fetch_raw_data` 속성 검사          | 데코레이터 래퍼가 적용되어 있음 (실제 동작은 Stub으로 검증)        | `__wrapped__` 속성 확인           |
+
+```
+
+```

--- a/docs/TCS/data-pipeline/TCS-ETL-003.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-003.md
@@ -1,35 +1,66 @@
-# FRED Extractor Test Specification
+# FRED Extractor 테스트 명세서
 
-## 1. 개요
+## 1. 문서 정보 및 전략
 
-- **Target Module:** `src.extractor.providers.fred_extractor.FREDExtractor`
-- **Purpose:** FRED API 호출 로직의 정합성, 파라미터 병합 우선순위, JSON 강제 변환 로직 및 예외 처리를 검증.
-- **Reference:** `kis_extractor_test.py` (구조적 일관성 유지)
+- **대상 모듈:** `extractor.fred_extractor.FREDExtractor`
+- **복잡도 수준:** **높음 (High)** (파라미터 병합 로직 및 부모 클래스 오버라이딩 포함)
+- **커버리지 목표:** 분기 커버리지 100%, 구문 커버리지 100%
+- **적용 전략:**
+  - [x] **MC/DC (수정 조건/결정 커버리지):** 필수 파라미터(`series_id`)의 소스(Policy vs Request)에 따른 분기 검증.
+  - [x] **Data Integrity (데이터 무결성):** 시스템 강제 파라미터(`file_type=json`, `api_key`)의 우선순위 검증.
+  - [x] **Fail-Fast (조기 실패):** 설정 누락 및 정책 위반 시 즉각적인 에러 발생 검증.
+  - [x] **Decorator Verification:** 재시도(`@retry`) 및 로깅(`@log`) 동작 확인.
 
-## 2. 테스트 환경 및 전략
+## 2. 로직 흐름도
 
-- **Mocking:**
-  - `IHttpClient`: 실제 외부 API 호출 차단 및 응답 조작.
-  - `AppConfig`: Pydantic 검증 로직 격리 및 테스트용 정책(Policy) 주입.
-  - `LogManager`: `src.extractor.providers.abstract_extractor` 내부의 로거 호출을 Patch하여 Global Config 의존성 제거 (Critical).
-- **Assertions:**
-  - `RequestDTO` -> `Params Merge` -> `HttpClient Call` -> `ResponseDTO` 흐름 검증.
-  - `file_type=json` 및 `api_key` 주입 여부 필수 검증.
+```mermaid
+graph TD
+    Start([RequestDTO Start]) --> Validate{Validate Request}
 
-## 3. 테스트 케이스 명세
+    Validate -- No Job ID --> Error_Job[Err: Mandatory JobID]
+    Validate -- No Policy --> Error_Policy[Err: Policy Missing]
+    Validate -- Wrong Provider --> Error_Prov[Err: Provider Mismatch]
 
-|  Test ID   | Category  | Given (Preconditions)                                                                                 | When (Action)           | Then (Expected Outcome)                                                                             | Input Data                    | Priority |
-| :--------: | :-------: | :---------------------------------------------------------------------------------------------------- | :---------------------- | :-------------------------------------------------------------------------------------------------- | :---------------------------- | :------- |
-| **TC-001** |   Unit    | 1. Config 정상 설정<br>2. Policy에 `series_id` 존재<br>3. API가 정상 JSON 반환 (`error_message` 없음) | `extract(request)` 호출 | 1. `ResponseDTO` 반환 성공<br>2. `source`="FRED"<br>3. `status_code`="200"<br>4. HTTP 호출 1회 발생 | `job_id="valid_job"`          | High     |
-| **TC-002** |   Unit    | 1. Policy Params: `{'freq': 'm'}`<br>2. Request Params: `{'start': '2020'}`                           | `extract(request)` 호출 | HTTP 호출 시 파라미터가 `{freq, start, api_key, file_type}` 모두 포함되어야 함                      | `params={'start': '2020'}`    | Medium   |
-| **TC-003** |   Unit    | 1. Request Params에 `file_type='xml'` 포함                                                            | `extract(request)` 호출 | **[FRED 특화]**<br>HTTP 호출 시 `file_type` 파라미터가 반드시 `'json'`으로 강제 변환되어야 함       | `params={'file_type': 'xml'}` | High     |
-| **TC-004** |   Unit    | 1. Config API Key = `'SECRET'`                                                                        | `extract(request)` 호출 | **[FRED 특화]**<br>HTTP 호출 파라미터에 `api_key='SECRET'`가 포함되어야 함                          | `job_id="valid_job"`          | High     |
-| **TC-005** |   Unit    | 1. Policy Params에 `series_id` 없음<br>2. Request Params에 `series_id` 존재                           | `extract(request)` 호출 | 정상 처리 (Request 파라미터로 필수값 충족)                                                          | `params={'series_id': 'GDP'}` | Medium   |
-| **TC-006** |   Edge    | 1. Request Params가 `{}` (Empty)                                                                      | `extract(request)` 호출 | Policy에 정의된 기본 파라미터만 사용하여 호출                                                       | `params={}`                   | Low      |
-| **TC-007** |   Unit    | 1. Config의 `fred.base_url`이 비어있음                                                                | `FREDExtractor` 초기화  | `ExtractorError("Critical Config Error...")` 발생                                                   | `Config(base_url="")`         | High     |
-| **TC-008** | Exception | 1. Request의 `job_id`가 `None`                                                                        | `extract(request)` 호출 | `ExtractorError("Invalid Request...")` 발생                                                         | `request(job_id=None)`        | Medium   |
-| **TC-009** | Exception | 1. 요청한 `job_id`가 Config Policy에 없음                                                             | `extract(request)` 호출 | `ExtractorError("Policy not found...")` 발생                                                        | `job_id="unknown"`            | Medium   |
-| **TC-010** | Exception | 1. Policy의 Provider가 "FRED"가 아님 (예: "KIS")                                                      | `extract(request)` 호출 | `ExtractorError("Provider Mismatch...")` 발생                                                       | `job_id="kis_job"`            | Medium   |
-| **TC-011** | Exception | 1. Policy와 Request 양쪽 모두 `series_id` 누락                                                        | `extract(request)` 호출 | `ExtractorError("Missing Parameter: 'series_id'...")` 발생                                          | `params={}`                   | High     |
-| **TC-012** | Exception | 1. API 응답(200 OK) Body에 `{"error_message": "Bad Request"}` 포함                                    | `extract(request)` 호출 | **[FRED 특화]**<br>`ExtractorError("FRED API Failed: Bad Request...")` 발생                         | `job_id="valid_job"`          | High     |
-| **TC-013** | Exception | 1. HTTP Client가 예기치 않은 Exception 발생                                                           | `extract(request)` 호출 | 로깅 후 `ExtractorError("System Error: ...")` 래핑 발생                                             | `job_id="valid_job"`          | Low      |
+    Validate -- Pass --> CheckParam{Check 'series_id'}
+    CheckParam -- In Policy? --> Merge[Merge Params]
+    CheckParam -- In Request? --> Merge
+    CheckParam -- Neither --> Error_Param[Err: Missing 'series_id']
+
+    Merge --> Inject[Inject System Params]
+    Inject --> Fetch[Fetch Raw Data]
+
+    Fetch -- HTTP Error --> Retry{Retry Logic}
+    Retry -- Max Retries --> Error_Net[Err: Network Failure]
+
+    Fetch -- Success (200 OK) --> LogicCheck{Contains Error Msg?}
+    LogicCheck -- Yes --> Error_Biz[Err: FRED API Error]
+    LogicCheck -- No --> CreateRes[Create ResponseDTO]
+
+    CreateRes --> InjectMeta[Inject Metadata: job_id]
+    InjectMeta --> End([Return ResponseDTO])
+```
+
+## 3. BDD 테스트 시나리오
+
+**시나리오 요약:**
+
+- **초기화 (Initialization):** 3건 (필수 설정값 방어 로직)
+- **유효성 검증 (Validation - MC/DC):** 5건 (정책, 제공자, 파라미터 조합)
+- **실행 및 병합 (Execution & Merging):** 2건 (파라미터 우선순위, 메타데이터 주입)
+- **에러 처리 (Error Handling):** 3건 (논리적 에러, 예상치 못한 예외 래핑)
+
+|  테스트 ID  | 분류 |    기법    | 전제 조건 (Given)                        | 수행 (When)                          | 검증 (Then)                                                                      | 입력 데이터 / 상황            |
+| :---------: | :--: | :--------: | :--------------------------------------- | :----------------------------------- | :------------------------------------------------------------------------------- | :---------------------------- |
+| **INIT-01** | 단위 | fail-fast  | `base_url`이 설정되지 않음               | `FREDExtractor(http, config)` 초기화 | `ExtractorError` 발생 ("base_url is empty")                                      | `base_url=""`                 |
+| **INIT-02** | 단위 | fail-fast  | `api_key`가 설정되지 않음                | `FREDExtractor(http, config)` 초기화 | `ExtractorError` 발생 ("api_key is missing")                                     | `api_key=None`                |
+| **INIT-03** | 단위 |    표준    | 유효한 설정(`SecretStr` 키 포함)         | `FREDExtractor(http, config)` 초기화 | 인스턴스 정상 생성됨                                                             | `base_url="http://..."`       |
+| **VAL-01**  | 단위 |    표준    | Config에 해당 `job_id` 정책 없음         | `extract(request)` 호출              | `ExtractorError` 발생 ("Policy not found")                                       | `job_id="UNKNOWN_JOB"`        |
+| **VAL-02**  | 단위 |    표준    | Policy의 Provider가 "KIS"임              | `extract(request)` 호출              | `ExtractorError` 발생 ("Provider Mismatch")                                      | `provider="KIS"`              |
+| **VAL-03**  | 단위 | **MC/DC**  | `series_id`가 **Policy에만** 존재        | `extract(request)` 호출              | 정상 수행 (API 호출 발생)                                                        | Policy:`{series_id: A}`       |
+| **VAL-04**  | 단위 | **MC/DC**  | `series_id`가 **Request에만** 존재       | `extract(request)` 호출              | 정상 수행 (API 호출 발생)                                                        | Request:`{series_id: B}`      |
+| **VAL-05**  | 단위 | **MC/DC**  | `series_id`가 **어디에도 없음**          | `extract(request)` 호출              | `ExtractorError` 발생 ("series_id is required")                                  | Policy:`{}`, Request:`{}`     |
+| **EXEC-01** | 단위 |   데이터   | Request 파라미터가 Policy와 중복됨       | `extract(request)` 호출              | 1. Request 값이 Policy 덮어씀<br>2. `file_type=json` 및 `api_key` 강제 주입 확인 | Request:`{period: "M"}`       |
+| **EXEC-02** | 단위 |    구조    | 부모 `extract` 호출 흐름                 | `extract(request)` 호출              | 반환된 `ResponseDTO`의 `meta` 필드에 `job_id`가 올바르게 주입됨                  | `meta['job_id'] == "JOB_01"`  |
+| **ERR-01**  | 단위 |    논리    | HTTP 200이나 Body에 `error_message` 있음 | `extract(request)` 호출              | `ExtractorError` 발생 (메시지 및 코드 포함)                                      | Body:`{"error_message": "X"}` |
+| **ERR-02**  | 단위 |    래핑    | 내부 로직 중 `KeyError` 등 예상 외 에러  | `extract(request)` 호출              | `ExtractorError`로 래핑되어 전파됨 ("System Error")                              | Mock: `raise KeyError`        |
+| **ERR-03**  | 통합 | 데코레이터 | 네트워크 에러 발생 (Mocking)             | `_fetch_raw_data(request)` 호출      | `retry` 데코레이터 작동 확인 (call_count > 1)                                    | Mock: `raise NetworkError`    |

--- a/docs/TCS/data-pipeline/TCS-ETL-003.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-003.md
@@ -2,7 +2,7 @@
 
 ## 1. 문서 정보 및 전략
 
-- **대상 모듈:** `extractor.fred_extractor.FREDExtractor`
+- **대상 모듈:** `extractor.providers.fred_extractor.FREDExtractor`
 - **복잡도 수준:** **높음 (High)** (파라미터 병합 로직 및 부모 클래스 오버라이딩 포함)
 - **커버리지 목표:** 분기 커버리지 100%, 구문 커버리지 100%
 - **적용 전략:**

--- a/docs/TCS/data-pipeline/TCS-ETL-004.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-004.md
@@ -1,36 +1,82 @@
-# ECOS Extractor Test Specification
+# ECOS Extractor 테스트 명세서
 
-## 1. 개요
+## 1. 문서 정보 및 전략
 
-- **Target Module:** `src.extractor.providers.ecos_extractor.ECOSExtractor`
-- **Purpose:** ECOS API 특유의 Path Variable 기반 URL 조립 정합성, 필수 날짜 파라미터 검증, 그리고 응답 코드(INFO-000) 처리 및 예외 매핑을 검증.
-- **Reference:** `kis_extractor_test.py` (구조적 일관성 유지)
+- **대상 모듈:** `extractor.providers.ecos_extractor.ECOSExtractor`
+- **복잡도 수준:** **중 (Medium)** (엄격한 URL 경로 조립 및 이중 응답 구조 파싱)
+- **커버리지 목표:** 분기 커버리지 100%, 구문 커버리지 100%
+- **적용 전략:**
+  - [x] **MC/DC (수정 조건/결정 커버리지):** `_validate_request` 내 Job ID, Policy, Provider, 필수 날짜 파라미터의 독립적 결함 유발 검증.
+  - [x] **Path-Based Testing (경로 기반 테스트):** ECOS 고유의 이중 JSON 구조(Root/Service Level)에 따른 파싱 로직 검증.
+  - [x] **Defensive Logic Verification (방어 로직 검증):** 성공 응답임에도 메타데이터 구조가 다르거나(Root Result 존재), 내부 키가 누락된 경우(Implicit Success)에 대한 방어 코드 검증.
+  - [x] **Fail-Fast (조기 실패):** `base_url` 및 `api_key` 설정 누락 시 인스턴스 생성 즉시 차단.
+  - [x] **Fault Injection (결함 주입):** 네트워크 및 시스템 에러 상황 시뮬레이션을 통한 예외 래핑 로직 검증.
 
-## 2. 테스트 환경 및 전략
+## 2. 로직 흐름도
 
-- **Mocking:**
-  - `IHttpClient`: 실제 네트워크 요청 차단 및 응답 조작.
-  - `AppConfig`: 설정(URL, Key) 주입 및 정책(Policy) 격리.
-  - `LogManager`: `src.extractor.providers.abstract_extractor` 내부의 로거 호출을 Patch하여 의존성 제거.
-- **Assertions:**
-  - URL 조립 결과 검증 (Strict Path Variable Order).
-  - Pydantic DTO 변환 및 메타데이터 검증.
-  - ECOS 고유 에러 코드 및 네트워크 예외 매핑 검증.
+```mermaid
+stateDiagram-v2
+    [*] --> Validate: extract(request)
 
-## 3. 테스트 케이스 명세
+    state Validate {
+        [*] --> CheckJobID
+        CheckJobID --> CheckPolicy: Present
+        CheckPolicy --> CheckProvider: Found
+        CheckProvider --> CheckParams: "ECOS"
+        CheckParams --> Fetch: Valid Dates
 
-|  Test ID   | Category  | Given (Preconditions)                                                 | When (Action)                                       | Then (Expected Outcome)                                                                                         | Input Data                                                          | Priority |
-| :--------: | :-------: | :-------------------------------------------------------------------- | :-------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------ | :------- |
-| **TC-001** |   Unit    | 정상적인 Config(URL, Key), 유효한 Policy(StatCode, Cycle 등)가 설정됨 | `extract` 메서드 호출 (정상 Job ID, 날짜 범위 포함) | 1. `INFO-000` 응답 파싱 성공.<br>2. 반환된 DTO의 data가 Mock 응답과 일치.<br>3. `http_client.get`이 1회 호출됨. | `job_id="ecos_job"`, `start_date="20240101"`, `end_date="20240102"` | **High** |
-| **TC-002** |   Unit    | 상동. (URL 조립 로직 검증)                                            | `extract` 메서드 호출                               | **[중요]** 호출된 URL이 지정된 순서(/Key/Type/.../Start/End/...)와 정확히 일치하는지 검증.                      | `policy={"stat_code":"100Y", "cycle":"D" ...}`                      | **High** |
-| **TC-003** | Exception | `config.ecos.base_url`이 비어 있음 ("")                               | `ECOSExtractor` 인스턴스 생성 시도 (`__init__`)     | `ExtractorError` 발생 (Critical Config Error).                                                                  | `config.ecos.base_url = ""`                                         | Medium   |
-| **TC-004** | Exception | `config.ecos.api_key`가 누락됨                                        | `ECOSExtractor` 인스턴스 생성 시도 (`__init__`)     | `ExtractorError` 발생 (Critical Config Error).                                                                  | `config.ecos.api_key = None`                                        | Medium   |
-| **TC-005** | Exception | 정상 Config                                                           | `extract` 호출 시 `job_id` 누락                     | `ExtractorError` 발생 (Invalid Request).                                                                        | `job_id=None`                                                       | Medium   |
-| **TC-006** | Exception | 정상 Config                                                           | `extract` 호출 시 `start_date` 파라미터 누락        | `ExtractorError` 발생 (Mandatory for ECOS).                                                                     | `params={"end_date": "..."}`                                        | **High** |
-| **TC-007** | Exception | 정상 Config                                                           | `extract` 호출 시 `end_date` 파라미터 누락          | `ExtractorError` 발생 (Mandatory for ECOS).                                                                     | `params={"start_date": "..."}`                                      | **High** |
-| **TC-008** | Exception | Config에 정의되지 않은 `job_id`                                       | `extract` 호출                                      | `ExtractorError` 발생 (Policy not found).                                                                       | `job_id="unknown_job"`                                              | Low      |
-| **TC-009** | Exception | 해당 `job_id`의 Policy Provider가 "KIS"로 설정됨                      | `extract` 호출                                      | `ExtractorError` 발생 (Provider Mismatch).                                                                      | `policy.provider="KIS"`                                             | Medium   |
-| **TC-010** |   Unit    | API 응답 Root 레벨에 `RESULT.CODE`가 `INFO-200` (에러)임              | `extract` 호출 및 응답 수신                         | `ExtractorError` 발생 (ECOS API Failed).                                                                        | API Res: `{"RESULT": {"CODE": "INFO-200", "MESSAGE": "Error"}}`     | High     |
-| **TC-011** |   Unit    | API 응답 서비스(Service) 레벨 `RESULT.CODE`가 `INFO-200`임            | `extract` 호출 및 응답 수신                         | `ExtractorError` 발생 (Business Failure).                                                                       | API Res: `{"StatSearch": {"RESULT": {"CODE": "INFO-200"}}}`         | High     |
-| **TC-012** |   Unit    | API 응답에 예상된 서비스명(Key)이 없음                                | `extract` 호출 및 응답 수신                         | `ExtractorError` 발생 (Invalid Response).                                                                       | API Res: `{"WrongService": {...}}`                                  | Medium   |
-| **TC-013** | Exception | HttpClient에서 네트워크 예외 발생                                     | `extract` 호출                                      | `ExtractorError`로 래핑되어 발생 (System Error).                                                                | `SideEffect=Exception("Timeout")`                                   | Medium   |
+        CheckJobID --> Error: Missing
+        CheckPolicy --> Error: Missing
+        CheckProvider --> Error: Mismatch
+        CheckParams --> Error: Missing Date
+    }
+
+    state Fetch {
+        [*] --> BuildURL
+        BuildURL --> CallAPI
+        CallAPI --> Parse: Success (200 OK)
+        CallAPI --> Error: Network/System Fail
+    }
+
+    state Parse {
+        [*] --> CheckRoot
+        CheckRoot --> CheckServiceKey: No Root Error
+        CheckServiceKey --> CheckInnerResult: Key Exists
+        CheckInnerResult --> Success: "INFO-000"
+
+        CheckRoot --> Error: Root Error Code
+        CheckServiceKey --> Error: Key Missing
+        CheckInnerResult --> Error: Inner Error Code
+    }
+
+    Success --> [*]: Return ResponseDTO
+    Error --> [*]: Raise ExtractorError
+```
+
+## 3. BDD 테스트 시나리오
+
+**시나리오 요약:**
+
+- **초기화 (Initialization):** 3건 (필수 설정값 및 객체 생성 검증)
+- **요청 검증 (Validation):** 4건 (MC/DC 적용 - JobID, Policy, Provider, Date Params)
+- **정상 흐름 (Functional):** 1건 (전체 파이프라인 성공 및 URL 검증)
+- **데이터 안정성 (Data/Parsing):** 5건 (응답 구조 변형, 에러 코드, 암시적 성공 처리)
+- **예외 처리 (Exception):** 2건 (시스템 에러 래핑 및 비즈니스 에러 전파)
+
+|  테스트 ID  | 분류 | 기법  | 전제 조건 (Given)                        | 수행 (When)                    | 검증 (Then)                                                          | 입력 데이터 / 상황              |
+| :---------: | :--: | :---: | :--------------------------------------- | :----------------------------- | :------------------------------------------------------------------- | :------------------------------ |
+| **INIT-01** | 단위 |  BVA  | `ecos.base_url`이 비어있는 설정 객체     | `ECOSExtractor(config)` 초기화 | `ExtractorError` 발생 (Critical Config Error)                        | `base_url=""`                   |
+| **INIT-02** | 단위 |  BVA  | `ecos.api_key`가 없는 설정 객체          | `ECOSExtractor(config)` 초기화 | `ExtractorError` 발생 (Critical Config Error)                        | `api_key=None`                  |
+| **INIT-03** | 단위 | 표준  | 유효한 설정(URL, Key 포함) 객체          | `ECOSExtractor(config)` 초기화 | 인스턴스 정상 생성 (가드 절 통과)                                    | `base_url="http://..."`         |
+| **REQ-01**  | 단위 | MC/DC | `job_id`가 없는 요청 객체                | `extract(request)` 호출        | `ExtractorError` 발생 (Invalid Request)                              | `job_id=None`                   |
+| **REQ-02**  | 단위 | MC/DC | 설정 파일에 정의되지 않은 `job_id` 요청  | `extract(request)` 호출        | `ExtractorError` 발생 (Policy not found)                             | `job_id="UNKNOWN"`              |
+| **REQ-03**  | 단위 | MC/DC | Provider가 'KIS'로 설정된 정책 요청      | `extract(request)` 호출        | `ExtractorError` 발생 (Provider Mismatch)                            | `provider="KIS"`                |
+| **REQ-04**  | 단위 | MC/DC | `start_date` 파라미터가 누락됨           | `extract(request)` 호출        | `ExtractorError` 발생 (Mandatory for ECOS)                           | `params={"end_date": "..."}`    |
+| **FLOW-01** | 단위 | 표준  | 정상 정책, 서비스 내 `INFO-000` 응답     | `extract(request)` 호출        | 1. `ResponseDTO` 반환<br>2. URL 조립 포맷 일치<br>3. 메타데이터 검증 | `CODE="INFO-000"`               |
+| **DATA-01** | 단위 | 구조  | Root 레벨에 `RESULT.CODE="INFO-200"`     | `extract(request)` 호출        | `ExtractorError` 발생 (Root Level Failure)                           | `{"RESULT": {"CODE": "200"}}`   |
+| **DATA-02** | 단위 | 구조  | Root에 정책 경로(`StatisticSearch`) 없음 | `extract(request)` 호출        | `ExtractorError` 발생 (Invalid Response)                             | `{"WrongKey": {...}}`           |
+| **DATA-03** | 단위 | 구조  | 서비스 내 `RESULT.CODE="INFO-200"`       | `extract(request)` 호출        | `ExtractorError` 발생 (Business Failure)                             | `{"Stat..": {"RESULT": "200"}}` |
+| **DATA-04** | 단위 | 방어  | Root `RESULT` 존재하나 성공(`INFO-000`)  | `extract(request)` 호출        | 에러 없이 정상 데이터 반환 (Root 결과 무시 분기 검증)                | Root `CODE="INFO-000"`          |
+| **DATA-05** | 단위 | 방어  | 서비스 내 `RESULT` 키 자체가 누락됨      | `extract(request)` 호출        | 에러 없이 정상 데이터 반환 (암시적 성공 처리 분기 검증)              | `{"row": [...]} ` (No RESULT)   |
+| **ERR-01**  | 예외 | 래핑  | HTTP 클라이언트가 `ValueError` 발생      | `extract(request)` 호출        | `ExtractorError`로 래핑되어 던져짐 (System Error)                    | Raise `ValueError`              |
+| **ERR-02**  | 예외 | 전파  | 내부 로직에서 `ExtractorError` 발생      | `extract(request)` 호출        | 에러가 래핑되지 않고 그대로 전파됨 (중복 래핑 방지)                  | Raise `ExtractorError`          |

--- a/docs/TCS/data-pipeline/TCS-ETL-005.md
+++ b/docs/TCS/data-pipeline/TCS-ETL-005.md
@@ -1,31 +1,40 @@
-# UPBIT Extractor Test Specification
+# UPBIT Extractor 테스트 명세서
 
-## 1. 개요
+## 1. 문서 정보 및 전략
 
-- **대상 모듈:** `src.extractor.providers.upbit_extractor.UPBITExtractor`
-- **작성 목적:** Upbit Open API 수집 로직의 정합성 검증 및 예외 처리 견고성 확보.
-- **테스트 범위:** 인증 전략 연동, 파라미터 동적 병합, URL/Header 조립, Upbit 고유 에러 핸들링, Request/Config 유효성 검사.
+- **대상 모듈:** `extractor.upbit_extractor.UPBITExtractor`
+- **복잡도 수준:** **최상 (Critical)** (외부 가상화폐 거래소 API 연동 및 시세 데이터 수집)
+- **커버리지 목표:** 분기 커버리지(Branch Coverage) 100%, 구문 커버리지(Statement Coverage) 100%
+- **적용 전략:**
+  - [x] **MC/DC (수정 조건/결정 커버리지):** `_validate_request` 내 필수 파라미터(`market`, `markets`) 조합에 따른 경고 로직의 독립적 검증.
+  - [x] **Fail-Fast (조기 실패):** `base_url` 설정 누락 및 잘못된 정책 요청 시 즉각적인 예외 발생 여부 검증.
+  - [x] **Mocking & Stubbing:** `IHttpClient`, `IAuthStrategy`의 응답 제어를 통한 네트워크/인증 격리 테스트.
+  - [x] **Data Integrity:** Request 파라미터의 Policy 덮어쓰기(Override) 및 에러 객체(`error`) 감지 로직 검증.
 
-## 2. 테스트 환경 및 전략
+## 2. BDD 테스트 시나리오 (전체 목록)
 
-- **Mocking:** `IHttpClient`, `IAuthStrategy`, `AppConfig`는 철저히 Mocking하여 외부 의존성을 격리합니다.
-- **Logging:** `LogManager`를 Patch하여 테스트 중 불필요한 I/O를 방지하고, 특정 상황(Warning)에서의 로그 호출 여부를 검증합니다.
-- **Assertions:** 결과값(DTO) 뿐만 아니라, 호출된 URL, Header, Log Message를 검증하여 내부 로직의 정확성을 보장합니다.
+**시나리오 요약:**
 
-## 3. 테스트 케이스 명세
+- **초기화 (Initialization):** 1건 (설정 검증)
+- **요청 검증 (Validation):** 4건 (MC/DC 적용 - JobID, Policy, Provider, Params)
+- **정상 흐름 (Functional):** 2건 (파라미터 병합, URL 구성)
+- **보안 (Security):** 2건 (토큰 존재/미존재 시 헤더 구성)
+- **데이터 안정성 (Robustness):** 2건 (API 에러 응답 처리, 정상 응답 매핑)
+- **예외 및 데코레이터 (Exception):** 3건 (인증 예외 전파, 시스템 예외 래핑, 데코레이터 적용)
 
-|  Test ID   |         Category         | Given (Preconditions)                                                 | When (Action)                                 | Then (Expected Outcome)                                                                                      | Input Data                   | Priority |
-| :--------: | :----------------------: | :-------------------------------------------------------------------- | :-------------------------------------------- | :----------------------------------------------------------------------------------------------------------- | :--------------------------- | :------- |
-| **TC-001** |    **Unit (Config)**     | `config.upbit.base_url`이 비어있는 상태("")                           | `UPBITExtractor` 인스턴스 초기화 (`__init__`) | `ExtractorError` 발생 ("Critical Config Error").                                                             | `base_url=""`                | High     |
-| **TC-002** |  **Unit (Happy Path)**   | 정상 Config, Policy, AuthToken 존재. API는 정상 Dict 응답 반환.       | `extract(request)` 호출                       | status='OK', data=원본응답 반환. Info 로그 호출 확인.                                                        | `job_id="upbit_job"`         | High     |
-| **TC-003** |  **Unit (Happy Path)**   | 정상 Config, Policy 존재.                                             | `extract(request)` 호출                       | **URL**(`base+path`), **Header**(`Bearer Token`), **Params**가 순서대로 조립되어 `client.get` 호출됨을 검증. | `job_id="upbit_job"`, params | High     |
-| **TC-004** |     **Unit (Logic)**     | `AuthStrategy`가 `None`을 반환 (Public API).                          | `extract(request)` 호출                       | `client.get` 호출 시 헤더에 `Authorization` 필드가 **없어야 함**.                                            | `job_id="public_job"`        | Medium   |
-| **TC-005** |     **Unit (Logic)**     | Policy Params(`count=1`)와 Request Params(`count=100`)가 중복.        | `extract(request)` 호출                       | `client.get` 호출 시 **Request Param(`count=100`)이 우선** 적용되었는지 검증.                                | `params={'count': 100}`      | Medium   |
-| **TC-006** |     **Unit (Logic)**     | Request와 Policy 양쪽 모두 `market` 파라미터 없음.                    | `extract(request)` 호출                       | 예외 없이 진행되나, **Warning 로그**가 기록됨을 검증.                                                        | `params={}` (No market)      | Medium   |
-| **TC-007** |     **Unit (Logic)**     | API가 Dict가 아닌 **List** (예: 캔들 데이터)를 반환.                  | `extract(request)` 호출                       | 에러 없이 정상 처리되며 `ResponseDTO.data`가 List인지 검증.                                                  | API Resp: `[{}, {}]`         | Medium   |
-| **TC-008** | **Exception (Request)**  | `request.job_id`가 `None`.                                            | `extract(request)` 호출                       | `ExtractorError` 발생 ("Invalid Request").                                                                   | `job_id=None`                | High     |
-| **TC-009** |  **Exception (Policy)**  | 요청한 `job_id`가 Config Policy 맵에 없음.                            | `extract(request)` 호출                       | `ExtractorError` 발생 ("Policy not found").                                                                  | `job_id="unknown"`           | High     |
-| **TC-010** |  **Exception (Policy)**  | 해당 Policy의 Provider가 "UPBIT"가 아님 (예: "KIS").                  | `extract(request)` 호출                       | `ExtractorError` 발생 ("Provider Mismatch").                                                                 | `provider="KIS"`             | High     |
-| **TC-011** | **Exception (Response)** | API 응답 Body에 `error` 객체 포함 (`{"error": {"message": "Fail"}}`). | `extract(request)` 호출                       | `ExtractorError` 발생 (메시지 포함).                                                                         | API Resp: `{"error": ...}`   | High     |
-| **TC-012** | **Exception (Response)** | API 응답 Body에 `error` 키가 있으나 내부 필드 누락.                   | `extract(request)` 호출                       | `ExtractorError` 발생 (기본 메시지 "UnknownError" 등 확인).                                                  | API Resp: `{"error": {}}`    | Low      |
-| **TC-013** |       **Resource**       | `http_client.get` 호출 시 `ConnectionError` 발생.                     | `extract(request)` 호출                       | `ExtractorError`로 래핑되어 던져짐 ("System Error").                                                         | `client.get` raises Ex       | High     |
+|  테스트 ID  | 분류 | 기법  | 전제 조건 (Given)                         | 수행 (When)                          | 검증 (Then)                                                     | 입력 데이터 / 상황               |
+| :---------: | :--: | :---: | :---------------------------------------- | :----------------------------------- | :-------------------------------------------------------------- | :------------------------------- |
+| **INIT-01** | 단위 |  BVA  | `upbit.base_url`이 비어있는 설정 객체     | `UPBITExtractor(config)` 초기화      | `ExtractorError` 발생 (Critical Config Error)                   | `base_url=""`                    |
+| **REQ-01**  | 단위 | MC/DC | `job_id`가 없는 요청 객체                 | `extract(request)` 호출              | `ExtractorError` 발생 (Invalid Request)                         | `job_id=None`                    |
+| **REQ-02**  | 단위 | MC/DC | 설정 파일에 정의되지 않은 `job_id` 요청   | `extract(request)` 호출              | `ExtractorError` 발생 (Policy not found)                        | `job_id="UNKNOWN"`               |
+| **REQ-03**  | 단위 | MC/DC | Provider가 'KIS'로 설정된 정책 요청       | `extract(request)` 호출              | `ExtractorError` 발생 (Provider Mismatch)                       | `provider="KIS"`                 |
+| **REQ-04**  | 단위 | MC/DC | 정책/요청에 `market`, `markets` 모두 없음 | `extract(request)` 호출              | **Logger.warning 호출됨** (Parameter Warning)                   | `params={}`                      |
+| **FLOW-01** | 단위 |  BVA  | 정책 파라미터와 요청 파라미터 중복        | `extract(request)` 호출              | **요청 파라미터가 우선순위**를 가져 정책값을 덮어씀             | Policy:`{cnt:1}`, Req:`{cnt:10}` |
+| **FLOW-02** | 단위 | 표준  | `base_url`과 `path`가 설정됨              | `_fetch_raw_data` 내부 호출 URL 확인 | 두 문자열이 결합된 **완전한 URL**로 호출됨                      | `url="host/v1/candles..."`       |
+| **SEC-01**  | 단위 | 보안  | `AuthStrategy`가 유효 토큰 반환           | `_fetch_raw_data` 헤더 검사          | `authorization` 헤더에 토큰 값이 포함됨                         | `headers["authorization"]` 존재  |
+| **SEC-02**  | 단위 | 보안  | `AuthStrategy`가 `None` 반환 (Public)     | `_fetch_raw_data` 헤더 검사          | `authorization` 헤더가 **포함되지 않음**                        | `token=None`                     |
+| **DATA-01** | 단위 |  BVA  | API 응답 본문에 `error` 키 존재           | `extract(request)` 호출              | `ExtractorError` 발생 (UPBIT API Failed)                        | `{"error": {"message": "Fail"}}` |
+| **DATA-02** | 단위 | 표준  | 정상 JSON 응답 수신                       | `extract(request)` 호출              | 1. `ResponseDTO` 반환<br>2. 메타데이터(`source`, `job_id`) 검증 | `{"market": "KRW-BTC"}`          |
+| **ERR-01**  | 예외 | 전파  | `AuthStrategy`에서 예외 발생              | `extract(request)` 호출              | 예외가 **그대로 상위로 전파됨** (로그 기록 확인)                | Raise `AuthError`                |
+| **ERR-02**  | 예외 | 래핑  | 수집 중 예상치 못한 `KeyError` 발생       | `extract(request)` 호출              | `ExtractorError`로 래핑되어 던져짐 (System Error)               | Raise `KeyError`                 |
+| **DEC-01**  | 단위 | 메타  | `@retry`, `@rate_limit` 데코레이터 적용   | `_fetch_raw_data` 속성 검사          | 데코레이터 래퍼가 적용되어 있음 (실제 동작은 Stub으로 검증)     | `__wrapped__` 속성 확인          |


### PR DESCRIPTION
## 1. 🎫 PR 요약
> **이종(Heterogeneous) 금융 데이터 소스(KIS, ECOS, FRED, UPBIT)를 표준화된 파이프라인으로 수집하기 위한 추상화 계층 및 구현체 개발**
- `Template Method` 패턴을 적용하여 수집 생명주기(Validation -> Execution -> Packaging)를 통일하고, `Strategy` 패턴으로 인증 로직(OAuth2 vs JWT)을 분리하여 유지보수성과 확장성을 확보함.

## 2. 🛠 작업 내용
- **Core Abstraction**: `AbstractExtractor`를 통해 수집 파이프라인의 뼈대 구축 및 공통 에러 핸들링/로깅 정책 적용.
- **Concrete Extractors**:
  - `KISExtractor`: REST API, OAuth2 인증, 동적 헤더 처리.
  - `ECOSExtractor`: Path Variable 기반의 엄격한 URL 생성 로직 구현.
  - `FREDExtractor`: XML -> JSON 강제 변환 및 파라미터 병합 우선순위 처리.
  - `UPBITExtractor`: JWT(Payload + Nonce) 기반의 Stateless 인증 및 에러 객체 파싱.
- **Authentication**: `IAuthStrategy` 구현 (KIS: Stateful/Locking, UPBIT: Stateless/Signing).
- **Quality Assurance**: 전체 모듈에 대한 단위 테스트 작성 (커버리지 100% 달성).

## 3. 💡 기술적 의사결정 (Architecture & Tech Stack)

### A. Template Method Pattern for Extraction
> **결정 배경:** 각기 다른 API 엔드포인트를 호출하더라도 `검증(Validate) -> 수집(Fetch) -> 응답 규격화(Wrap)`라는 흐름은 동일함.
- **Trade-off:** 상속 구조로 인해 유연성이 일부 저하될 수 있으나(Strong Coupling), 모든 수집기가 동일한 로깅 및 에러 처리 표준을 준수하도록 강제하여 **운영 안정성(Operational Stability)**을 최우선함.

### B. Dual Auth Strategy (Stateful vs Stateless)
> **결정 배경:** API 제공자의 보안 모델 차이에 따라 인증 처리 방식을 이원화함.
- **KIS (Stateful/Manager):**
  - OAuth2 토큰의 만료 시간을 관리해야 하므로 `Double-Checked Locking`을 적용한 In-Memory Caching 구현.
  - **이유:** 잦은 토큰 발급 요청으로 인한 API Rate Limit 초과 방지.
- **UPBIT (Stateless/Manufacturer):**
  - 요청마다 고유한 Nonce와 Query Hash를 포함해 JWT를 즉시 생성.
  - **이유:** Replay Attack 방지 및 서버 상태 동기화 비용 제거.

### C. Fail-Fast Configuration
> **결정 배경:** 잘못된 설정(URL 누락, API Key 부재)으로 인한 에러는 런타임 재시도로 해결될 수 없음.
- **구현:** 객체 초기화(`__init__`) 시점에 필수 설정을 검사하고, 위반 시 즉시 `ExtractorError`를 발생시켜 어플리케이션 구동 단계에서 문제를 인지하도록 설계.

## 4. 📋 주요 변경점
- `src/extractor/providers/abstract_extractor.py`: 수집 라이프사이클 템플릿 정의 및 공통 에러(NetworkError -> ExtractorError) 래핑 로직.
- `src/extractor/adapters/auth.py`: KIS(Locking) 및 UPBIT(Signing) 인증 전략 구현.
- `src/extractor/providers/ecos_extractor.py`: ECOS 특유의 Path Variable URL 조립 로직 구현.
- `src/extractor/providers/fred_extractor.py`: JSON 포맷 강제(`file_type=json`) 및 200 OK 내 논리적 에러 파싱.
- `src/extractor/providers/kis_extractor.py`: Config 기반의 동적 URL/Header 로딩 처리.
- `src/extractor/providers/upbit_extractor.py`: Quotation API 연동 및 `error` 객체 파싱 로직.

## 5. 📸 테스트 결과 / 스크린샷
> **Unit Test Coverage: 100% Pass**
- 모든 분기(Branch)와 구문(Statement)에 대해 테스트를 수행하였으며, 특히 예외 상황(Network Timeout, 401/403 Auth Error, Malformed Response)에 대한 검증을 완료함.

| Module | Tests | Statements | Miss | Branch | BrPart | Coverage |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: |
| `abstract_extractor.py` | 10 | 38 | 0 | 2 | 0 | **100%** |
| `ecos_extractor.py` | 15 | 74 | 0 | 22 | 0 | **100%** |
| `fred_extractor.py` | 14 | 62 | 0 | 14 | 0 | **100%** |
| `kis_extractor.py` | 14 | 58 | 0 | 12 | 0 | **100%** |
| `upbit_extractor.py` | 15 | 62 | 0 | 14 | 0 | **100%** |
| **TOTAL** | **68** | **294** | **0** | **64** | **0** | **100%** |

## 6. 💬 리뷰 포인트 (Focus On)
- **Concurrency Safety (`auth.py`):** KIS 인증 전략에서 `asyncio.Lock`과 `_should_refresh()`를 활용한 토큰 갱신 로직이 Race Condition을 완벽히 방어하는지 검토 부탁드립니다.
- **Error Granularity:** 현재 모든 인프라/로직 에러를 `ExtractorError`로 단일화하여 래핑하고 있습니다. 상위 호출 계층에서 더 세분화된 에러 핸들링이 필요할지 의견 주십시오.
- **Parameter Merging:** 각 Extractor 별로 파라미터 병합 우선순위(Config vs Request) 정책이 조금씩 다릅니다(API 특성 반영). 이 부분이 문서화 없이 코드만으로 충분히 인지 가능한지 확인 바랍니다.