### PR TITLE
[Refactor] 로그인 응답 스키마 변경 및 로직 검증

### DIFF
--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -3,7 +3,7 @@ import type {
 	LoginParams,
 	LoginResponse,
 	LogoutResponse,
-	RefreshTokenResponse,
+	ReissueTokenResponse,
 	SignupParams,
 	VerifyEmailResponse,
 } from '../types/auth';
@@ -69,10 +69,9 @@ export const socialLogin = async (provider: string, code: string) => {
 };
 
 // 토큰 갱신 API 함수 (AuthResponse 반환)
-export const refreshToken = async (): Promise<RefreshTokenResponse> => {
-	// LoginResponse가 AuthResponse를 확장하도록 변경됨
+export const refreshToken = async (): Promise<ReissueTokenResponse> => {
 	const { data } =
-		await axiosInstance.post<RefreshTokenResponse>('/auth/refresh'); // Refresh Token은 인터셉터에서 처리
+		await axiosInstance.post<ReissueTokenResponse>('/auth/reissue'); // Refresh Token은 인터셉터에서 처리
 	return data;
 };
 

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,7 +1,8 @@
-import { axiosInstance } from '../libs/axios';
+import { axiosInstance, removeAuthTokens } from '../libs/axios';
 import type {
 	LoginParams,
 	LoginResponse,
+	RefreshTokenResponse,
 	SignupParams,
 	VerifyEmailResponse,
 } from '../types/auth';
@@ -67,9 +68,10 @@ export const socialLogin = async (provider: string, code: string) => {
 };
 
 // 토큰 갱신 API 함수 (AuthResponse 반환)
-export const refreshToken = async (): Promise<LoginResponse> => {
+export const refreshToken = async (): Promise<RefreshTokenResponse> => {
 	// LoginResponse가 AuthResponse를 확장하도록 변경됨
-	const { data } = await axiosInstance.post<LoginResponse>('/auth/refresh'); // Refresh Token은 인터셉터에서 처리
+	const { data } =
+		await axiosInstance.post<RefreshTokenResponse>('/auth/refresh'); // Refresh Token은 인터셉터에서 처리
 	return data;
 };
 
@@ -79,4 +81,5 @@ export const logout = async (): Promise<void> => {
 	// 리프레시 토큰은 HttpOnly Cookie로 관리되는 경우 서버가 자동으로 파싱합니다.
 	// 그렇지 않은 경우, 요청 바디나 헤더에 명시적으로 포함해야 합니다.
 	await axiosInstance.post('/auth/logout');
+	removeAuthTokens(); // 클라이언트 측 토큰 및 인증 플래그 제거
 };

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -2,6 +2,7 @@ import { axiosInstance, removeAuthTokens } from '../libs/axios';
 import type {
 	LoginParams,
 	LoginResponse,
+	LogoutResponse,
 	RefreshTokenResponse,
 	SignupParams,
 	VerifyEmailResponse,
@@ -77,9 +78,6 @@ export const refreshToken = async (): Promise<RefreshTokenResponse> => {
 
 // 로그아웃 API 함수 (서버에 Refresh Token 무효화 요청)
 export const logout = async (): Promise<void> => {
-	// 클라이언트가 가지고 있는 리프레시 토큰을 서버에 보내 무효화하도록 요청합니다.
-	// 리프레시 토큰은 HttpOnly Cookie로 관리되는 경우 서버가 자동으로 파싱합니다.
-	// 그렇지 않은 경우, 요청 바디나 헤더에 명시적으로 포함해야 합니다.
-	await axiosInstance.post('/auth/logout');
-	removeAuthTokens(); // 클라이언트 측 토큰 및 인증 플래그 제거
+	await axiosInstance.post<LogoutResponse>('/auth/logout');
+	removeAuthTokens();
 };

--- a/apps/web/src/components/auth/login-modal.tsx
+++ b/apps/web/src/components/auth/login-modal.tsx
@@ -54,9 +54,9 @@ export default function LoginModal({
 							type='email'
 							placeholder='아이디를 입력해 주세요.'
 							// 에러 메시지 전달
-							errorMessage={errors.id?.message}
-							className={errors.id ? 'border-red-500' : ''}
-							{...register('id')}
+							errorMessage={errors.email?.message}
+							className={errors.email ? 'border-red-500' : ''}
+							{...register('email')}
 						/>
 					</div>
 

--- a/apps/web/src/components/auth/logout-modal.tsx
+++ b/apps/web/src/components/auth/logout-modal.tsx
@@ -1,0 +1,25 @@
+import Modal from '../common/modal';
+import Button from '../common/button';
+
+type Props = {
+	onClose: () => void;
+	onConfirm: () => void;
+};
+
+export default function LogoutModal({ onClose, onConfirm }: Props) {
+	return (
+		<Modal onClose={onClose}>
+			<div className='flex flex-col w-full px-2 gap-6'>
+				<p>정말 로그아웃 하시겠습니까?</p>
+				<div className='flex gap-4 w-full justify-center'>
+					<Button size='sm' onClick={onClose}>
+						취소
+					</Button>
+					<Button size='sm' onClick={onConfirm}>
+						확인
+					</Button>
+				</div>
+			</div>
+		</Modal>
+	);
+}

--- a/apps/web/src/components/common/modal.tsx
+++ b/apps/web/src/components/common/modal.tsx
@@ -4,7 +4,7 @@ import Portal from './portal';
 // props로 클로즈 버튼과 내용을 정의
 type Props = {
 	children: React.ReactNode;
-	onClose: () => void;
+	onClose?: () => void;
 };
 
 /*

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -1,37 +1,14 @@
-import { useState } from 'react';
 import Button from '../common/button';
 import LogoIcon from '../icon/logo';
 import LoginModal from '../auth/login-modal';
 import SignupModal from '../auth/signup-modal';
-import { useAuthStore } from '../../store/auth';
-import { removeAuthTokens } from '../../libs/axios';
-import { logout as apiLogout } from '../../api/auth';
-
-// 모달 타입정의 어떤 모달을 띄울지 선택함
-type ModalType = 'login' | 'signup' | 'findIdPw' | null;
+import LogoutModal from '../auth/logout-modal';
+import { useHeaderLogic } from '../../hooks/auth/use-header-logic';
 
 export default function Header() {
-	const [modalType, setModalType] = useState<ModalType>(null);
-
-	// Zustand에서 로그인 상태와 로그아웃 액션만 가져옴
-	const { isLoggedIn, logout } = useAuthStore();
-
-	// 모달 on, off
-	const closeAll = () => setModalType(null);
-
-	// 로그아웃 핸들러
-	const handleLogout = async () => {
-		try {
-			// 서버에 로그아웃 요청 (리프레시 토큰 무효화)
-			await apiLogout();
-		} catch (error) {
-			console.error('Server logout failed:', error);
-			// 서버 로그아웃 실패해도 클라이언트 측 로그아웃은 진행
-		} finally {
-			removeAuthTokens(); // 클라이언트 측 토큰 삭제 (액세스, 리프레시 모두)
-			logout(); // Zustand 상태 업데이트
-		}
-	};
+	const { state, actions } = useHeaderLogic();
+	const { modalType, isLoggedIn } = state;
+	const { openModal, closeAll, handleLogoutConfirm } = actions;
 
 	return (
 		<>
@@ -43,16 +20,12 @@ export default function Header() {
 					<Button
 						size='sm'
 						className='w-auto px-3' // 로그아웃 텍스트 길이에 맞춰 너비 조정
-						onClick={handleLogout}
+						onClick={() => openModal('logout')}
 					>
 						로그아웃
 					</Button>
 				) : (
-					<Button
-						size='sm'
-						className='w-16'
-						onClick={() => setModalType('login')}
-					>
+					<Button size='sm' className='w-16' onClick={() => openModal('login')}>
 						로그인
 					</Button>
 				)}
@@ -62,16 +35,20 @@ export default function Header() {
 			{modalType === 'login' && (
 				<LoginModal
 					onClose={closeAll}
-					onClickSignup={() => setModalType('signup')}
-					onClickFindIdPw={() => setModalType('findIdPw')}
+					onClickSignup={() => openModal('signup')}
+					onClickFindIdPw={() => openModal('findIdPw')}
 				/>
 			)}
 
 			{modalType === 'signup' && (
 				<SignupModal
 					onClose={closeAll}
-					onClickLogin={() => setModalType('login')}
+					onClickLogin={() => openModal('login')}
 				/>
+			)}
+
+			{modalType === 'logout' && (
+				<LogoutModal onClose={closeAll} onConfirm={handleLogoutConfirm} />
 			)}
 		</>
 	);

--- a/apps/web/src/hooks/auth/use-header-logic.ts
+++ b/apps/web/src/hooks/auth/use-header-logic.ts
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { useAuthStore } from '../../store/auth';
+import { removeAuthTokens } from '../../libs/axios';
+import { logout as apiLogout } from '../../api/auth';
+
+export type ModalType = 'login' | 'signup' | 'findIdPw' | 'logout' | null;
+
+export function useHeaderLogic() {
+	const [modalType, setModalType] = useState<ModalType>(null);
+	const { isLoggedIn, logout } = useAuthStore();
+
+	const openModal = (type: ModalType) => setModalType(type);
+	const closeAll = () => setModalType(null);
+
+	const handleLogoutConfirm = async () => {
+		try {
+			// 서버에 로그아웃 요청 (리프레시 토큰 무효화)
+			await apiLogout();
+		} catch (error) {
+			console.error('Server logout failed:', error);
+			// 서버 로그아웃 실패해도 클라이언트 측 로그아웃은 진행
+		} finally {
+			removeAuthTokens(); // 클라이언트 측 토큰 삭제
+			logout(); // Zustand 상태 업데이트
+			closeAll(); // 모달 닫기
+		}
+	};
+
+	return {
+		state: {
+			modalType,
+			isLoggedIn,
+		},
+		actions: {
+			openModal,
+			closeAll,
+			handleLogoutConfirm,
+		},
+	};
+}

--- a/apps/web/src/hooks/auth/use-login-logic.ts
+++ b/apps/web/src/hooks/auth/use-login-logic.ts
@@ -21,7 +21,7 @@ export function useLoginLogic({ onClose }: Props) {
 		resolver: zodResolver(loginSchema),
 		mode: 'onSubmit',
 		defaultValues: {
-			id: '',
+			email: '',
 			password: '',
 		},
 	});
@@ -31,42 +31,53 @@ export function useLoginLogic({ onClose }: Props) {
 	const { mutate: loginMutate, isPending: isLoggingIn } = useLogin();
 
 	// 제출 핸들러
-	const onSubmit = handleSubmit((data) => {
-		loginMutate(
-			{ id: data.id, password: data.password },
-			{
-				onSuccess: (response) => {
-					// response 타입은 AuthResponse (LoginResponse)
-					if (response.accessToken) {
-						setAccessToken(response.accessToken);
-					}
-					// Refresh Token은 백엔드에서 HttpOnly 쿠키로 설정하므로 클라이언트에서 처리하지 않음
-					login(response.user || { id: 0, email: data.id });
+	const onSubmit = handleSubmit(
+		(data) => {
+			if (isLoggingIn) return;
+			loginMutate(
+				{ email: data.email, password: data.password },
+				{
+					onSuccess: (response) => {
+						// response 타입은 LoginResponse (success, message, data)
+						const accessToken = response.data?.access_token;
+						if (accessToken) {
+							setAccessToken(accessToken);
 
-					// [성공 메시지]
-					setToastMessage('로그인 되었습니다.');
+							login({
+								id: 0,
+								email: data.email,
+								name: '사용자',
+							});
+						}
 
-					onClose();
-					navigate('/');
+						// [성공 메시지]
+						setToastMessage('로그인 되었습니다.');
+
+						onClose();
+						navigate('/');
+					},
+					onError: (error: any) => {
+						const status = error?.response?.status;
+
+						if (status === 401 || status === 404) {
+							setError('password', {
+								type: 'manual',
+								message: '아이디 또는 비밀번호를 확인해주세요.',
+							});
+						} else {
+							setError('password', {
+								type: 'manual',
+								message: '회원이 아닙니다. 회원가입을 진행해 주세요',
+							});
+						}
+					},
 				},
-				onError: (error: any) => {
-					const status = error?.response?.status;
-
-					if (status === 401 || status === 404) {
-						setError('password', {
-							type: 'manual',
-							message: '아이디 또는 비밀번호를 확인해주세요.',
-						});
-					} else {
-						setError('password', {
-							type: 'manual',
-							message: '회원이 아닙니다. 회원가입을 진행해 주세요',
-						});
-					}
-				},
-			},
-		);
-	});
+			);
+		},
+		(errors) => {
+			console.error('로그인 유효성 검사 실패:', errors);
+		},
+	);
 
 	return {
 		formMethods,

--- a/apps/web/src/hooks/auth/use-refresh.ts
+++ b/apps/web/src/hooks/auth/use-refresh.ts
@@ -20,11 +20,18 @@ export function useRefresh() {
 			try {
 				// HttpOnly 쿠키에 저장된 Refresh Token이 있다면 브라우저가 자동으로 요청에 포함
 				// 클라이언트에서는 토큰 존재 여부를 알 수 없으므로, 일단 갱신을 시도하고 실패 시 로그아웃 처리
-				const data = await apiRefreshToken(); // API refresh 함수 호출
+				const response = await apiRefreshToken(); // API refresh 함수 호출
 
 				// 성공 시 새 토큰 저장 및 로그인 상태 복구
-				setAccessToken(data.accessToken);
-				login(data.user);
+				const newAccessToken = response.data.access_token;
+				setAccessToken(newAccessToken);
+
+				// 백엔드 명세상 유저 정보가 없으므로 기본값으로 로그인 처리
+				login({
+					id: 0,
+					email: '',
+					name: '사용자',
+				});
 			} catch (error) {
 				console.error('Silent refresh 실패:', error);
 				// 갱신 실패는 유효한 리프레시 토큰이 없다는 의미이므로, 모든 로컬 인증 정보를 제거

--- a/apps/web/src/hooks/auth/use-refresh.ts
+++ b/apps/web/src/hooks/auth/use-refresh.ts
@@ -10,6 +10,13 @@ export function useRefresh() {
 
 	useEffect(() => {
 		const trySilentRefresh = async () => {
+			// 로그인 상태 플래그가 없으면 갱신 시도하지 않음 (로그아웃 상태로 간주)
+			const isAuthenticated = localStorage.getItem('isAuthenticated');
+			if (!isAuthenticated) {
+				setIsInitialized(true);
+				return;
+			}
+
 			try {
 				// HttpOnly 쿠키에 저장된 Refresh Token이 있다면 브라우저가 자동으로 요청에 포함
 				// 클라이언트에서는 토큰 존재 여부를 알 수 없으므로, 일단 갱신을 시도하고 실패 시 로그아웃 처리

--- a/apps/web/src/libs/axios.ts
+++ b/apps/web/src/libs/axios.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import type { ReissueTokenResponse } from '../types/auth';
 
 const ACCESS_TOKEN_KEY = 'accessToken';
 const IS_AUTHENTICATED_KEY = 'isAuthenticated';
@@ -50,6 +51,12 @@ axiosInstance.interceptors.response.use(
 	(response) => response,
 	async (error) => {
 		const originalRequest = error.config;
+
+		// [무한 루프 방지] 토큰 갱신 요청 자체가 401 실패한 경우, 더 이상 재시도하지 않음
+		if (originalRequest.url?.includes('/auth/reissue')) {
+			return Promise.reject(error);
+		}
+
 		// 401 에러이고, 이전에 재시도하지 않은 요청인 경우
 		if (error.response?.status === 401 && !originalRequest._retry) {
 			originalRequest._retry = true; // 재시도 플래그 설정
@@ -57,9 +64,11 @@ axiosInstance.interceptors.response.use(
 			try {
 				// 토큰 갱신 API 호출 (Refresh Token은 서버에서 HttpOnly Cookie 등으로 관리,
 				// 필요시 요청 바디/헤더에 명시적으로 포함하여 전송)
-				const { data } = await axiosInstance.post('/auth/refresh'); // api/auth.ts의 refreshToken 함수 호출
-				setAccessToken(data.accessToken);
-				originalRequest.headers.Authorization = `Bearer ${data.accessToken}`; // 원래 요청 헤더 업데이트
+				const { data } =
+					await axiosInstance.post<ReissueTokenResponse>('/auth/reissue');
+				const newAccessToken = data.data.access_token;
+				setAccessToken(newAccessToken);
+				originalRequest.headers.Authorization = `Bearer ${newAccessToken}`; // 원래 요청 헤더 업데이트
 				return axiosInstance(originalRequest); // 원래 요청 재시도
 			} catch (refreshError) {
 				console.error('Token refresh failed:', refreshError);

--- a/apps/web/src/libs/axios.ts
+++ b/apps/web/src/libs/axios.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 const ACCESS_TOKEN_KEY = 'accessToken';
+const IS_AUTHENTICATED_KEY = 'isAuthenticated';
 
 export const getAccessToken = (): string | null => {
 	return localStorage.getItem(ACCESS_TOKEN_KEY);
@@ -10,9 +11,11 @@ export const setAccessToken = (token: string | null) => {
 	// Access Token은 Authorization 헤더에 항상 포함
 	if (token) {
 		localStorage.setItem(ACCESS_TOKEN_KEY, token);
+		localStorage.setItem(IS_AUTHENTICATED_KEY, 'true');
 		axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
 	} else {
 		localStorage.removeItem(ACCESS_TOKEN_KEY);
+		localStorage.removeItem(IS_AUTHENTICATED_KEY);
 		delete axiosInstance.defaults.headers.common['Authorization'];
 	}
 };
@@ -20,6 +23,7 @@ export const setAccessToken = (token: string | null) => {
 // Access Token과 Refresh Token 모두 제거하는 함수
 export const removeAuthTokens = () => {
 	localStorage.removeItem(ACCESS_TOKEN_KEY);
+	localStorage.removeItem(IS_AUTHENTICATED_KEY);
 	delete axiosInstance.defaults.headers.common['Authorization'];
 	// HttpOnly 쿠키로 관리되는 Refresh Token은 서버 측 로그아웃 엔드포인트 호출을 통해 제거
 };

--- a/apps/web/src/libs/schema/auth.ts
+++ b/apps/web/src/libs/schema/auth.ts
@@ -42,9 +42,9 @@ export type SignupSchemaType = z.infer<typeof signupSchema>;
 // 아이디는 이메일 형식인 것만 체크
 // 비밀번호: 입력 여부만 체크
 export const loginSchema = z.object({
-	id: z
+	email: z
 		.string()
-		.min(1, '아이디를 입력해주세요.')
+		.min(1, '이메일을 입력해주세요.')
 		.email('올바른 이메일 형식이 아닙니다.'),
 	password: z.string().min(1, '비밀번호를 입력해주세요.'),
 });

--- a/apps/web/src/mocks/handler.ts
+++ b/apps/web/src/mocks/handler.ts
@@ -169,7 +169,14 @@ const logoutResolver: HttpResponseResolver = async () => {
 	console.log('[MSW] 로그아웃 요청 받음');
 	// 클라이언트에서 토큰을 삭제하는 것이 주 목적이므로,
 	// 서버에서는 성공 응답만 보내주면 됨
-	return HttpResponse.json({ message: '로그아웃 성공' }, { status: 200 });
+	return HttpResponse.json(
+		{
+			success: true,
+			message: '로그아웃 성공',
+			data: null,
+		},
+		{ status: 200 },
+	);
 };
 
 /*

--- a/apps/web/src/mocks/handler.ts
+++ b/apps/web/src/mocks/handler.ts
@@ -109,7 +109,12 @@ const loginResolver: HttpResponseResolver = async ({ request }) => {
 						'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2YWMyNTI5ZS1kMDY3LTQ2ODQtOTZhOS0yYmYzNGM1NDBhMDYiLCJyb2xlIjoiVVNFUiIsImlhdCI6MTc2OTk1MTkxMywiZXhwIjoxNzY5OTUzNzEzfQ.WErNWe_zgQrhPXe5PKlTKZ-aeX7JDKjDev2Yu2Fmp8k',
 				},
 			},
-			{ status: 200 },
+			{
+				status: 200,
+				headers: {
+					'Set-Cookie': `refresh_token=mock-refresh-token-${Date.now()}; Path=/; Max-Age=604800; HttpOnly; SameSite=Lax`,
+				},
+			},
 		);
 	}
 
@@ -142,25 +147,43 @@ const socialLoginResolver: HttpResponseResolver = async ({
 				loginType: provider,
 			},
 		},
-		{ status: 200 },
+		{
+			status: 200,
+			headers: {
+				'Set-Cookie': `refresh_token=mock-social-refresh-token-${Date.now()}; Path=/; Max-Age=604800; HttpOnly; SameSite=Lax`,
+			},
+		},
 	);
 };
 
 // 토큰 갱신 Resolver
-const refreshTokenResolver: HttpResponseResolver = async () => {
+const refreshTokenResolver: HttpResponseResolver = async ({ cookies }) => {
 	console.log('[MSW] 토큰 갱신 요청 받음');
-	// 실제 백엔드에서는 리프레시 토큰을 사용하여 새 액세스 토큰을 발급
-	// 여기서는 간단히 새로운 가짜 액세스 토큰과 사용자 정보를 반환
+	console.log('[MSW] Cookies:', cookies); // 디버깅용: 실제 들어오는 쿠키 확인
+
+	// 쿠키 확인 (RTR) - MSW에서 파싱해준 cookies 객체 사용
+	const refreshToken = cookies.refresh_token;
+	if (!refreshToken) {
+		return HttpResponse.json(
+			{ message: 'Refresh Token이 없습니다.' },
+			{ status: 401 },
+		);
+	}
+
 	return HttpResponse.json(
 		{
-			accessToken: 'mock-new-access-token-' + Date.now(), // 매번 다른 토큰 반환
-			user: {
-				id: 1,
-				email: 'refreshed@test.com',
-				name: '갱신된유저',
+			success: true,
+			message: null,
+			data: {
+				access_token: 'mock-new-access-token-' + Date.now(),
 			},
 		},
-		{ status: 200 },
+		{
+			status: 200,
+			headers: {
+				'Set-Cookie': `refresh_token=mock-new-refresh-token-${Date.now()}; Path=/; Max-Age=604800; HttpOnly; SameSite=Lax`,
+			},
+		},
 	);
 };
 
@@ -203,7 +226,7 @@ export const handlers = [
 	http.post('*/auth/login/:provider', socialLoginResolver),
 
 	// 토큰 갱신 (POST)
-	http.post('*/auth/refresh', refreshTokenResolver),
+	http.post('*/auth/reissue', refreshTokenResolver),
 
 	// 로그아웃 (POST)
 	http.post('*/auth/logout', logoutResolver),

--- a/apps/web/src/mocks/handler.ts
+++ b/apps/web/src/mocks/handler.ts
@@ -95,18 +95,18 @@ const verifyCodeResolver: HttpResponseResolver = async ({ request }) => {
 
 // 일반 로그인 Resolver
 const loginResolver: HttpResponseResolver = async ({ request }) => {
-	const body = (await request.json()) as { id: string; password: string };
-	console.log(`[MSW] 로그인 요청: ${body.id}`);
+	const body = (await request.json()) as { email: string; password: string };
+	console.log(`[MSW] 로그인 요청: ${body.email}`);
 
 	// [테스트 시나리오] 특정 계정으로 로그인 시 성공
-	if (body.id === 'test@test.com' && body.password === 'password123!') {
+	if (body.email === 'test@test.com' && body.password === 'test1234!') {
 		return HttpResponse.json(
 			{
-				accessToken: 'mock-access-token-12345', // 가짜 토큰 발급
-				user: {
-					id: 1,
-					email: body.id,
-					name: '테스트유저',
+				success: true,
+				message: null,
+				data: {
+					access_token:
+						'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2YWMyNTI5ZS1kMDY3LTQ2ODQtOTZhOS0yYmYzNGM1NDBhMDYiLCJyb2xlIjoiVVNFUiIsImlhdCI6MTc2OTk1MTkxMywiZXhwIjoxNzY5OTUzNzEzfQ.WErNWe_zgQrhPXe5PKlTKZ-aeX7JDKjDev2Yu2Fmp8k',
 				},
 			},
 			{ status: 200 },

--- a/apps/web/src/types/auth.d.ts
+++ b/apps/web/src/types/auth.d.ts
@@ -78,8 +78,14 @@ export interface EmailVerificationResponse {
 	sign_up_token: string;
 }
 
-// 토큰 갱신 응답
-export interface RefreshTokenResponse extends AuthResponse {}
+// 토큰 갱신 (재발급) 응답
+export interface ReissueTokenResponse {
+	success: boolean;
+	message: string | null;
+	data: {
+		access_token: string;
+	};
+}
 
 // 로그아웃 응답
 export interface LogoutResponse {

--- a/apps/web/src/types/auth.d.ts
+++ b/apps/web/src/types/auth.d.ts
@@ -80,3 +80,10 @@ export interface EmailVerificationResponse {
 
 // 토큰 갱신 응답
 export interface RefreshTokenResponse extends AuthResponse {}
+
+// 로그아웃 응답
+export interface LogoutResponse {
+	success: boolean;
+	message: string;
+	data: null;
+}

--- a/apps/web/src/types/auth.d.ts
+++ b/apps/web/src/types/auth.d.ts
@@ -1,6 +1,6 @@
 // 일반 자체 로그인
 export interface LoginParams {
-	id: string;
+	email: string;
 	password: string; // LoginResponse는 AuthResponse를 확장
 }
 
@@ -55,7 +55,13 @@ export interface AuthResponse {
 }
 
 // LoginResponse와 RefreshTokenResponse가 AuthResponse를 확장
-export interface LoginResponse extends AuthResponse {}
+export interface LoginResponse {
+	success: boolean;
+	message: string | null;
+	data: {
+		access_token: string;
+	};
+}
 
 // 비밀번호 재설정 토큰 응답
 export interface VerifyTokenResponse {


### PR DESCRIPTION
## PR 개요

로그인 API 응답 DTO 구조와 백엔드 명세 동기화 및 성공/실패 시나리오별 분기 처리 고도화.
Axios 인터셉터 연동을 통한 RTR(Refresh Token Rotation) 토큰 갱신 로직 안정화 및 UI/UX 로직의 훅 분리를 통한 유지보수성 향상.

## 주요 변경 사항

### 1. 로그인 API 응답 DTO 및 데이터 매핑 최적화

* **백엔드 명세 동기화**
    * `LoginResponse` 및 `ReissueTokenResponse` 인터페이스 재정의 (`success`, `data.access_token` 구조 반영)
    * `response.data.access_token` 경로 통일을 통한 토큰 추출 로직 명확화 및 데이터 무결성 확보

### 2. 로그인 성공/실패 분기 처리 및 예외 핸들링 강화

* **성공 시나리오 통합**
    * `useLoginLogic` 훅 내 토큰 저장, 스토어 상태 업데이트, 토스트 메시지 출력, 리다이렉트 처리 흐름 일원화
* **에러 핸들링 세분화**
    * HTTP 상태 코드(401, 404 등)별 `onError` 분기 처리 적용
    * `react-hook-form`의 `setError`를 활용하여 UI 필드에 구체적 피드백(아이디/비밀번호 불일치 등) 직접 바인딩
* **개발 편의성 증대**
    * `handleSubmit`의 `onInvalid` 콜백 추가를 통해 폼 유효성 검사 실패 원인 파악 용이성 확보

### 3. 토큰 갱신(RTR) 및 인증 유지 로직 고도화

* **인터셉터 무한 루프 방지**
    * 401 에러 발생 시 토큰 갱신 시도, 갱신 실패 시 즉시 에러 반환 예외 처리 추가
* **MSW 모킹 환경 개선**
    * 로그인 및 토큰 갱신 시 `Set-Cookie` 헤더를 통한 `refresh_token` 브라우저 쿠키 저장 핸들러 수정
    * `cookies` 객체를 활용한 검증 로직 적용으로 모킹 환경 신뢰도 향상

### 4. 구조 리팩토링 및 테스트 용이성 확보

* **관심사 분리 (SoC)**
    * `Header` 컴포넌트의 모달 제어 및 로그아웃 로직을 `useHeaderLogic` 커스텀 훅으로 분리하여 뷰와 비즈니스 로직 격리
* **로그아웃 프로세스 안정화**
    * `finally` 블록 활용을 통해 서버 요청 실패 여부와 무관하게 클라이언트 토큰 및 인증 상태 초기화 보장