### PR TITLE
[feat] 주식 랭킹 UI 신규 도입 및 메인 페이지 구성(mockup)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import Header from './components/layout/header';
 import { useRefresh } from './hooks/auth/use-refresh';
 import OauthCallback from './components/auth/oauth-callback';
+import MainPage from './pages/main-page';
 
 export default function App() {
 	// 앱 초기화 (토큰 리프레시 시도)
@@ -25,10 +26,7 @@ export default function App() {
 			<Header />
 			<main className='w-full'>
 				<Routes>
-					<Route
-						path='/'
-						element={<div className='p-10 text-center'>홈</div>}
-					/>
+					<Route path='/' element={<MainPage />} />
 
 					<Route
 						path='/oauth/callback/google'

--- a/apps/web/src/components/stock/rank-layout.tsx
+++ b/apps/web/src/components/stock/rank-layout.tsx
@@ -1,0 +1,227 @@
+import StockFilterGroup from './stock-filter-group';
+import StockItem, { type StockItemData } from './stock-item';
+import TableHeader from './table-header';
+
+// 확인을 위한 임시 데이터
+const MOCK_DATA: StockItemData[] = [
+	{
+		id: 1,
+		rank: 1,
+		name: '현대차',
+		price: '517,000',
+		changeRate: 3.6,
+		tradeVolume: '379억원',
+		buyRatio: 75,
+		sellRatio: 25,
+	},
+	{
+		id: 2,
+		rank: 2,
+		name: '삼성전자',
+		price: '188,700',
+		changeRate: 4.13,
+		tradeVolume: '91억원',
+		buyRatio: 38,
+		sellRatio: 62,
+	},
+	{
+		id: 3,
+		rank: 3,
+		name: '한온시스템',
+		price: '5,670',
+		changeRate: 27.13,
+		tradeVolume: '82억원',
+		buyRatio: 43,
+		sellRatio: 57,
+	},
+	{
+		id: 4,
+		rank: 4,
+		name: 'SK하이닉스',
+		price: '890,000',
+		changeRate: 1.13,
+		tradeVolume: '75억원',
+		buyRatio: 21,
+		sellRatio: 79,
+	},
+	{
+		id: 5,
+		rank: 5,
+		name: 'KODEX 코스닥150레버리지',
+		price: '18,900',
+		changeRate: 13.44,
+		tradeVolume: '68억원',
+		buyRatio: 71,
+		sellRatio: 29,
+	},
+	{
+		id: 6,
+		rank: 6,
+		name: '에코프로',
+		price: '170,300',
+		changeRate: 13.23,
+		tradeVolume: '45억원',
+		buyRatio: 60,
+		sellRatio: 40,
+	},
+	{
+		id: 7,
+		rank: 7,
+		name: 'KODEX 레버리지',
+		price: '89,355',
+		changeRate: 5.6,
+		tradeVolume: '39억원',
+		buyRatio: 55,
+		sellRatio: 45,
+	},
+	{
+		id: 8,
+		rank: 8,
+		name: '한화솔루션',
+		price: '55,800',
+		changeRate: 21.56,
+		tradeVolume: '35억원',
+		buyRatio: 53,
+		sellRatio: 47,
+	},
+	{
+		id: 9,
+		rank: 9,
+		name: '현대ADM',
+		price: '9,370',
+		changeRate: 26.96,
+		tradeVolume: '32억원',
+		buyRatio: 51,
+		sellRatio: 49,
+	},
+	{
+		id: 10,
+		rank: 10,
+		name: '미래에셋증권',
+		price: '70,800',
+		changeRate: 14.93,
+		tradeVolume: '28억원',
+		buyRatio: 47,
+		sellRatio: 53,
+	},
+	{
+		id: 11,
+		rank: 11,
+		name: 'KODEX 코스닥150',
+		price: '20,230',
+		changeRate: 6.72,
+		tradeVolume: '27억원',
+		buyRatio: 69,
+		sellRatio: 31,
+	},
+	{
+		id: 12,
+		rank: 12,
+		name: '삼성전기',
+		price: '359,000',
+		changeRate: 15.99,
+		tradeVolume: '21억원',
+		buyRatio: 49,
+		sellRatio: 51,
+	},
+	{
+		id: 13,
+		rank: 13,
+		name: '대동기어',
+		price: '26,200',
+		changeRate: 3.96,
+		tradeVolume: '21억원',
+		buyRatio: 49,
+		sellRatio: 51,
+	},
+	{
+		id: 14,
+		rank: 14,
+		name: '두산에너빌리티',
+		price: '98,800',
+		changeRate: 2.17,
+		tradeVolume: '20억원',
+		buyRatio: 32,
+		sellRatio: 68,
+	},
+	{
+		id: 15,
+		rank: 15,
+		name: '기아',
+		price: '170,200',
+		changeRate: 3.71,
+		tradeVolume: '18억원',
+		buyRatio: 75,
+		sellRatio: 25,
+	},
+	{
+		id: 16,
+		rank: 16,
+		name: '우리기술',
+		price: '12,870',
+		changeRate: 4.29,
+		tradeVolume: '16억원',
+		buyRatio: 49,
+		sellRatio: 51,
+	},
+	{
+		id: 17,
+		rank: 17,
+		name: 'KODEX 200',
+		price: '84,200',
+		changeRate: 2.85,
+		tradeVolume: '16억원',
+		buyRatio: 51,
+		sellRatio: 49,
+	},
+	{
+		id: 18,
+		rank: 18,
+		name: '한화오션',
+		price: '140,700',
+		changeRate: 8.39,
+		tradeVolume: '15억원',
+		buyRatio: 59,
+		sellRatio: 41,
+	},
+	{
+		id: 19,
+		rank: 19,
+		name: 'LG전자',
+		price: '122,200',
+		changeRate: 4.26,
+		tradeVolume: '14억원',
+		buyRatio: 67,
+		sellRatio: 33,
+	},
+	{
+		id: 20,
+		rank: 20,
+		name: '한미반도체',
+		price: '201,000',
+		changeRate: -0.74,
+		tradeVolume: '12억원',
+		buyRatio: 24,
+		sellRatio: 76,
+	},
+];
+
+// 랭킹 페이지의 전체 레이아웃 담당
+export default function RankLayout() {
+	return (
+		<div className='w-full max-w-6xl mx-auto px-4'>
+			{/* 필터 영역 */}
+			<StockFilterGroup />
+
+			{/* 랭킹 리스트 영역 */}
+			<div className='rounded-lg'>
+				<TableHeader />
+				<div className='flex flex-col'>
+					{MOCK_DATA.map((item) => (
+						<StockItem key={item.id} data={item} />
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/stock/ratio-bar.tsx
+++ b/apps/web/src/components/stock/ratio-bar.tsx
@@ -1,0 +1,22 @@
+interface Props {
+	buy: number;
+	sell: number;
+}
+
+// 매수, 매도 비율 시각화 바
+export default function RatioBar({ buy, sell }: Props) {
+	return (
+		<div className='flex flex-col gap-1 w-full max-w-30'>
+			{/* 바 그래프 영역 */}
+			<div className='flex h-1.5 w-full overflow-hidden rounded-full bg-gray-200'>
+				<div className='bg-blue-500' style={{ width: `${buy}%` }} />
+				<div className='bg-red-500' style={{ width: `${sell}%` }} />
+			</div>
+			{/* 텍스트 수치 영역 */}
+			<div className='flex w-full justify-between text-[11px] text-gray-400'>
+				<span className='text-blue-500'>{buy}</span>
+				<span className='text-red-500'>{sell}</span>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/stock/stock-filter-group.tsx
+++ b/apps/web/src/components/stock/stock-filter-group.tsx
@@ -1,0 +1,40 @@
+// 랭킹 필터 버튼 그룹
+export default function StockFilterGroup() {
+	const wrapperClass = 'flex items-center rounded-xl bg-[#282932] p-1';
+	const activeBtnClass =
+		'rounded-lg bg-[#41434D] px-3 py-1.5 text-[13px] font-semibold text-white shadow-sm whitespace-nowrap';
+	const inactiveBtnClass =
+		'rounded-lg px-3 py-1.5 text-[13px] font-medium text-gray-400 transition-colors hover:text-gray-200 hover:bg-[#343540] whitespace-nowrap';
+
+	return (
+		<div className='flex gap-3 py-4 overflow-x-auto w-full scrollbar-hide'>
+			{/* 지역 필터 */}
+			<div className={wrapperClass}>
+				<button className={activeBtnClass}>전체</button>
+				<button className={inactiveBtnClass}>국내</button>
+				<button className={inactiveBtnClass}>해외</button>
+			</div>
+
+			{/* 정렬 기준 필터 */}
+			<div className={wrapperClass}>
+				<button className={activeBtnClass}>증권 거래대금</button>
+				<button className={inactiveBtnClass}>증권 거래량</button>
+				<button className={inactiveBtnClass}>거래대금</button>
+				<button className={inactiveBtnClass}>거래량</button>
+				<button className={inactiveBtnClass}>급상승</button>
+				<button className={inactiveBtnClass}>급하락</button>
+			</div>
+
+			{/* 시간 필터 */}
+			<div className={wrapperClass}>
+				<button className={activeBtnClass}>실시간</button>
+				<button className={inactiveBtnClass}>1일</button>
+				<button className={inactiveBtnClass}>1주일</button>
+				<button className={inactiveBtnClass}>1개월</button>
+				<button className={inactiveBtnClass}>3개월</button>
+				<button className={inactiveBtnClass}>6개월</button>
+				<button className={inactiveBtnClass}>1년</button>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/stock/stock-item.tsx
+++ b/apps/web/src/components/stock/stock-item.tsx
@@ -1,0 +1,58 @@
+import RatioBar from './ratio-bar';
+
+export interface StockItemData {
+	id: number;
+	rank: number;
+	name: string;
+	price: string;
+	changeRate: number;
+	tradeVolume: string;
+	buyRatio: number;
+	sellRatio: number;
+}
+
+interface Props {
+	data: StockItemData;
+}
+
+// 각 개별 종목 행 렌더링
+export default function StockItem({ data }: Props) {
+	const isPositive = data.changeRate > 0;
+	const changeColor = isPositive ? 'text-red-500' : 'text-blue-500';
+	const changeSign = isPositive ? '+' : '';
+
+	return (
+		<div className='grid grid-cols-[2.5fr_1fr_1fr_1fr_1.2fr] gap-4 items-center py-2 text-sm hover:bg-neutral-800 hover:rounded-md transition-colors '>
+			{/* 하트 + 순위 + 로고 + 이름 */}
+			<div className='flex items-center gap-3 pl-2'>
+				<button className='text-gray-300 hover:text-red-400'>♥</button>
+				<span className='w-5 text-center font-bold text-gray-500'>
+					{data.rank}
+				</span>
+				<div className='w-8 h-8 rounded-full bg-blue-300 flex items-center justify-center text-[10px] font-bold'>
+					로고
+				</div>
+				<span className='font-semibold'>{data.name}</span>
+			</div>
+
+			{/* 현재가 */}
+			<div className='text-right font-medium'>{data.price}원</div>
+
+			{/* 등락률 */}
+			<div className={`text-right font-semibold ${changeColor}`}>
+				{changeSign}
+				{data.changeRate.toFixed(2)}%
+			</div>
+
+			{/* 거래대금 순 */}
+			<div className='text-right font-medium text-gray-600'>
+				{data.tradeVolume}
+			</div>
+
+			{/* 비율 바 */}
+			<div className='flex justify-end pr-2'>
+				<RatioBar buy={data.buyRatio} sell={data.sellRatio} />
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/stock/table-header.tsx
+++ b/apps/web/src/components/stock/table-header.tsx
@@ -1,0 +1,12 @@
+// 테이블의 헤더를 담당
+export default function TableHeader() {
+	return (
+		<div className='grid grid-cols-[2.5fr_1fr_1fr_1fr_1.2fr] gap-4 py-3 text-sm'>
+			<div className='pl-2'>순위 · 오늘 13:25 기준</div>
+			<div className='text-right'>현재가</div>
+			<div className='text-right'>등락률</div>
+			<div className='text-right'>거래대금 순</div>
+			<div className='text-right pr-2'>증권 거래 비율 ⓘ</div>
+		</div>
+	);
+}

--- a/apps/web/src/pages/main-page.tsx
+++ b/apps/web/src/pages/main-page.tsx
@@ -1,0 +1,11 @@
+import RankLayout from '../components/stock/rank-layout';
+
+export default function MainPage() {
+	return (
+		<div className='py-10'>
+			{/* 추후 광고 진행 공간 */}
+			<div className='py-24' />
+			<RankLayout />
+		</div>
+	);
+}


### PR DESCRIPTION
## PR 개요

주식 랭킹 화면의 기본 골격을 구성하는 신규 UI 컴포넌트 및 메인 페이지 뼈대(Mockup) 구현.
임시 데이터를 활용한 시각화 및 라우팅 연결을 통해, 향후 실제 데이터 연동 및 기능 확장을 위한 프론트엔드 기반 구축.

## 주요 변경 사항

### 1. 주식 랭킹 전용 UI 컴포넌트 신규 구현

* **RankLayout**
    * 랭킹 페이지의 전체적인 레이아웃 구조를 담당하는 래퍼(Wrapper) 컴포넌트 구현
* **StockItem**
    * 주식 리스트 내 개별 종목의 데이터를 나타내는 행(Row) 렌더링 처리
* **RatioBar**
    * 각 종목별 매수/매도 비율을 직관적으로 보여주는 시각화 바 구성
* **StockFilterGroup**
    * 랭킹 조회 기준을 변경할 수 있는 필터 버튼 그룹 추가
* **TableHeader**
    * 주식 리스트 상단의 테이블 형태 헤더 영역 구성

### 2. 메인 페이지 구성 및 라우팅 연결

* **MainPage 신규 추가**
    * 새롭게 구현된 `RankLayout`을 렌더링하는 메인 페이지 컴포넌트 생성
* **루트 경로(/) 라우팅 수정**
    * 기존 루트 경로에 할당되어 있던 임시 플레이스홀더 제거
    * 앱 진입 시 `MainPage`가 바로 노출되도록 라우터 연결 수정

### 3. UI 데모용 Mock 데이터 적용

* **프레젠테이션 환경 구성**
    * 컴포넌트 레이아웃 및 스타일 검증을 위한 임시 목업(Mock) 데이터 통합
* **기본 인터랙션 시각화**
    * 테이블 스타일의 주식 리스트, 매수/매도 비율 바, 필터 버튼 등의 정상 출력 및 기본 UI 인터랙션 구조 확인 완료

## 완성된 UI
<img width="1423" height="787" alt="image" src="https://github.com/user-attachments/assets/e4185cc6-2657-4fe6-a250-6e2af477ebc6" />

* 위 빈 공간은 추후 광고 진행으로 임시로 빈공간으로 둠 `py-28` 적용
* 각 주식 행에 hover시 색깔이 달라짐 임시로 `bg-neutral-800` 적용
* 마우스 스크롤로 아래로 이동 가능 현재 20개의 데모 데이터 넣어둠