### PR TITLE
[Feat] Transformer Exception Handling Expansion

### DIFF
--- a/apps/data-pipeline/src/common/exceptions.py
+++ b/apps/data-pipeline/src/common/exceptions.py
@@ -13,7 +13,7 @@ LogManager(log.py)와 결합하여 ELK/Datadog 등의 시스템에서 즉시 쿼
 Exception 발생 -> to_dict() 호출 -> LogManager가 JSON 직렬화 및 시간(KST/UTC) 태깅 -> 로그 저장
 """
 
-from typing import Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Tuple
 
 # ==============================================================================
 # 1. Global Base Exception
@@ -151,7 +151,79 @@ class AuthError(HttpError):
 # 5. Transformer Layer Detailed Exceptions
 # ==============================================================================
 
+class MergeKeyNotFoundError(TransformerError):
+    """병합 기준 키(Join Keys)가 대상 데이터프레임에 존재하지 않을 때 발생하는 예외.
+    
+    DataMerger 실행 전 DataFrame 검증 단계에서 누락된 키를 
+    조기에 발견하여, 잘못된 조인으로 인한 데이터 유실이나 메모리 낭비를 방지합니다.
+    """
 
+    def __init__(self, message: str, missing_keys: List[str], target_df_name: str) -> None:
+        # missing_keys를 Set이 아닌 List로 받는 이유: 
+        # Python의 Set 구조는 기본적으로 JSON 직렬화(Serialization)를 지원하지 않으므로,
+        # LogManager(ELK/Datadog 연동)에서 에러 없이 바로 파싱할 수 있도록 List 타입을 강제합니다.
+        details = {
+            "missing_keys": missing_keys,
+            "target_df_name": target_df_name
+        }
+        
+        # 데이터 누락은 재시도(Retry)한다고 해결되는 일시적 네트워크 에러가 아니므로
+        # should_retry=False로 설정하여 무한 루프나 불필요한 리소스 낭비를 원천 차단합니다.
+        super().__init__(message, details=details, should_retry=False)
+
+
+class MergeColumnCollisionError(TransformerError):
+    """조인 키가 아닌 동일한 이름의 컬럼이 두 데이터프레임에 존재할 때 발생하는 예외.
+    
+    Pandas가 자동으로 `_x`, `_y` 등의 접미사(Suffix)를 붙여 원본 스키마를 
+    은밀하게 변형하는 것을 방지하기 위한 방어적 예외입니다.
+    """
+
+    def __init__(self, message: str, colliding_columns: List[str]) -> None:
+        details = {
+            "colliding_columns": colliding_columns
+        }
+        
+        super().__init__(message, details=details, should_retry=False)
+
+
+class MergeCardinalityError(TransformerError):
+    """병합 과정에서 데이터(Row)가 폭발적으로 증가하거나 복제될 때 발생하는 예외.
+    
+    1:1 또는 N:1 병합을 의도했으나, 조인 키의 중복으로 인해 M:N 조인이 발생하여 
+    원본 데이터가 왜곡되는(Row 수가 늘어나는) 현상을 차단합니다.
+    """
+
+    def __init__(self, message: str, expected_relation: str, left_shape: Tuple[int, int], right_shape: Tuple[int, int]) -> None:
+        # shape 정보를 기록할 때 단순히 row count만 남기지 않고 Tuple 형태(행, 열)를 통째로 보존함으로써, 
+        # 컬럼 수가 함께 변형되었는지 여부를 디버깅 단계에서 추적할 수 있게 합니다.
+        details = {
+            "expected_relation": expected_relation,
+            "left_shape": left_shape,
+            "right_shape": right_shape
+        }
+        
+        super().__init__(message, details=details, should_retry=False)
+
+
+class MergeExecutionError(TransformerError):
+    """데이터프레임 병합 연산 중 발생하는 예측 불가한 런타임 예외.
+    
+    컬럼 타입 불일치(dtype mismatch), 메모리 초과(MemoryError) 등 
+    pandas의 merge() 호출 과정에서 발생하는 에러를 포착하고 원본 예외를 보존합니다.
+    """
+
+    def __init__(self, message: str, join_type: str, original_exception: Optional[Exception] = None) -> None:
+        details = {
+            "join_type": join_type
+        }
+        
+        super().__init__(
+            message, 
+            details=details, 
+            original_exception=original_exception, 
+            should_retry=False
+        )
 
 # ==============================================================================
 # 6. Loader Layer Detailed Exceptions

--- a/apps/data-pipeline/tests/unit/common/test_exceptions.py
+++ b/apps/data-pipeline/tests/unit/common/test_exceptions.py
@@ -11,7 +11,11 @@ from src.common.exceptions import (
     NetworkConnectionError,
     HttpError,
     RateLimitError,
-    AuthError
+    AuthError,
+    MergeKeyNotFoundError,
+    MergeColumnCollisionError,
+    MergeCardinalityError,
+    MergeExecutionError
 )
 
 # ========================================================================================
@@ -205,3 +209,83 @@ def test_hier_01_auth_inheritance():
     
     # AuthError는 재시도하지 않음 (401/403은 영구적 오류로 취급)
     assert error.should_retry is False
+
+# ========================================================================================
+# 4. 변환 계층 예외 테스트 (Transformer Exceptions)
+# ========================================================================================
+
+def test_trf_01_merge_key_not_found():
+    """[TRF-01] [Property] MergeKeyNotFoundError 생성 시 missing_keys 보존 및 재시도 불가 강제 검증"""
+    # Given
+    missing = ["user_id", "product_id"]
+    target_name = "df_sales"
+    
+    # When
+    error = MergeKeyNotFoundError(
+        message="Join keys are missing.", 
+        missing_keys=missing, 
+        target_df_name=target_name
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["missing_keys"] == missing
+    assert result["details"]["target_df_name"] == target_name
+    assert result["should_retry"] is False
+
+def test_trf_02_merge_column_collision():
+    """[TRF-02] [Property] MergeColumnCollisionError 생성 시 colliding_columns 보존 및 재시도 불가 강제 검증"""
+    # Given
+    colliding = ["status", "created_at"]
+    
+    # When
+    error = MergeColumnCollisionError(
+        message="Column collision detected.", 
+        colliding_columns=colliding
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["colliding_columns"] == colliding
+    assert result["should_retry"] is False
+
+def test_trf_03_merge_cardinality():
+    """[TRF-03] [Property] MergeCardinalityError 생성 시 shape 튜플 보존 및 재시도 불가 강제 검증"""
+    # Given
+    left = (100, 5)
+    right = (200, 6)
+    relation = "1:1"
+    
+    # When
+    error = MergeCardinalityError(
+        message="Cardinality explosion detected.", 
+        expected_relation=relation, 
+        left_shape=left, 
+        right_shape=right
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["expected_relation"] == relation
+    assert result["details"]["left_shape"] == left
+    assert result["details"]["right_shape"] == right
+    assert result["should_retry"] is False
+
+def test_trf_04_merge_execution_chaining():
+    """[TRF-04] [Chaining] MergeExecutionError 생성 시 join_type 보존 및 원본 런타임 예외 체이닝 검증"""
+    # Given
+    original = MemoryError("Out of memory during pandas merge")
+    join_type = "left"
+    
+    # When
+    error = MergeExecutionError(
+        message="Pandas merge failed unexpectedly.", 
+        join_type=join_type, 
+        original_exception=original
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["join_type"] == join_type
+    assert result["cause"] == "Out of memory during pandas merge"
+    assert result["should_retry"] is False

--- a/docs/TCS/data-pipeline/TCS-EXC-001.md
+++ b/docs/TCS/data-pipeline/TCS-EXC-001.md
@@ -8,8 +8,8 @@
 - **적용 전략:**
   - [x] **경계값 분석 (BVA):** 로그 축약(Truncation) 임계값인 500자를 기준으로 `Under`, `Exact`, `Over` 케이스 검증.
   - [x] **데이터 직렬화 (Serialization):** `to_dict()` 메서드가 LogManager가 요구하는 JSON 스키마를 정확히 준수하는지 검증.
-  - [x] **상속 계층 (Inheritance Hierarchy):** `try-except` 블록에서 상위 클래스(예: `ExtractorError`)로 하위 에러가 정상적으로 잡히는지 검증.
-  - [x] **재시도 정책 (Retry Policy):** 각 예외 클래스의 `should_retry` 속성이 설계 의도(네트워크=True, 설정=False 등)대로 설정되었는지 확인.
+  - [x] **상속 계층 (Inheritance Hierarchy):** `try-except` 블록에서 상위 클래스(예: `ExtractorError`, `TransformerError`)로 하위 에러가 정상적으로 잡히는지 검증.
+  - [x] **재시도 정책 (Retry Policy):** 각 예외 클래스의 `should_retry` 속성이 설계 의도대로 올바르게 고정되었는지 확인.
 
 ## 2. 로직 흐름도
 
@@ -31,29 +31,70 @@ classDiagram
     HttpError <|-- RateLimitError
     HttpError <|-- AuthError
 
+    TransformerError <|-- MergeKeyNotFoundError
+    TransformerError <|-- MergeColumnCollisionError
+    TransformerError <|-- MergeCardinalityError
+    TransformerError <|-- MergeExecutionError
+
     note for HttpError "Logic: Truncate body if len > 500"
     note for RateLimitError "Force: should_retry = True"
+    note for TransformerError "Force: should_retry = False (데이터 결함은 재시도 불가)"
 ```
 
 ## 3. BDD 테스트 시나리오
 
-**시나리오 요약 (총 12건):**
+### 3.1. 전역 기반 예외 (Global Base Exceptions)
 
-1.  **기반 로직 (Base Logic):** 3건 (JSON 직렬화, 원인 예외 체이닝, 콘솔 출력 포맷)
-2.  **데이터 축약 (Truncation):** 5건 (HTTP Body 경계값 [Under, Exact, Over], Null 처리, 스키마 데이터)
-3.  **계층 및 속성 (Hierarchy & Props):** 4건 (설정 키, 네트워크 URL, RateLimit 헤더, Auth 상속/재시도 정책)
+**시나리오 요약 (총 4건):**
 
-|  테스트 ID   | 분류 |   기법    | 전제 조건 (Given)                     | 수행 (When)                       | 검증 (Then)                                                                    | 입력 데이터 / 상황          |
-| :----------: | :--: | :-------: | :------------------------------------ | :-------------------------------- | :----------------------------------------------------------------------------- | :-------------------------- |
-| **BASE-01**  | 단위 |  직렬화   | `ETLError` 인스턴스 생성              | `to_dict()` 호출                  | 반환된 딕셔너리에 `error_type`, `message`, `should_retry` 키가 필수적으로 존재 | `msg="Base Error"`          |
-| **BASE-02**  | 단위 |  체이닝   | 하위 예외(`ValueError`)가 원인인 에러 | `to_dict()` 호출                  | `cause` 필드에 원본 예외의 문자열 표현(`str(e)`)이 포함됨                      | `original=ValueError("..")` |
-| **BASE-03**  | 단위 |  포맷팅   | `ETLError` 인스턴스 생성              | `str(error)` (콘솔 출력) 확인     | `[ETLError] 메시지 (Caused by: ..)` 형식의 디버깅용 문자열 반환                | `msg="Debug Check"`         |
-| **TRUNC-01** | 단위 |  **BVA**  | HTTP Body 길이가 **499자** (Under)    | `HttpError` 초기화 후 `to_dict()` | `details['response_body_preview']`에 원본 문자열이 **그대로** 저장됨           | `body="A" * 499`            |
-| **TRUNC-02** | 단위 |  **BVA**  | HTTP Body 길이가 **500자** (Exact)    | `HttpError` 초기화 후 `to_dict()` | 1. 문자열이 잘리지 않음<br>2. `...(truncated)` 접미사가 붙지 않음              | `body="A" * 500`            |
-| **TRUNC-03** | 단위 |  **BVA**  | HTTP Body 길이가 **501자** (Over)     | `HttpError` 초기화 후 `to_dict()` | 1. 문자열이 500자에서 잘림<br>2. 끝에 `...(truncated)` 접미사가 붙음           | `body="A" * 501`            |
-| **TRUNC-04** | 단위 |   방어    | HTTP Body가 `None` 또는 빈 값         | `HttpError` 초기화 후 `to_dict()` | 에러 없이 `preview` 값이 "Empty"로 안전하게 처리됨                             | `body=None`                 |
-| **TRUNC-05** | 단위 |    BVA    | 검증 실패 데이터가 매우 큰 딕셔너리   | `SchemaValidationError` 초기화    | `invalid_data_preview`가 문자열 변환 후 500자로 축약됨                         | `data={"k": "v"*100}`       |
-| **PROP-01**  | 단위 | 속성/분기 | `ConfigurationError` 생성             | `details` 속성 검사               | `key_name` 키가 `details` 딕셔너리에 올바르게 주입됨                           | `key_name="DB_HOST"`        |
-| **PROP-02**  | 단위 | 속성/분기 | `NetworkConnectionError` 생성         | `details` 속성 검사               | `url` 키가 `details` 딕셔너리에 올바르게 주입됨                                | `url="http://test.com"`     |
-| **PROP-03**  | 단위 | 속성/분기 | `RateLimitError` 생성                 | 인스턴스 속성 검사                | 1. `should_retry`가 **True**여야 함<br>2. `retry_after`가 `details`에 포함됨   | `retry_after=60`            |
-| **HIER-01**  | 단위 |   상속    | `AuthError` 인스턴스 생성             | `isinstance` 및 속성 체크         | 1. `HttpError`의 인스턴스임(True)<br>2. `should_retry`는 **False**여야 함      | `AuthError(...)`            |
+1. **기반 로직 검증:** 3건 (JSON 직렬화 필수 키, 예외 체이닝 원인 보존, 콘솔 출력 포맷)
+2. **설정 예외 검증:** 1건 (`ConfigurationError` 속성 주입)
+
+|   Test ID   | Category |   Technique   | Given                                 | When                | Then                                                                   | Input Data                  |
+| :---------: | :------: | :-----------: | :------------------------------------ | :------------------ | :--------------------------------------------------------------------- | :-------------------------- |
+| **BASE-01** |   Unit   | Serialization | `ETLError` 인스턴스 생성              | `to_dict()` 호출    | 반환된 딕셔너리에 `error_type`, `message`, `should_retry` 키 필수 존재 | `msg="Base Error"`          |
+| **BASE-02** |   Unit   |   Chaining    | 하위 예외(`ValueError`)가 원인인 에러 | `to_dict()` 호출    | `cause` 필드에 원본 예외의 문자열 표현(`str(e)`)이 포함됨              | `original=ValueError("..")` |
+| **BASE-03** |   Unit   |  Formatting   | `ETLError` 인스턴스 생성              | `str(error)` 확인   | `[ETLError] 메시지 (Caused by: ..)` 형식의 텍스트 반환                 | `msg="Debug Check"`         |
+| **BASE-04** |   Unit   |   Property    | `ConfigurationError` 생성             | `details` 속성 검사 | `key_name` 키가 `details` 딕셔너리에 올바르게 주입됨                   | `key_name="DB_HOST"`        |
+
+### 3.2. 데이터 축약 로직 (Log Noise Reduction)
+
+**시나리오 요약 (총 5건):**
+
+1. **HTTP Body 경계값 (BVA):** 3건 (500자 기준 Under, Exact, Over 검증)
+2. **데이터 방어 (Robustness):** 2건 (Null 입력 시 안전 처리, 스키마 딕셔너리 데이터 축약)
+
+|   Test ID    | Category | Technique  | Given                         | When                 | Then                                                      | Input Data           |
+| :----------: | :------: | :--------: | :---------------------------- | :------------------- | :-------------------------------------------------------- | :------------------- |
+| **TRUNC-01** |   Unit   |  **BVA**   | HTTP Body 길이가 **499자**    | `HttpError` 초기화   | `response_body_preview`에 원본 문자열이 **그대로** 저장됨 | `body="A" * 499`     |
+| **TRUNC-02** |   Unit   |  **BVA**   | HTTP Body 길이가 **500자**    | `HttpError` 초기화   | 문자열이 잘리지 않고 `...(truncated)` 접미사 없음         | `body="A" * 500`     |
+| **TRUNC-03** |   Unit   |  **BVA**   | HTTP Body 길이가 **501자**    | `HttpError` 초기화   | 500자에서 잘리며 끝에 `...(truncated)` 접미사 추가됨      | `body="A" * 501`     |
+| **TRUNC-04** |   Unit   | Robustness | HTTP Body가 `None` 또는 빈 값 | `HttpError` 초기화   | 에러 없이 `preview` 값이 "Empty"로 안전 처리됨            | `body=None`          |
+| **TRUNC-05** |   Unit   |  **BVA**   | 매우 큰 딕셔너리 데이터       | `SchemaError` 초기화 | 딕셔너리가 문자열 변환 후 500자로 축약됨                  | `data={"k":"v"*100}` |
+
+### 3.3. 수집 계층 예외 (Extractor Exceptions)
+
+**시나리오 요약 (총 3건):**
+
+1. **속성 및 재시도 검증:** 2건 (네트워크 URL 보존, RateLimit 재시도 속성 및 시간 강제)
+2. **상속 계층 검증:** 1건 (AuthError의 HttpError 상속 및 재시도 불가 확인)
+
+|  Test ID   | Category | Technique | Given                         | When                | Then                                                     | Input Data              |
+| :--------: | :------: | :-------: | :---------------------------- | :------------------ | :------------------------------------------------------- | :---------------------- |
+| **EXT-01** |   Unit   | Property  | `NetworkConnectionError` 생성 | `details` 속성 검사 | `url` 키가 딕셔너리에 보존되며 `should_retry` = **True** | `url="http://test.com"` |
+| **EXT-02** |   Unit   | Property  | `RateLimitError` 생성         | 인스턴스 검사       | `should_retry` = **True** 강제, `retry_after` 보존됨     | `retry_after=60`        |
+| **EXT-03** |   Unit   | Hierarchy | `AuthError` 인스턴스 생성     | `isinstance` 체크   | `HttpError` 인스턴스 인식 및 `should_retry` = **False**  | `AuthError(...)`        |
+
+### 3.4. 변환 계층 예외 (Transformer Exceptions)
+
+**시나리오 요약 (총 4건):**
+
+1. **속성 및 재시도 강제성:** 3건 (누락된 키 리스트, 충돌 컬럼 리스트, 병합 전후 튜플 형태 보존 및 재시도 불가 강제)
+2. **실행 예외 체이닝:** 1건 (Pandas 런타임 에러 원인 보존)
+
+|  Test ID   | Category | Technique | Given                            | When             | Then                                                              | Input Data                |
+| :--------: | :------: | :-------: | :------------------------------- | :--------------- | :---------------------------------------------------------------- | :------------------------ |
+| **TRF-01** |   Unit   | Property  | `MergeKeyNotFoundError` 생성     | `to_dict()` 호출 | `missing_keys` 리스트 보존, `should_retry` = **False**            | `missing_keys=["id"]`     |
+| **TRF-02** |   Unit   | Property  | `MergeColumnCollisionError` 생성 | `to_dict()` 호출 | `colliding_columns` 리스트 보존, `should_retry` = **False**       | `colliding_cols=["name"]` |
+| **TRF-03** |   Unit   | Property  | `MergeCardinalityError` 생성     | `to_dict()` 호출 | `left_shape`, `right_shape` 튜플 보존, `should_retry` = **False** | `left=(10,2)`             |
+| **TRF-04** |   Unit   | Chaining  | `MergeExecutionError` 생성       | `to_dict()` 호출 | `join_type` 보존, `original_exception` 전달 시 `cause` 기록       | `join_type="left"`        |


### PR DESCRIPTION
## 1. 🎫 PR 요약
> **데이터 변환(Transformer) 단계의 예외 구조화 및 안정적인 로깅을 위한 커스텀 예외 클래스 구현**
- ETL 파이프라인의 변환 과정에서 발생하는 데이터 결함 및 런타임 오류를 세분화하여 정의하고, 구조화된 로깅(Structured Logging)을 위한 데이터 직렬화 로직을 구축함.

## 2. 🛠 작업 내용
- **변환 계층 전용 예외 클래스 설계:** `TransformerError`를 기점으로 `MergeKeyNotFoundError`, `MergeColumnCollisionError`, `MergeCardinalityError`, `MergeExecutionError` 정의.
- **상태 데이터 보존 로직:** 에러 발생 당시의 컬럼명, 데이터프레임 Shape, 조인 타입 등 디버깅에 필수적인 메타데이터를 `details` 딕셔너리에 보존.
- **재시도 정책(Retry Policy) 강제:** 변환 단계의 에러는 데이터 원본의 결함으로 판단하여 `should_retry` 속성을 `False`로 고정, 불필요한 재시도에 따른 리소스 낭비 방지.
- **유닛 테스트 작성:** BDD 시나리오 기반의 테스트 케이스 4종 구현 및 검증.

## 3. 💡 기술적 의사결정 (Architecture & Tech Stack)
> **데이터 무결성 확보와 로깅 효율성을 고려한 설계**
- **결정 배경 (Fixed Retry Policy):** 네트워크 오류와 달리 데이터 변환 에러(스키마 불일치, 카디널리티 폭발 등)는 재시도 시에도 결과가 변하지 않는 'Determinstic'한 성격을 가짐. 따라서 모든 `TransformerError` 하위 클래스에서 `should_retry=False`를 강제함.
- **Trade-off (Data Types for Serialization):** `missing_keys`나 `colliding_columns` 저장 시 Python `Set` 대신 `List`를 사용함. `Set`은 중복 방지에 유리하나 JSON 직렬화가 불가능하여, LogManager(ELK/Datadog 연동)에서의 런타임 에러를 방지하기 위해 직렬화가 용이한 `List`를 선택함.
- **결정 배경 (Preserving Shape as Tuple):** `MergeCardinalityError` 발생 시 행(Row) 수뿐만 아니라 열(Column) 수를 포함한 `Tuple` 전체를 저장함. 이는 단순 데이터 증폭 외에 예기치 못한 스키마 변형 여부를 디버깅 단계에서 즉시 판별하기 위함임.

## 4. 📋 주요 변경점
- `src/common/exceptions.py`: 
    - `TransformerError` 추상 클래스 및 하위 4종 예외 클래스 추가.
    - 데이터 축약(Truncation) 및 JSON 직렬화(`to_dict`) 로직 구현.
- `tests/test_exceptions.py`:
    - `TRF-01` ~ `TRF-04` 시나리오에 대한 유닛 테스트 코드 추가.
    - 예외 체이닝 및 속성 보존 여부 검증.

## 5. 📸 테스트 결과 / 스크린샷
- **Unit Test 결과:** `pytest` 기반의 모든 변환 계층 테스트 케이스(4건) 통과 확인.
- **Coverage 결과:** 구문(Statement) 및 분기(Branch) 커버리지 100% 달성.

| Name | Stmts | Miss | Branch | BrPart | Cover | Missing |
| :--- | :---: | :---: | :---: | :---: | :---: | :--- |
| `src/common/exceptions.py` | 63 | 0 | 6 | 0 | **100%** | |
| **TOTAL** | **63** | **0** | **6** | **0** | **100%** | |

## 6. 💬 리뷰 포인트 (Focus On)
- `MergeCardinalityError`에서 `left_shape`, `right_shape`를 튜플 형태로 그대로 노출하는 것이 로그 시스템의 스키마 정책에 위배되지 않는지 확인 부탁드립니다.
- `MergeExecutionError`에서 Pandas의 `MemoryError` 등을 캡처할 때, `original_exception`을 통한 원인 보존 로직이 의도대로 동작하는지 검토 바랍니다.

---
**작업 결과에 대해 추가적인 유닛 테스트나 시나리오 확장이 필요하시면 말씀해 주세요.**