### PR TITLE
[Design] 거래 비율 바 차트 디자인

### DIFF
--- a/design_docs/DESIGN_CHANGELOG_#185.md
+++ b/design_docs/DESIGN_CHANGELOG_#185.md
@@ -1,0 +1,12 @@
+## [2026-02-22] - feature/#185-chart-design-KSY
+
+### Added & Changed (추가 및 변경 사항)
+* **태블릿 해상도 대응 반응형 디자인 적용**
+- 신규 마스터 컴포넌트 생성 및 UI 디자인 적용
+- 양방향(매수/매도 등) 거래 비율을 시각적으로 나타내는 게이지 막대(`Gauge_Bar`) UI 구현
+- 게이지 바 하단에 비율 수치를 표시하는 라벨(`Labels`) 영역 추가
+- 화면 해상도 및 데이터 길이에 맞게 유동적으로 크기가 변하도록 오토 레이아웃(Auto Layout) 최적화
+  - 라벨 영역에 `Gap: Auto` 속성을 적용하여 비율 수치가 게이지 양끝에 자동 정렬되도록 레이아웃 규칙 설정
+
+### 관련 산출물 및 참고 자료
+* **디자인 시안:** [https://www.figma.com/design/20IMijeghQ9NI6WxtS1wC8/AssetMind_-stock_chart?node-id=0-1&t=TbgFcvFGaxxj6Q1K-1]


### PR DESCRIPTION
# 거래 비율 시각화 Linear Gauge 바 차트 디자인

## 📌 **1. PR 요약**
매수와 매도의 거래 비율을 직관적으로 시각화하는 **Linear Gauge 형태의 바 차트 디자인**을 완료했습니다. 특히 데이터가 한쪽으로 치우치는 극단적인 상황에서도 시각적 요소가 소실되지 않도록 **최소 너비 규칙**을 정의하고 **명도 대비를 최적화**했습니다.

## 🛠 **2. 작업 내용**

### Linear Gauge UI 디자인
* **시각화 구조**: 매수(Red)와 매도(Blue)의 비율을 수평 바 형태로 배치하여 실시간 거래 기세를 파악하기 용이하도록 설계
* **텍스트 배치**: 차트 내부에 비율(%) 혹은 수치를 표기할 때의 가독성을 고려한 레이아웃 구성

### 극단적 비율 및 예외 상황 처리 (Edge Case)
* **최소 너비 규칙 (Min-width: 4)**: 99:1과 같이 한쪽 비율이 매우 낮을 때도 해당 영역이 최소 4의 크기를 유지하도록 최대 넓이를 설정하여 시각적으로 인지 가능하게 처리
* **전표/무표 상태 정의 (100:0 & 0:100)**: 한쪽 거래가 아예 없는 경우 바의 끝처리와 속성값을 정의하여 UI가 비어 보이지 않도록 구성

### 시각 보정 및 명도 대비 테스트
* **Contrast Check**: 차트 배경과 매수/매도 컬러 간의 명도 대비를 점검하여 정보 전달력 강화
* **A11y 검증**: 색약 사용자도 비율의 차이를 인지할 수 있도록 명도 차이를 둔 컬러 토큰 매핑

## 📸 **3. 스크린샷 / 영상 (선택 사항)**

| Trade Ratio Bar Chart (Linear Gauge) | Chart Contrast & Edge Case Validation |
| :---: | :---: |
| <img width="356" height="179" alt="image" src="https://github.com/user-attachments/assets/1557901c-b929-4181-a887-2272780e3614" /> | <img width="608" height="227" alt="image" src="https://github.com/user-attachments/assets/f70b7e27-e25b-4c33-9abc-d5ce25be477b" /> |

> **[참고]** 왼쪽: 기본 매수/매도 비율 차트 시안, 오른쪽: 99:1 상황에서의 최대 너비 적용 모습 및 명도 대비 점검 결과

## 📋 **4. 파일 변경 목록**
* `design_docs/DESIGN_CHANGELOG_#185`

## 🔗 5. 관련 링크
- **Figma 링크**: https://www.figma.com/design/20IMijeghQ9NI6WxtS1wC8/AssetMind_-stock_chart?node-id=0-1&t=iC6BKkhyvDbVvNtA-1

## 💬 **6. 리뷰 포인트**
* **최소 너비 적절성**: 극단적 비율(99:1)에서 정의한 **최소 크기 4**가 데이터 왜곡을 주지 않으면서도 충분히 인지 가능한 수준인지 확인 부탁드립니다.
* **100:0 상태 표현**: 한쪽이 0일 때 바의 라운딩 처리나 컬러 채우기 방식이 의도대로 자연스럽게 보이는지 검토해 주세요.