### PR TITLE
[Feat] 전사적 예외 처리 고도화 (Global Exception Handling)

### DIFF
--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/global/error/GlobalExceptionHandler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/global/error/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -30,19 +31,46 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(e.getMessage()));
     }
 
-    @ExceptionHandler(InvalidStockParameterException.class)
-    public ResponseEntity<ApiResponse<Void>> handleInvalidStockParameterException(InvalidStockParameterException e) {
-        log.warn("[Global Exception Handler] Invalid Stock Parameter Error: {}", e.getMessage());
+    /**
+     * DTO의 @Valid 검증 실패 시 발생
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+        log.warn("[Global Exception Handler] DTO Validation Error: {}", errorMessage);
+
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.fail(e.getMessage()));
+                .body(ApiResponse.fail(errorMessage));
     }
 
-    @ExceptionHandler(StockNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleStockNotFoundException(StockNotFoundException e) {
-        log.warn("[Global Exception Handler] Stock Not Found Error: {}", e.getMessage());
+    /**
+     * 비즈니스 로직 실행 중 발생하는 커스텀 예외 처리
+     * (StockNotFoundException, InvalidStockParameterException 등 모두 여기서 잡힘)
+     */
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.warn("[Global Exception Handler] Business Error: {}", e.getMessage());
+
+        ErrorCode errorCode = e.getErrorCode();
+
         return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.fail(e.getMessage()));
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode.getMessage()));
+    }
+
+    /**
+     * 처리하지 못한 모든 시스템 예외 (500 Internal Server Error)
+     * 클라이언트에게는 내부의 상세한 에러 내역을 숨기고 공통 메시지만 전달합니다.
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("[Global Exception Handler] 예상치 못한 서버 에러 발생: {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail("서버 내부에서 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."));
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
@@ -97,8 +97,8 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) {
         String payload = message.getPayload();
-        if (payload == null || payload.isEmpty()) return;
 
+        if (payload.isEmpty()) return;
 
         try {
             if (payload.startsWith("{")) {
@@ -132,7 +132,6 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
         dataList.forEach(data -> {
             log.info("[KIS WS] 실시간 체결 데이터 : {}", data.toString());
             eventPublisher.publishEvent(eventMapper.toEvent(data));
-
         });
     }
 

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
@@ -130,8 +130,12 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
         List<KisRealTimeData> dataList = dataParser.parse(payload);
 
         dataList.forEach(data -> {
-            log.info("[KIS WS] 실시간 체결 데이터 : {}", data.toString());
-            eventPublisher.publishEvent(eventMapper.toEvent(data));
+            try {
+                log.info("[KIS WS] 실시간 체결 데이터 : {}", data.toString());
+                eventPublisher.publishEvent(eventMapper.toEvent(data));
+            } catch (Exception e) {
+                log.error("[KIS WS] 개별 체결 데이터 처리 및 발행 중 에러 발생. Data: {}", data, e);
+            }
         });
     }
 

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/StockService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/StockService.java
@@ -8,7 +8,6 @@ import com.assetmind.server_stock.stock.application.mapper.StockMapper;
 import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
 import com.assetmind.server_stock.stock.domain.repository.StockHistoryRepository;
 import com.assetmind.server_stock.stock.domain.repository.StockSnapshotRepository;
-import com.assetmind.server_stock.stock.exception.InvalidStockParameterException;
 import com.assetmind.server_stock.stock.exception.StockNotFoundException;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockDataEntity;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockPriceRedisEntity;
@@ -39,7 +38,7 @@ public class StockService {
     public void processRealTimeTrade(RealTimeStockTradeEvent event) {
 
         if (event == null || event.stockCode() == null || event.stockCode().isBlank()) {
-            throw new InvalidStockParameterException(ErrorCode.INVALID_STOCK_PARAMETER);
+            throw new IllegalArgumentException("실시간 체결 데이터 이벤트에 필수 값이 누락되었습니다. (event: " + event + ")");
         }
 
         // 캐싱된 국내 전체 주식에서 실시간 주식 데이터의 주식 이름 추출
@@ -78,8 +77,8 @@ public class StockService {
 
     // 특정 주식의 시계열 데이터 조회
     public List<StockHistoryResponse> getStockRecentHistory(String stockCode, int limit) {
-        if (stockCode == null || stockCode.isBlank()) {
-            throw new InvalidStockParameterException(ErrorCode.INVALID_STOCK_PARAMETER);
+        if (!stockMetadataProvider.isExist(stockCode)) {
+            throw new StockNotFoundException(ErrorCode.NOT_FOUND_STOCK);
         }
 
         return stockHistoryRepository.findRecentData(stockCode, limit).stream()

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/listener/StockTradeEventListener.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/listener/StockTradeEventListener.java
@@ -37,7 +37,7 @@ public class StockTradeEventListener {
         } catch (Exception e) {
             // @Async가 적용된 비동기 메서드 이므로 메인 스레드로 예외가 전파되지 않음
             // 문제 파악을 위한 로그를 남김
-            log.error("[Stock Trade Event] 처리 중 에러 발생 : {}", e.getMessage());
+            log.error("[Stock Trade Event] 처리 중 에러 발생 : {}", e.getMessage(), e);
         }
     }
 

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/provider/StockMetadataProvider.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/provider/StockMetadataProvider.java
@@ -34,6 +34,11 @@ public class StockMetadataProvider {
         log.info("[StockMetadataProvider] {} 개의 주식 메타데이터 캐싱", stockNameCache.size());
     }
 
+    // 종목 코드를 기반으로 해당 종목 코드가 캐싱되어있는지 확인
+    public boolean isExist(String stockCode) {
+        return stockNameCache.containsKey(stockCode);
+    }
+
     // 종목 코드를 기반으로 종목 이름 조회
     public String getStockName(String stockCode) {
         return stockNameCache.getOrDefault(stockCode, stockCode);

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/StockWebSocketEventHandler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/StockWebSocketEventHandler.java
@@ -26,7 +26,7 @@ public class StockWebSocketEventHandler {
         try {
             messagingTemplate.convertAndSend("/topic/stocks/" + event.stockCode(), event.response());
         } catch (Exception e) {
-            log.error("[Stock WebSocket Event Handler] 특정 종목 시계열 데이터 전송 에러 : {}", e.getMessage());
+            log.error("[Stock WebSocket Event Handler] 특정 종목 시계열 데이터 전송 에러 : {}", e.getMessage(), e);
         }
     }
 
@@ -42,7 +42,7 @@ public class StockWebSocketEventHandler {
             // 부하가 생길 경우 0.5 ~ 1초에 한번 전송으로 로직을 구성할 수 있음
             messagingTemplate.convertAndSend("/topic/ranking", event.response());
         } catch (Exception e) {
-            log.error("[Stock WebSocket Event Handler] 랭킹 데이터 전송 에러 : {}", e.getMessage());
+            log.error("[Stock WebSocket Event Handler] 랭킹 데이터 전송 에러 : {}", e.getMessage(), e);
         }
     }
 }

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandlerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandlerTest.java
@@ -1,7 +1,9 @@
 package com.assetmind.server_stock.market_access.infrastructure.kis.websocket;
 
 import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisRealTimeData;
+import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.mapper.KisEventMapper;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisRealTimeDataParser;
+import com.assetmind.server_stock.stock.application.listener.dto.RealTimeStockTradeEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +15,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -27,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
 class KisWebSocketHandlerTest {
 
     @InjectMocks
@@ -41,6 +46,12 @@ class KisWebSocketHandlerTest {
 
     @Mock
     private KisRealTimeDataParser dataParser;
+
+    @Mock
+    private KisEventMapper eventMapper;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     private final String TEST_KEY = "TEST_APP_KEY";
 
@@ -153,6 +164,57 @@ class KisWebSocketHandlerTest {
 
             // Then: 반복문이 멈추지 않고 2번 모두 시도했는지 확인
             verify(session, times(2)).sendMessage(any(TextMessage.class));
+        }
+
+        @Test
+        @DisplayName("성공/실패: 다건 데이터 중 1건의 이벤트 발행에 실패해도, 나머지 데이터는 정상적으로 발행되어야 한다")
+        void givenMultipleData_whenOneFails_thenContinuePublishing(CapturedOutput output) throws Exception {
+            // Given: 2건의 데이터가 들어왔다고 가정
+            String payload = "0|H0STCNT0|002|MockData...";
+            KisRealTimeData successData = new KisRealTimeData("005930", "123000", 80000L, "1", 0L, 2.5,
+                    80000L, 81000L, 79000L, 100L, 1000L, 1000000L, 100.0, "20");
+            KisRealTimeData failData = new KisRealTimeData("035420", "123000", 80000L, "1", 0L, 2.5,
+                    80000L, 81000L, 79000L, 100L, 1000L, 1000000L, 100.0, "20");
+
+            when(dataParser.parse(payload)).thenReturn(List.of(failData, successData));
+
+            RealTimeStockTradeEvent dummyEvent = RealTimeStockTradeEvent.builder()
+                    .stockCode("005930")
+                    .currentPrice(80000L)
+                    .build();
+
+            // Mock: 첫 번째 데이터(failData) 매핑 시 RuntimeException 발생, 두 번째는 정상 통과
+            when(eventMapper.toEvent(failData)).thenThrow(new RuntimeException("매핑 도중 에러 발생"));
+            when(eventMapper.toEvent(successData)).thenReturn(dummyEvent);
+
+            // When: 메시지 핸들링 실행
+            assertDoesNotThrow(() -> handler.handleMessage(session, new TextMessage(payload)));
+
+            // Then 1: 첫 번째가 실패했어도 반복문이 멈추지 않고 두 번째 데이터에 대해 publishEvent가 1번 호출되어야 함
+            verify(eventPublisher, times(1)).publishEvent(any(RealTimeStockTradeEvent.class));
+
+            // Then 2: 실패한 데이터에 대한 정확한 에러 로그가 찍혔는지 검증
+            assertThat(output.getOut())
+                    .contains("[KIS WS] 개별 체결 데이터 처리 및 발행 중 에러 발생")
+                    .contains("매핑 도중 에러 발생");
+        }
+
+        @Test
+        @DisplayName("실패: 수신된 메시지 처리 중 치명적인 에러가 발생해도 세션이 죽지 않고 에러 로그를 남겨야 한다")
+        void givenFatalError_whenHandleMessage_thenCatchAndLog(CapturedOutput output) throws Exception {
+            // Given: payload 파싱 단계에서 NullPointerException이 터지도록 강제 설정
+            String badPayload = "CRITICAL_BAD_PAYLOAD";
+            when(dataParser.parse(badPayload)).thenThrow(new NullPointerException("Parser Crashed!"));
+
+            TextMessage message = new TextMessage(badPayload);
+
+            // When: 메시지 핸들링 실행
+            assertDoesNotThrow(() -> handler.handleMessage(session, message));
+
+            // Then: 로그 캡처 객체를 통해 에러 로그가 남았는지 확인
+            assertThat(output.getOut())
+                    .contains("[KIS WS] 메시지 처리 중 에러 발생")
+                    .contains("Parser Crashed!");
         }
     }
 

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/StockServiceTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/StockServiceTest.java
@@ -2,7 +2,6 @@ package com.assetmind.server_stock.stock.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -17,7 +16,7 @@ import com.assetmind.server_stock.stock.application.mapper.StockMapper;
 import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
 import com.assetmind.server_stock.stock.domain.repository.StockHistoryRepository;
 import com.assetmind.server_stock.stock.domain.repository.StockSnapshotRepository;
-import com.assetmind.server_stock.stock.exception.InvalidStockParameterException;
+import com.assetmind.server_stock.stock.exception.StockNotFoundException;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockDataEntity;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockPriceRedisEntity;
 import com.assetmind.server_stock.stock.presentation.dto.StockHistoryResponse;
@@ -112,8 +111,7 @@ class StockServiceTest {
         void givenNullEvent_whenProcessRealTimeTrade_thenThrowException() {
             // when & then
             assertThatThrownBy(() -> stockService.processRealTimeTrade(null))
-                    .isInstanceOf(InvalidStockParameterException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_STOCK_PARAMETER);
+                    .isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
@@ -124,7 +122,7 @@ class StockServiceTest {
 
             // when & then
             assertThatThrownBy(() -> stockService.processRealTimeTrade(event))
-                    .isInstanceOf(InvalidStockParameterException.class);
+                    .isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
@@ -135,7 +133,7 @@ class StockServiceTest {
 
             // when & then
             assertThatThrownBy(() -> stockService.processRealTimeTrade(event))
-                    .isInstanceOf(InvalidStockParameterException.class);
+                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 
@@ -196,6 +194,7 @@ class StockServiceTest {
             int limit = 20;
             List<StockDataEntity> repositoryDataList = List.of(StockDataEntity.builder().build());
             given(stockHistoryRepository.findRecentData(stockCode, limit)).willReturn(repositoryDataList);
+            given(stockMetadataProvider.isExist(stockCode)).willReturn(true);
 
             List<StockHistoryResponse> expectedHistory = repositoryDataList.stream()
                     .map(StockHistoryResponse::from)
@@ -214,8 +213,8 @@ class StockServiceTest {
         void givenNullStockCode_whenGetStockRecentHistory_thenThrowException() {
             // when & then
             assertThatThrownBy(() -> stockService.getStockRecentHistory(null, 10))
-                    .isInstanceOf(InvalidStockParameterException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_STOCK_PARAMETER);
+                    .isInstanceOf(StockNotFoundException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_STOCK);
         }
 
         @Test
@@ -223,7 +222,7 @@ class StockServiceTest {
         void givenEmptyStockCode_whenGetStockRecentHistory_thenThrowException() {
             // when & then
             assertThatThrownBy(() -> stockService.getStockRecentHistory("  ", 10))
-                    .isInstanceOf(InvalidStockParameterException.class);
+                    .isInstanceOf(StockNotFoundException.class);
         }
     }
 }

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/RealTimeStockEventLightTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/RealTimeStockEventLightTest.java
@@ -1,5 +1,6 @@
 package com.assetmind.server_stock.stock.integration;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -13,14 +14,18 @@ import com.assetmind.server_stock.stock.application.listener.dto.RealTimeStockTr
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.web.socket.TextMessage;
 
+@ExtendWith(OutputCaptureExtension.class)
 @SpringBootTest(classes = {
         KisWebSocketHandler.class,          // 발행자
         StockTradeEventListener.class,      // 수신자
@@ -43,7 +48,7 @@ public class RealTimeStockEventLightTest {
     private StockService stockService;
 
     @Test
-    @DisplayName("이벤트 테스트용 컨텍스트에서 이벤트 발행 및 수신 검증")
+    @DisplayName("성공: 이벤트 테스트용 컨텍스트에서 이벤트 발행 및 수신 검증")
     void givenStockData_whenPublishEvent_thenSubscribeEvent() throws Exception {
         // given
         KisRealTimeData mockData = KisRealTimeData.builder()
@@ -74,6 +79,29 @@ public class RealTimeStockEventLightTest {
         assertThat(event.stockCode()).isEqualTo("005930");
         assertThat(event.changeSign()).isEqualTo("1");
 
+    }
+
+    @Test
+    @DisplayName("실패: 서비스 계층에서 예외가 발생해도 리스너가 스레드를 보호하고 로그를 남긴다.")
+    void givenServiceException_whenHandleEvent_thenCatchAndLogError(CapturedOutput output) {
+        // given: 임의의 실시간 체결 이벤트 생성
+        RealTimeStockTradeEvent dummyEvent = RealTimeStockTradeEvent.builder()
+                .stockCode("005930")
+                .currentPrice(80000L)
+                .changeSign("3") // 보합 기호
+                .build();
+
+        // Mocking: 서비스 계층에서 DB 타임아웃 등의 치명적 에러가 터졌다고 가정
+        doThrow(new RuntimeException("DB Connection Timeout!"))
+                .when(stockService).processRealTimeTrade(any(RealTimeStockTradeEvent.class));
+
+        // when & then 1: 예외가 리스너 밖으로 새어나가지 않는지 검증 (스레드 생존 검증)
+        assertDoesNotThrow(() -> eventListener.handleStockTradeEvent(dummyEvent));
+
+        // when & then 2: 캡처된 로그(output)에 의도한 ERROR 로그가 찍혔는지 검증
+        assertThat(output.getOut())
+                .contains("[Stock Trade Event] 처리 중 에러 발생")
+                .contains("DB Connection Timeout!");
     }
 
 }

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/StockRestApiIntegrationTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/StockRestApiIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 
+import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
 import com.assetmind.server_stock.stock.domain.repository.StockHistoryRepository;
 import com.assetmind.server_stock.stock.domain.repository.StockSnapshotRepository;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.StockDataEntity;
@@ -18,12 +19,15 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +46,9 @@ class StockRestApiIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
     private StringRedisTemplate redisTemplate;
+
+    @MockitoBean
+    private StockMetadataProvider stockMetadataProvider;
 
     @AfterEach
     void tearDown() {
@@ -209,6 +216,8 @@ class StockRestApiIntegrationTest extends IntegrationTestSupport {
             String stockCode = "005930";
             saveHistory(stockCode, 71000L, LocalDateTime.now());
 
+            BDDMockito.given(stockMetadataProvider.isExist(stockCode)).willReturn(true);
+
             // when & then
             // PathParameter(StockCode) 문서화를 위해 MockMvcRequestBuilders.get 대신 RestDocumentationRequestBuilders.get 사용
             mockMvc.perform(RestDocumentationRequestBuilders.get("/api/stocks/{stockCode}/history", stockCode)
@@ -254,6 +263,8 @@ class StockRestApiIntegrationTest extends IntegrationTestSupport {
             // given
             String stockCode = "005930";
             saveHistory(stockCode, 70000L, LocalDateTime.now());
+
+            BDDMockito.given(stockMetadataProvider.isExist(stockCode)).willReturn(true);
 
             // when & then
             mockMvc.perform(get("/api/stocks/{stockCode}/history", stockCode))

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/StockWebSocketIntegrationTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/StockWebSocketIntegrationTest.java
@@ -45,13 +45,10 @@ class StockWebSocketIntegrationTest extends IntegrationTestSupport {
     @Autowired
     private WebSocketHandler kisWebSocketHandler;
 
-    @Autowired
-    private SimpMessagingTemplate messagingTemplate;
-
     private WebSocketStompClient socketStompClient;
 
     private static final String WEBSOCKET_ENDPOINT = "/ws-stock";
-    private static final String SUBSCRIBE_SPECIFIC_TOPIC = "/topic/stocks/005930";
+    private static final String SUBSCRIBE_SPECIFIC_TOPIC = "/topic/stocks/035420";
     private static final String SUBSCRIBE_RANKING_TOPIC = "/topic/ranking";
 
     @BeforeEach
@@ -137,7 +134,7 @@ class StockWebSocketIntegrationTest extends IntegrationTestSupport {
 
         // when
         // MockDataFeeder로 가짜 다건 데이터 생성 후 강제 주입
-        String mockKisData = MockKisDataFeeder.createMockDataWithCount("005930", "75000", 3);
+        String mockKisData = MockKisDataFeeder.createMockDataWithCount("035420", "75000", 3);
 
         WebSocketSession mockSession = Mockito.mock(WebSocketSession.class);
         TextMessage textMessage = new TextMessage(mockKisData);

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/StockWebSocketEventHandlerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/StockWebSocketEventHandlerTest.java
@@ -13,10 +13,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
 class StockWebSocketEventHandlerTest {
 
     @Mock
@@ -48,7 +50,8 @@ class StockWebSocketEventHandlerTest {
 
     @Test
     @DisplayName("실패: StockHistorySavedEvent를 받고 데이터를 전송 중 예외가 발생해도 프로세스가 중단되지 않고 로그를 남기고 종료한다.")
-    void givenStockHistorySavedEvent_whenOccurErrorInSending_thenNotThrowExceptionLogging() {
+    void givenStockHistorySavedEvent_whenOccurErrorInSending_thenNotThrowExceptionLogging(
+            CapturedOutput output) {
         // given
         String stockCode = "005930";
         StockHistoryResponse mockHistoryResponse = StockHistoryResponse.builder()
@@ -66,6 +69,10 @@ class StockWebSocketEventHandlerTest {
         // handleSavedHistory 메서드 수행 도중 예외가 밖으로 던져지지 않았는지 검증
         assertThatCode(() -> stockWebSocketEventHandler.handleSavedHistory(historyEvent))
                 .doesNotThrowAnyException();
+
+        // 의도한 ERROR 로그가 콘솔에 잘 찍혔는지 검증
+        assertThat(output.getOut())
+                .contains("[Stock WebSocket Event Handler] 특정 종목 시계열 데이터 전송 에러");
     }
 
     @Test
@@ -91,7 +98,7 @@ class StockWebSocketEventHandlerTest {
 
     @Test
     @DisplayName("실패: StockRankingUpdatedEvent를 받고 데이터를 전송 중 예외가 발생해도 프로세스가 중단되지 않고 로그를 남기고 종료한다.")
-    void givenStockRankingUpdatedEvent_whenOccurErrorInSending_thenNotThrowExceptionLogging() {
+    void givenStockRankingUpdatedEvent_whenOccurErrorInSending_thenNotThrowExceptionLogging(CapturedOutput output) {
         // given
         String stockCode = "005930";
         StockRankingResponse mockRankingResponse = StockRankingResponse.builder()
@@ -101,9 +108,17 @@ class StockWebSocketEventHandlerTest {
         StockRankingUpdatedEvent rankingUpdatedEvent = new StockRankingUpdatedEvent(
                 mockRankingResponse);
 
+        willThrow(new MessagingException("랭킹 브로드캐스트 브로커 에러"))
+                .given(messagingTemplate)
+                .convertAndSend(any(String.class), any(Object.class));
+
         // when & then
         // handleUpdatedRanking 메서드 수행 도중 예외가 밖으로 던져지지 않았는지 검증
         assertThatCode(() -> stockWebSocketEventHandler.handleUpdatedRanking(rankingUpdatedEvent))
                 .doesNotThrowAnyException();
+
+        // 의도한 ERROR 로그가 콘솔에 잘 찍혔는지 검증
+        assertThat(output.getOut())
+                .contains("[Stock WebSocket Event Handler] 랭킹 데이터 전송 에러");
     }
 }

--- a/apps/server-stock/src/test/resources/application-test.yml
+++ b/apps/server-stock/src/test/resources/application-test.yml
@@ -5,7 +5,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop # 테스트 시작 시 생성, 끝나면 삭제
+      ddl-auto: create # 테스트 시작 시 생성
     show-sql: true
     properties:
       hibernate:

--- a/docs/TCS/stock/TCS-EVENT-001.md
+++ b/docs/TCS/stock/TCS-EVENT-001.md
@@ -2,7 +2,7 @@
 
 | 문서 ID | **TCS-EVENT-001**                             |
 | :--- |:----------------------------------------------|
-| **문서 버전** | 1.0                                           |
+| **문서 버전** | 1.1                                           |
 | **프로젝트** | AssetMind                                     |
 | **작성자** | 이재석                                           |
 | **작성일** | 2026년 02월 11일                                 |
@@ -18,7 +18,7 @@
 - **Test Class:** `RealTimeStockEventLightTest`
 - **Context Configuration:**
     - `KisWebSocketHandler`: 웹소켓 메시지 수신 및 이벤트 발행 (Subject)
-    - `StockTradeEventListener`: 이벤트 수신 확인 (`@SpyBean`)
+    - `StockTradeEventListener`: 이벤트 수신 및 예외 방어 로직 확인 (`@SpyBean`)
     - `KisRealTimeDataParser`: 원본 데이터 파싱 모의 (`@MockBean`)
     - `KisEventMapper`: DTO 변환 로직 (Real Bean)
 
@@ -32,11 +32,18 @@
 | :--- | :--- | :--- | :--- | :--- |
 | **STK-INT-001** | **정상적인 주가 데이터 수신 및 이벤트 전파**<br>(Golden Path) | 1. **Mock Data 생성:**<br> - 종목코드: `005930` (삼성전자)<br> - 현재가: `160,000`<br> - 등락부호: `"1"` (상한/상승)<br>2. **Parser Stubbing:**<br> - `parser.parse()` 호출 시 위 데이터를 반환하도록 설정 (`given`) | `webSocketHandler`<br>`.handleMessage()` 호출<br>(Dummy Payload 주입) | 1. `eventListener.handleStockTradeEvent()` 메서드가 **1회 호출**되어야 한다. (`verify`)<br>2. 리스너가 수신한 이벤트(`RealTimeStockTradeEvent`)의 필드값이 검증되어야 한다.<br> - `stockCode`: `"005930"` 일치<br> - `changeSign`: `"1"` 일치 |
 
+### 2.2. 예외 처리 및 스레드 생존 (Exception Handling & Stability)
+
+| ID | 시나리오 | Given (사전 조건) | When (실행) | Then (기대 결과) |
+| :--- | :--- | :--- | :--- | :--- |
+| **STK-INT-002** | **서비스 계층 예외 발생 시 리스너 생존 및 로깅**<br>(Exception Path) | 1. **Mock Event 생성:**<br>종목코드 `005930` 더미 이벤트<br>2. **Service Stubbing:**<br>`stockService.processRealTimeTrade()` 호출 시 `RuntimeException("DB Connection Timeout!")` 발생 강제 | `eventListener.handleStockTradeEvent()` 직접 호출 | 1. 예외가 리스너 외부로 던져지지 않음 (`assertDoesNotThrow`, 스레드 생존 보장)<br>2. 캡처된 콘솔 로그(`CapturedOutput`)에 정확한 에러 메시지와 원인이 기록됨 |
+
 ---
 
 ## 3. 종합 결과
 
 | 항목 | 전체 케이스 | Pass | Fail | 비고 |
 | :--- | :---: | :---: | :---: | :--- |
-| **Stock Event Pipeline** | 1 | 1 | 0 | 핸들러와 리스너 간의 이벤트 연결 및 데이터 매핑 검증 완료 |
-| **합계** | **1** | **1** | **0** | **Pass** ✅ |
+| **이벤트 파이프라인 흐름** | 1 | 1 | 0 | 정상 수신 및 데이터 매핑 검증 완료 |
+| **비동기 예외 방어** | 1 | 1 | 0 | **DB 장애 등 치명적 에러 발생 시 스레드 생존 및 로깅 완벽 검증** |
+| **합계** | **2** | **2** | **0** | **Pass** ✅ |

--- a/docs/TCS/stock/TCS-KIS-002.md
+++ b/docs/TCS/stock/TCS-KIS-002.md
@@ -2,7 +2,7 @@
 
 | 문서 ID | **TCS-KIS-002**                              |
 | :--- |:---------------------------------------------|
-| **문서 버전** | 1.1                                          |
+| **문서 버전** | 1.2                                          |
 | **프로젝트** | AssetMind                                    |
 | **작성자** | 이재석                                          |
 | **작성일** | 2026년 02월 05일                                |
@@ -11,19 +11,19 @@
 ## 1. 개요 (Overview)
 
 본 문서는 한국투자증권(KIS) 실시간 주식 데이터를 처리하는 **웹소켓 모듈 전체**에 대한 단위 테스트(Unit Test) 명세이다.
-연결을 관리하는 **어댑터(Adapter)**와 데이터를 처리하는 **핸들러(Handler)**의 기능을 다루며, 비동기 환경에서의 안정성 확보를 목표로 한다.
+연결을 관리하는 `어댑터(Adapter)`와 데이터를 처리하는 `핸들러(Handler)`의 기능을 다루며, 비동기 환경에서의 안정성 확보를 목표로 한다.
 
 ### 1.1. 테스트 대상 및 도구
-| 구분 | 대상 클래스 | 주요 검증 항목 | Mocking 도구 |
-|:---:|:---|:---|:---|
-| **Connection** | `KisWebSocketAdapter` | 연결/재접속, 구독 위임, 자원 해제 | `ReflectionTestUtils`, `CompletableFuture` |
-| **Logic** | `KisWebSocketHandler` | 구독 버퍼링, 데이터 파싱, 포맷 방어("H"), 예외 처리 | `WebSocketSession`, `ObjectMapper` |
+| 구분 | 대상 클래스 | 주요 검증 항목 | Mocking 도구                                                   |
+|:---:|:---|:---|:-------------------------------------------------------------|
+| **Connection** | `KisWebSocketAdapter` | 연결/재접속, 구독 위임, 자원 해제 | `ReflectionTestUtils`, `CompletableFuture`                   |
+| **Logic** | `KisWebSocketHandler` | 구독 버퍼링, 데이터 파싱, 포맷 방어("H"), 예외 처리 | `WebSocketSession`, `ObjectMapper`, `CapturedOutput(로그 확인용)` |
 
 ---
 
 ## 2.  KisWebSocketHandler 테스트 명세
 > **대상 클래스:** `KisWebSocketHandlerTest`
-> **검증 목표:** 데이터의 흐름 제어 및 파싱 정확성 검증
+> **검증 목표:** 데이터의 흐름 제어 및 파싱 정확성 검증, 스레드 생존성 및 로깅 검증
 
 ### 2.1. 구독 요청 및 버퍼링 (Subscription & Buffering)
 
@@ -34,76 +34,56 @@
 
 ### 2.2. 실시간 데이터 처리 (Data Parsing)
 
-| ID          | 테스트 메서드 / 시나리오                                                                                                                        | Given (사전 조건)                                      | When (수행 행동)                                 | Then (검증 결과)         |
-|:------------|:--------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------|:---------------------------------------------|:---------------------|
+| ID          | 테스트 메서드 / 시나리오                                                                                               | Given (사전 조건)                                      | When (수행 행동)                                 | Then (검증 결과)         |
+|:------------|:-------------------------------------------------------------------------------------------------------------|:---------------------------------------------------|:---------------------------------------------|:---------------------|
 | **WSH-003** | `givenRealTimePayload_whenHandleMessage_`<br>`thenInvokeParser`<br>👉 **실시간 데이터 수신 시 파서를 호출하고 데이터를 처리해야 한다** | **정상 텍스트 패킷**<br>`0\|ID\| 001\|데이터... (파이프 구분자 포함) | **메시지 수신** (`handleMessage`)                | 1. 파서가 한번 호출 되었는지 검증 |
 
 
-### 2.3. 예외 처리 및 자원 정리 (Exception & Cleanup)
+### 2.3. 예외 처리 및 스레드 생존 (Exception & Stability)
 
-| ID          | 테스트 메서드 / 시나리오                                                                                                                        | Given (사전 조건)                                                       | When (수행 행동)                                 | Then (검증 결과)                                                                                       |
-|:------------|:--------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------|:---------------------------------------------|:---------------------------------------------------------------------------------------------------|
-| **WSH-004** | `givenJsonError_whenSubscribeNewStock_`<br>`thenNotExitSystem`<br>👉 **객체 변환(JSON) 실패 시 시스템이 죽지 않고 로그만 남겨야 한다.** | **Mapper 고장 (Mock)**<br>`writeValueAsString` 호출 시 예외 발생 설정         | **구독 요청** (`subscribe`)                      | 1. 예외가 `catch` 블록에서 처리되어 시스템 종료를 방지함.<br>2. `sendMessage`는 호출되지 않음 (`never`).                  |
-| **WSH-005** | `givenTransportError_whenSubscribeNewStock_`<br>`thenNotExitSystem`<br>👉 **전송 중 IO 예외가 발생해도 다음 종목 처리는 계속되어야 한다.** | **네트워크 불안정 (Mock)**<br>첫 번째 전송 시 `IOException` 발생 설정              | **다수 종목 구독 요청** | 1. 첫 번째 종목 전송 실패 로그 출력.<br>2. 반복문이 중단되지 않고 **두 번째 종목 전송을 시도**함 (`times(2)`).               |
-| **WSH-006** | `whenCloseConnection_`<br>`thenCleanUpSessionAndFiled`<br>👉 **연결 종료 요청 시 세션을 닫고 내부 상태 변수를 초기화해야 한다.** | **세션 활성 (Open)**<br>구독 목록(`Set`)에 데이터가 존재하는 상태                   | **연결 종료** (`closeConnection`)                | 1. `session.close()`가 호출됨.<br>2. `currentSession`이 `null`로 초기화됨.<br>3. `subscribedStock`이 비워짐. |
-| **WSH-007** | `givenCloseError_whenCloseConnection_`<br>`thenCleanUpSessionAndFiled`<br>👉 **종료 중 에러가 발생해도 자원 정리는 수행되어야 한다 (Finally 검증).** | **종료 실패 (Mock)**<br>`close()` 호출 시 `IOException` 발생 설정             | **연결 종료** (`closeConnection`)                | 1. 예외가 발생하지만 무시됨.<br>2. `finally` 블록이 실행되어 내부 변수(`null`, `clear`) 초기화가 보장됨.                 |
-
----
-
-데이터의 흐름 제어 및 파싱 정확성 검증
-
-### 2.1. 구독 요청 및 버퍼링 (Subscription)
-
-| ID | 테스트 메서드 / 시나리오 | Given | When | Then |
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
 |:---:|:---|:---|:---|:---|
-| **WSH-001** | `givenNoSession_...`<br>👉 **세션 연결 전 요청은 대기열에 저장 후 일괄 전송한다.** | 세션 없음 (Null) | 1. 구독 요청<br>2. 연결 성공 이벤트 | 1. 요청 시점 전송 X (`never`)<br>2. 연결 직후 전송 O (`verify`) |
-| **WSH-002** | `givenSession_...`<br>👉 **연결된 상태에서는 대기열 없이 즉시 전송한다.** | 세션 활성 (Open) | 구독 요청 | 1. 즉시 `sendMessage` 호출됨. |
+| **WSH-004** | `givenJsonError_whenSubscribeNewStock_`<br>`thenNotExitSystem`<br>👉 **구독 페이로드(JSON) 변환 실패 시 시스템은 죽지 않아야 한다.** | Mapper 에러 설정 (Mock) | 구독 요청 | 예외 발생 없이(`catch`) 구독 전송만 건너뜀 |
+| **WSH-005** | `givenTransportError_whenSubscribeNewStock_`<br>`thenNotExitSystem`<br>👉 **연속 구독 요청 중 일부 전송 실패 시, 다음 종목은 계속 처리한다.** | 첫 번째 전송 IO 에러 설정 | 2개 종목 동시 구독 요청 | 반복문 중단 없이 2번 모두 전송 시도함 (`times(2)`) |
+| **WSH-006** | `givenMultipleData_whenOneFails_`<br>`thenContinuePublishing`<br>👉 **[부분 실패] 다건 데이터 중 1건 매핑 실패 시, 나머지는 정상 발행된다.** | 2건 데이터 파싱 중 1건 매핑 시 예외 발생 강제 | 메시지 수신 | 1. 반복문 중단 없이 두 번째 데이터 이벤트 정상 발행<br>2. 실패 데이터에 대한 ERROR 로그 출력 (`CapturedOutput` 확인) |
+| **WSH-007** | `givenFatalError_whenHandleMessage_`<br>`thenCatchAndLog`<br>👉 **수신 메시지 파싱 중 치명적 에러 발생 시 세션 유지 및 로깅한다.** | 파서에서 `NullPointerException` 강제 발생 | 메시지 수신 | 1. 웹소켓 스레드 종료 안 됨 (`assertDoesNotThrow`)<br>2. 원인 추적을 위한 에러 로그 기록 확인 |
 
-### 2.2. 데이터 파싱 및 방어 (Parsing & Defense)
+### 2.4. 자원 정리 (Cleanup)
 
-| ID | 테스트 메서드 / 시나리오 | Given | When | Then |
+| ID | 테스트 메서드 / 시나리오 | Given (사전 조건) | When (수행 행동) | Then (검증 결과) |
 |:---:|:---|:---|:---|:---|
-| **WSH-003** | `givenNormalStockData_...`<br>👉 **정상 체결 데이터(Count=1)를 파싱한다.** | 정상 텍스트 패킷 | 메시지 수신 | 예외 없이 로그 출력 확인. |
-| **WSH-004** | `givenMultiStockData_...`<br>👉 **멀티 레코드(Count=2+)를 반복 처리한다.** | 멀티 텍스트 패킷 | 메시지 수신 | 반복문 2회 실행 확인. |
-| **WSH-005** | `givenErrorStockData_...`<br>👉 **'H' 에러(개수 누락) 데이터도 방어 처리한다.** | 비정상 패킷 | 메시지 수신 | `NumberFormatEx` 없이 정상 처리. |
-| **WSH-006** | `givenJsonOperatorData_...`<br>👉 **JSON 제어 메시지는 별도로 처리한다.** | JSON 패킷 | 메시지 수신 | JSON 파서로 분기 처리됨. |
-
-### 2.3. 예외 및 정리 (Exception & Cleanup)
-
-| ID | 테스트 메서드 / 시나리오 | Given | When | Then |
-|:---:|:---|:---|:---|:---|
-| **WSH-007** | `givenJsonError_...`<br>👉 **변환 실패 시 시스템은 죽지 않아야 한다.** | Mapper 에러 설정 | 구독 요청 | `catch` 블록 처리, 시스템 유지. |
-| **WSH-008** | `givenTransportError_...`<br>👉 **전송 실패 시 다음 종목을 계속 처리한다.** | IO 에러 설정 | 다수 구독 요청 | 반복문 중단 없이 계속 진행. |
-| **WSH-009** | `whenCloseConnection_...`<br>👉 **종료 시 세션을 닫고 변수를 초기화한다.** | 세션 활성 | 연결 종료 | `close()` 호출 및 변수 `null` 확인. |
+| **WSH-008** | `whenCloseConnection_thenCleanUpSessionAndFiled`<br>👉 **종료 시 세션을 닫고 내부 상태 변수를 초기화한다.** | 세션 활성 및 구독 목록 존재 | 연결 종료 | `close()` 호출 및 변수 초기화 (`null`, `clear`) |
+| **WSH-009** | `givenCloseError_whenCloseConnection_`<br>`thenCleanUpSessionAndFiled`<br>👉 **종료 중 에러가 발생해도 자원 정리는 수행되어야 한다.** | `close()` 호출 시 예외 강제 | 연결 종료 | 예외 무시, `finally` 블록에서 변수 초기화 보장됨 |
 
 ---
 
 ## 3. Adapter Layer 테스트 명세 (Connection Lifecycle)
 > **대상:** `KisWebSocketAdapterTest`
 > **목표:** 연결 생명주기 및 외부 클라이언트 제어 검증
-
 ### 3.1. 연결 및 재접속 (Connect & Auto-Reconnect)
 
 | ID | 테스트 메서드 / 시나리오 | Given | When | Then |
 |:---:|:---|:---|:---|:---|
-| **ADP-001** | `givenMockSuccess_...`<br>👉 **연결 성공 시 재접속을 예약하지 않는다.** | 연결 성공 가정 | 연결 요청 | 1. 핸들러 키 주입.<br>2. 스케줄러 호출 X (`never`). |
-| **ADP-002** | `givenMockFail_...`<br>👉 **연결 실패 시 3초 뒤 재접속을 예약한다.** | 연결 실패 가정 | 연결 요청 | 1. 에러 로그.<br>2. 스케줄러 작업 예약 O (`verify`). |
+| **ADP-001** | `givenMockSuccess_whenConnect_thenLogSuccessAndNoReconnect`<br>👉 **연결 성공 시 재접속을 예약하지 않는다.** | 연결 성공 가정 | 연결 요청 | 1. 핸들러 키 주입.<br>2. 스케줄러 호출 X (`never`). |
+| **ADP-002** | `givenMockFail_whenConnect_thenScheduleReconnect`<br>👉 **연결 실패 시 3초 뒤 재접속을 예약한다.** | 연결 실패 가정 | 연결 요청 | 1. 에러 로그.<br>2. 스케줄러 작업 예약 O (`verify`). |
 
 ### 3.2. 위임 및 종료 (Delegation & Cleanup)
 
 | ID | 테스트 메서드 / 시나리오 | Given | When | Then |
 |:---:|:---|:---|:---|:---|
-| **ADP-003** | `whenSubscribe_...`<br>👉 **구독 요청을 핸들러에게 위임한다.** | - | 구독 요청 | `handler.subscribe` 호출 확인. |
-| **ADP-004** | `givenScheduledTask_...`<br>👉 **종료 시 재접속 예약을 취소한다.** | 예약된 태스크 존재 | 연결 종료 | 1. 태스크 `cancel` 호출.<br>2. `handler.close` 호출. |
+| **ADP-003** | `whenSubscribe_thenDelegateToHandler`<br>👉 **구독 요청을 핸들러에게 위임한다.** | - | 구독 요청 | `handler.subscribe` 호출 확인. |
+| **ADP-004** | `givenScheduledTask_whenDisconnect_thenCancelTaskAndCloseHandler`<br>👉 **종료 시 재접속 예약을 취소한다.** | 예약된 태스크 존재 | 연결 종료 | 1. 태스크 `cancel` 호출.<br>2. `handler.close` 호출. |
 
 ---
 
 ## 4. 테스트 결과 요약
 
 ### 4.1. 수행 결과
-| 구분                       | 전체 케이스 |  Pass  | Fail | 비고 |
-|:-------------------------|:------:|:------:| :---: | :--- |
-| **Subscription** |   2    |   2    | 0 | 연결 전/후 구독 요청 타이밍 검증 완료 |
-| **Parsing Logic** |   4    |   4    | 0 | 정상/비정상/멀티 패킷 파싱 완벽 대응 |
-| **Exception & Cleanup** |   4    |   4    | 0 | 장애 상황에서의 복구 및 자원 누수 방지 확인 |
-| **합계** | **10** | **10** | **0** | **Pass** ✅ |
+| 구분 | 전체 케이스 | Pass | Fail | 비고                         |
+|:---|:---:|:---:|:---:|:---------------------------|
+| **Subscription** | 2 | 2 | 0 | 연결 전/후 대기열 처리 완벽 검증        |
+| **Parsing Logic** | 1 | 1 | 0 | 파서 위임 및 정상 흐름 검증           |
+| **Exception & Stability** | 4 | 4 | 0 | 부분 실패 복구, 스레드 생존, 로그 캡처 검증 |
+| **Cleanup** | 2 | 2 | 0 | 메모리 누수 방지 (Finally 검증)     |
+| **Adapter 연동** | 4 | 4 | 0 | 연결, 재접속 스케줄러 검증            |
+| **합계** | **13** | **13** | **0** | **All Pass ✅**             |


### PR DESCRIPTION
## 📌 작업 내용
- **부분 실패(Partial Failure) 격리 및 방어:** KIS 실시간 데이터 다건 파싱 중 특정 1건이 실패하더라도, 전체 반복문이 중단되지 않고 나머지 정상 데이터는 끝까지 이벤트로 발행되도록 수정했습니다.
- **비동기 스레드 생존성 확보 및 로깅 강화:** `@Async` 리스너와 STOMP 브로드캐스트 발송부에 `try-catch`를 적용하여, DB 에러나 메시지 브로커 장애 시 스레드가 강제 종료되지 않고 정확한 Stack Trace를 남기도록 개선했습니다.

## 🏗 기술적 의사결정 및 설계 (Core Design)

### 1. GlobalExceptionHandler를 통한 중앙 집중형 에러 제어
> **목적:** 일관된 에러 응답 제공 및 서버 내부 에러 은닉

- **문제:** 기존에는 도메인별 예외가 산발적으로 던져지거나 검증 실패(`@Validated`) 시 표준화되지 않은 응답이 내려갔으며, 치명적 에러 발생 시 Stack Trace가 클라이언트에 날것으로 노출될 위험이 있었습니다.
- **해결:** `BusinessException`을 최상위 도메인 예외로 두고 다형성을 활용해 한 번에 낚아채도록 설계했습니다. 또한 `Exception.class`를 잡는 최후의 방어선을 구축하여, 서버 내부 에러는 500 상태 코드와 안전한 공통 메시지로 덮어씌우고 내부 로그로만 Stack Trace를 남기도록 처리했습니다.

### 2. 비동기 파이프라인(웹소켓/이벤트) 스레드 생존성 보장
> **목적:** 단건 데이터 파싱 에러나 일시적 브로커 장애 시 전체 실시간 스트림 유실 방지

- **문제:** KIS 수신부에서 배치 데이터를 처리할 때 1건이라도 매핑 에러가 나거나, `@Async` 리스너가 DB 저장 및 STOMP 전송 중 예외를 던지면 해당 백그라운드 스레드가 종료되어 이후 데이터가 모두 유실되는 구조적 취약점이 있었습니다.
- **설계 & 해결:** `KisWebSocketHandler`의 `forEach` 루프 내부와 이벤트 리스너 로직에 개별 `try-catch`를 촘촘하게 적용하여 에러를 격리시켰습니다.
- **결과:** 특정 이벤트 처리가 실패해도 시스템은 멈추지 않고 계속 동작하며, `OutputCaptureExtension`을 활용한 단위/통합 테스트를 통해 스레드 생존과 ERROR 로그 기록을 코드로 증명했습니다.

## ✅ 주요 변경점
- **Global & API:**
    - `GlobalExceptionHandler`: Validation, Business 커스텀 예외, 최상위 500 에러 처리 로직 추가.
- **Infrastructure (WebSocket & Event):**
    - `KisWebSocketHandler`: 실시간 데이터 순회 시 부분 실패 방어를 위한 로직 개선.
    - `StockTradeEventListener` & `StockWebSocketEventHandler`: 예외 캡처 및 로깅(`log.error`) 로직 추가.
- **Test:**
    - `RealTimeStockEventLightTest` 외 2건: `OutputCaptureExtension` 기반 비동기 예외 로깅 검증 테스트 추가.
- **Test Coverage**
실시간 웹소켓 통신 중에 발생할 예외들을 던지지않고 로그를 남기는 부분을 검증하는 테스트를 추가함으로 써, 코드 커버리지 및 분기 커버리지 각각 약 5% 향상
> 과거 예외 로깅을 검증하지 않은 테스트 결과서
<img width="2580" height="850" alt="image" src="https://github.com/user-attachments/assets/bdb59bff-0d7a-4016-939e-a7c98de4d901" />

> 현재 예외 로깅 검증을 추가한 테스트 결과서
<img width="1288" height="426" alt="image" src="https://github.com/user-attachments/assets/381a5053-af0d-47d6-a19b-cee040ef0c77" />


## 📝 리뷰 포인트
- **예외 응답 포맷:** `GlobalExceptionHandler`에서 정의한 400, 404, 500 에러의 `ApiResponse` JSON 응답 구조가 프론트엔드 연동 스펙과 정확히 일치하는지 확인 부탁드립니다.
- **비동기 예외 처리 방식:** `try-catch`로 묶어 단순히 ERROR 로그만 남기고 스레드를 살려둔 비동기 로직(`StockWebSocketEventHandler`, `StockTradeEventListener`) 중, 비즈니스 흐름상 반드시 상위 예외로 전파(Propagation)하거나 재시도(Retry)가 필요한 크리티컬한 구간은 없는지 검토 부탁드립니다.