### PR TITLE
 [Feat] Abstract Transformer Implementation & Test Suite

### DIFF
--- a/apps/data-pipeline/src/common/exceptions.py
+++ b/apps/data-pipeline/src/common/exceptions.py
@@ -13,7 +13,7 @@ LogManager(log.py)와 결합하여 ELK/Datadog 등의 시스템에서 즉시 쿼
 Exception 발생 -> to_dict() 호출 -> LogManager가 JSON 직렬화 및 시간(KST/UTC) 태깅 -> 로그 저장
 """
 
-from typing import Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Tuple
 
 # ==============================================================================
 # 1. Global Base Exception
@@ -151,7 +151,79 @@ class AuthError(HttpError):
 # 5. Transformer Layer Detailed Exceptions
 # ==============================================================================
 
+class MergeKeyNotFoundError(TransformerError):
+    """병합 기준 키(Join Keys)가 대상 데이터프레임에 존재하지 않을 때 발생하는 예외.
+    
+    DataMerger 실행 전 DataFrame 검증 단계에서 누락된 키를 
+    조기에 발견하여, 잘못된 조인으로 인한 데이터 유실이나 메모리 낭비를 방지합니다.
+    """
 
+    def __init__(self, message: str, missing_keys: List[str], target_df_name: str) -> None:
+        # missing_keys를 Set이 아닌 List로 받는 이유: 
+        # Python의 Set 구조는 기본적으로 JSON 직렬화(Serialization)를 지원하지 않으므로,
+        # LogManager(ELK/Datadog 연동)에서 에러 없이 바로 파싱할 수 있도록 List 타입을 강제합니다.
+        details = {
+            "missing_keys": missing_keys,
+            "target_df_name": target_df_name
+        }
+        
+        # 데이터 누락은 재시도(Retry)한다고 해결되는 일시적 네트워크 에러가 아니므로
+        # should_retry=False로 설정하여 무한 루프나 불필요한 리소스 낭비를 원천 차단합니다.
+        super().__init__(message, details=details, should_retry=False)
+
+
+class MergeColumnCollisionError(TransformerError):
+    """조인 키가 아닌 동일한 이름의 컬럼이 두 데이터프레임에 존재할 때 발생하는 예외.
+    
+    Pandas가 자동으로 `_x`, `_y` 등의 접미사(Suffix)를 붙여 원본 스키마를 
+    은밀하게 변형하는 것을 방지하기 위한 방어적 예외입니다.
+    """
+
+    def __init__(self, message: str, colliding_columns: List[str]) -> None:
+        details = {
+            "colliding_columns": colliding_columns
+        }
+        
+        super().__init__(message, details=details, should_retry=False)
+
+
+class MergeCardinalityError(TransformerError):
+    """병합 과정에서 데이터(Row)가 폭발적으로 증가하거나 복제될 때 발생하는 예외.
+    
+    1:1 또는 N:1 병합을 의도했으나, 조인 키의 중복으로 인해 M:N 조인이 발생하여 
+    원본 데이터가 왜곡되는(Row 수가 늘어나는) 현상을 차단합니다.
+    """
+
+    def __init__(self, message: str, expected_relation: str, left_shape: Tuple[int, int], right_shape: Tuple[int, int]) -> None:
+        # shape 정보를 기록할 때 단순히 row count만 남기지 않고 Tuple 형태(행, 열)를 통째로 보존함으로써, 
+        # 컬럼 수가 함께 변형되었는지 여부를 디버깅 단계에서 추적할 수 있게 합니다.
+        details = {
+            "expected_relation": expected_relation,
+            "left_shape": left_shape,
+            "right_shape": right_shape
+        }
+        
+        super().__init__(message, details=details, should_retry=False)
+
+
+class MergeExecutionError(TransformerError):
+    """데이터프레임 병합 연산 중 발생하는 예측 불가한 런타임 예외.
+    
+    컬럼 타입 불일치(dtype mismatch), 메모리 초과(MemoryError) 등 
+    pandas의 merge() 호출 과정에서 발생하는 에러를 포착하고 원본 예외를 보존합니다.
+    """
+
+    def __init__(self, message: str, join_type: str, original_exception: Optional[Exception] = None) -> None:
+        details = {
+            "join_type": join_type
+        }
+        
+        super().__init__(
+            message, 
+            details=details, 
+            original_exception=original_exception, 
+            should_retry=False
+        )
 
 # ==============================================================================
 # 6. Loader Layer Detailed Exceptions

--- a/apps/data-pipeline/src/extractor/providers/abstract_extractor.py
+++ b/apps/data-pipeline/src/extractor/providers/abstract_extractor.py
@@ -53,8 +53,8 @@ class AbstractExtractor(IExtractor, ABC):
             ConfigurationError: 필수 의존성(Config 등)이 누락된 경우.
         """
         # Rationale: 의존성 주입 시점에 None 체크를 수행하여 런타임 NullReference 에러 방지.
-        if not config:
-             raise ConfigurationError("초기화 실패: ConfigManager 인스턴스가 필요합니다.")
+        if config is None:
+            raise ConfigurationError("초기화 실패: ConfigManager 인스턴스가 필요합니다.")
              
         self.http_client = http_client
         self.config = config

--- a/apps/data-pipeline/src/transformer/processors/abstract_transformer.py
+++ b/apps/data-pipeline/src/transformer/processors/abstract_transformer.py
@@ -1,0 +1,138 @@
+"""
+[AbstractTransformer 모듈]
+
+ITransformer 인터페이스를 구현하며, 모든 구체적인 변환기(Concrete Transformer)들이
+공통적으로 가져야 할 실행 흐름(Template Method Pattern)과 로깅/에러 핸들링 로직을 제공합니다.
+
+[전체 데이터 흐름 설명 (Input -> Output)]
+Input DataFrame -> [_validate: 스키마/데이터 무결성 검증] -> [_apply_transform: 실제 알고리즘 적용] -> Output DataFrame
+
+주요 기능:
+- [기능 1] Template Method (`transform`): 검증 -> 변환 -> 로깅으로 이어지는 표준화된 파이프라인 실행 흐름 강제
+- [기능 2] 예외 포착 및 래핑: 하위 클래스에서 발생하는 예측 불가능한 런타임 에러를 도메인 예외(TransformerError)로 규격화
+- [기능 3] 로깅 내장: 모든 변환기의 실행 시작/종료 및 에러 발생 시점을 자동으로 추적
+
+Trade-off: 
+- 장점: 중복되는 로깅 및 예외 처리(Try-Catch) 보일러플레이트를 부모 클래스로 끌어올려, 하위 클래스 개발자는 순수 데이터 변환 알고리즘(`_apply_transform`)과 검증(`_validate`)에만 집중할 수 있습니다.
+- 단점: 파이썬의 동적 타이핑 특성상, 추상 클래스의 보호 속성(Protected Attributes) 접근이나 오버라이딩을 문법적으로 완벽히 강제하기는 어렵습니다.
+- 근거: 실제 프로덕션 파이프라인에서는 "어떤 변환기에서 에러가 터졌는가?"를 즉시 추적하는 것이 생명입니다. 모든 구체 클래스가 각자 로깅과 에러 핸들링을 구현하면 반드시 누락이 발생하므로, 중앙 집중식 에러 핸들링을 제공하는 템플릿 메서드 패턴 도입이 필수적입니다.
+"""
+
+import logging
+from abc import abstractmethod
+from typing import Any, Optional
+
+import pandas as pd
+
+# 프로젝트 내부 모듈 (경로는 실제 프로젝트 구조에 맞게 조정 필요)
+from src.common.interfaces import ITransformer
+from src.common.exceptions import TransformerError, ConfigurationError, ETLError
+from src.common.log import LogManager
+from src.common.config import ConfigManager
+
+class AbstractTransformer(ITransformer):
+    """모든 데이터 변환기의 기반이 되는 추상 클래스.
+    
+    구현체(DataMerger, FeatureScaler 등)는 이 클래스를 상속받아 구체적인 
+    변환 로직을 구현해야 하며, 반드시 ConfigManager를 주입받아야 합니다.
+
+    Attributes:
+        config (ConfigManager): 애플리케이션 전역 설정 객체. (변환 정책, 파라미터 포함)
+        logger (logging.Logger): 구조화된 로깅을 위한 커스텀 로거 인스턴스.
+    """
+
+    def __init__(self, config: ConfigManager):
+        """AbstractTransformer를 초기화하고 필수 의존성을 검증합니다.
+
+        Args:
+            config (ConfigManager): 데이터 변환 정책이 포함된 앱 설정 객체.
+
+        Raises:
+            ConfigurationError: 필수 의존성(Config 등)이 누락된 경우.
+        """
+        if config is None:
+            raise ConfigurationError("초기화 실패: ConfigManager 인스턴스가 필요합니다.")
+             
+        self.config = config
+        self.logger = LogManager.get_logger(self.__class__.__name__)
+
+    def transform(self, data: pd.DataFrame) -> pd.DataFrame:
+        """데이터 변환 파이프라인의 뼈대(Template)를 실행합니다.
+        
+        로깅, 검증, 실제 변환, 에러 핸들링의 순서를 엄격하게 제어합니다.
+
+        Args:
+            data (pd.DataFrame): 변환을 수행할 원본 데이터프레임.
+
+        Returns:
+            pd.DataFrame: 변환이 완료된 데이터프레임.
+
+        Raises:
+            TransformerError: 데이터 검증 실패 또는 변환 중 발생한 모든 런타임 에러.
+        """
+        transformer_name = self.__class__.__name__
+        self.logger.info(f"[{transformer_name}] 데이터 변환 작업을 시작합니다. (Input shape: {data.shape})")
+
+        try:
+            # 1. 사전 검증: 입력 데이터의 스키마 및 무결성 사전 검증
+            self._validate(data)
+
+            # 2. 변환 로직: 하위 클래스에서 구현한 실제 변환 로직 실행
+            transformed_data = self._apply_transform(data)
+
+            # 3. 결과 검증: 변환 로직의 반환값이 정상적인 DataFrame인지 확인
+            if not isinstance(transformed_data, pd.DataFrame):
+                raise TransformerError(
+                    message=f"[{transformer_name}] 반환 타입 오류: DataFrame이 아닙니다. (Type: {type(transformed_data)})",
+                    should_retry=False
+                )
+            
+            self.logger.info(f"[{transformer_name}] 데이터 변환 작업을 완료했습니다. (Output shape: {transformed_data.shape})")
+            return transformed_data
+
+        except ETLError as e:
+            # 하위 클래스에서 발생시킨 비즈니스/도메인 에러는 로깅 후 그대로 통과(Pass-through)
+            self.logger.error(f"[{transformer_name}] 도메인 로직 실패 | Error: {e.message}")
+            raise e
+            
+        except Exception as e:
+            # 판다스 내부 C엔진 에러(MemoryError 등)와 같은 예측 불가능한 예외를 
+            # 파이프라인 공통 규격인 TransformerError로 래핑하여 추적성 확보
+            error_msg = f"[{transformer_name}] 변환 로직 수행 중 예기치 않은 오류 발생"
+            self.logger.error(f"{error_msg} | Error: {e}", exc_info=True)
+            raise TransformerError(
+                message=error_msg,
+                details={"transformer": transformer_name, "raw_error": str(e)},
+                original_exception=e,
+                should_retry=False
+            )
+
+    @abstractmethod
+    def _validate(self, data: pd.DataFrame) -> None:
+        """데이터 변환 전 입력 DataFrame과 설정의 무결성을 검증합니다.
+        
+        구현체는 `self.config`를 참조하여 필수 파라미터 유무를 확인하고,
+        DataFrame의 필수 컬럼 존재 여부, 데이터 타입 등을 확인해야 합니다.
+
+        Args:
+            data (pd.DataFrame): 검증할 입력 데이터프레임.
+            
+        Raises:
+            TransformerError (또는 하위 예외): 데이터나 설정이 변환 조건을 만족하지 않을 경우.
+        """
+        pass
+
+    @abstractmethod
+    def _apply_transform(self, data: pd.DataFrame) -> pd.DataFrame:
+        """실제 데이터 변환 알고리즘을 수행합니다.
+        
+        모든 구체 클래스는 이 메서드 내부에 벡터화된(Vectorized) 
+        pandas/numpy 연산을 구현해야 합니다.
+
+        Args:
+            data (pd.DataFrame): 변환할 대상 데이터프레임.
+
+        Returns:
+            pd.DataFrame: 변환이 완료된 데이터프레임.
+        """
+        pass

--- a/apps/data-pipeline/tests/unit/common/test_exceptions.py
+++ b/apps/data-pipeline/tests/unit/common/test_exceptions.py
@@ -11,7 +11,11 @@ from src.common.exceptions import (
     NetworkConnectionError,
     HttpError,
     RateLimitError,
-    AuthError
+    AuthError,
+    MergeKeyNotFoundError,
+    MergeColumnCollisionError,
+    MergeCardinalityError,
+    MergeExecutionError
 )
 
 # ========================================================================================
@@ -205,3 +209,83 @@ def test_hier_01_auth_inheritance():
     
     # AuthError는 재시도하지 않음 (401/403은 영구적 오류로 취급)
     assert error.should_retry is False
+
+# ========================================================================================
+# 4. 변환 계층 예외 테스트 (Transformer Exceptions)
+# ========================================================================================
+
+def test_trf_01_merge_key_not_found():
+    """[TRF-01] [Property] MergeKeyNotFoundError 생성 시 missing_keys 보존 및 재시도 불가 강제 검증"""
+    # Given
+    missing = ["user_id", "product_id"]
+    target_name = "df_sales"
+    
+    # When
+    error = MergeKeyNotFoundError(
+        message="Join keys are missing.", 
+        missing_keys=missing, 
+        target_df_name=target_name
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["missing_keys"] == missing
+    assert result["details"]["target_df_name"] == target_name
+    assert result["should_retry"] is False
+
+def test_trf_02_merge_column_collision():
+    """[TRF-02] [Property] MergeColumnCollisionError 생성 시 colliding_columns 보존 및 재시도 불가 강제 검증"""
+    # Given
+    colliding = ["status", "created_at"]
+    
+    # When
+    error = MergeColumnCollisionError(
+        message="Column collision detected.", 
+        colliding_columns=colliding
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["colliding_columns"] == colliding
+    assert result["should_retry"] is False
+
+def test_trf_03_merge_cardinality():
+    """[TRF-03] [Property] MergeCardinalityError 생성 시 shape 튜플 보존 및 재시도 불가 강제 검증"""
+    # Given
+    left = (100, 5)
+    right = (200, 6)
+    relation = "1:1"
+    
+    # When
+    error = MergeCardinalityError(
+        message="Cardinality explosion detected.", 
+        expected_relation=relation, 
+        left_shape=left, 
+        right_shape=right
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["expected_relation"] == relation
+    assert result["details"]["left_shape"] == left
+    assert result["details"]["right_shape"] == right
+    assert result["should_retry"] is False
+
+def test_trf_04_merge_execution_chaining():
+    """[TRF-04] [Chaining] MergeExecutionError 생성 시 join_type 보존 및 원본 런타임 예외 체이닝 검증"""
+    # Given
+    original = MemoryError("Out of memory during pandas merge")
+    join_type = "left"
+    
+    # When
+    error = MergeExecutionError(
+        message="Pandas merge failed unexpectedly.", 
+        join_type=join_type, 
+        original_exception=original
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["join_type"] == join_type
+    assert result["cause"] == "Out of memory during pandas merge"
+    assert result["should_retry"] is False

--- a/apps/data-pipeline/tests/unit/transformer/processors/test_abstract_transformer.py
+++ b/apps/data-pipeline/tests/unit/transformer/processors/test_abstract_transformer.py
@@ -1,0 +1,193 @@
+import pytest
+import pandas as pd
+from unittest.mock import MagicMock, patch
+
+# [Target Modules]
+from src.transformer.processors.abstract_transformer import AbstractTransformer
+
+# [Dependencies & Interfaces]
+from src.common.exceptions import ConfigurationError, TransformerError, ETLError
+
+# ========================================================================================
+# [Mocks & Stubs]
+# ========================================================================================
+
+class StubTransformer(AbstractTransformer):
+    """테스트용 구체 클래스 (Stub)
+    
+    추상 클래스의 흐름을 테스트하기 위해 동작을 세밀하게 제어(Spy/Mocking)할 수 있도록 구현했습니다.
+    """
+    def __init__(self, config):
+        super().__init__(config)
+        self.validate_call_count = 0
+        self.apply_call_count = 0
+        
+        # 동작 제어를 위한 변수
+        self.error_to_raise_in_validate = None
+        self.error_to_raise_in_apply = None
+        self.mock_return_value = None
+
+    def _validate(self, data: pd.DataFrame) -> None:
+        self.validate_call_count += 1
+        if self.error_to_raise_in_validate:
+            raise self.error_to_raise_in_validate
+
+    def _apply_transform(self, data: pd.DataFrame) -> pd.DataFrame:
+        self.apply_call_count += 1
+        if self.error_to_raise_in_apply:
+            raise self.error_to_raise_in_apply
+        
+        if self.mock_return_value is not None:
+            return self.mock_return_value
+        return data  # 기본 동작: 원본 반환
+
+# ========================================================================================
+# [Fixtures]
+# ========================================================================================
+
+@pytest.fixture(autouse=True)
+def mock_logger_isolation():
+    """Service Class의 로거 격리 픽스처 (로그 출력 차단)."""
+    with patch("src.common.log.LogManager.get_logger") as mock_get_logger:
+        mock_get_logger.return_value = MagicMock()
+        yield mock_get_logger
+
+@pytest.fixture
+def mock_config():
+    """ConfigManager 객체 모방"""
+    return MagicMock()
+
+@pytest.fixture
+def valid_df():
+    """정상적인 구조의 DataFrame 반환"""
+    return pd.DataFrame({"col1": [1, 2, 3], "col2": ["A", "B", "C"]})
+
+@pytest.fixture
+def empty_df():
+    """로우(Row)가 없는 빈 DataFrame 반환"""
+    return pd.DataFrame(columns=["col1", "col2"])
+
+@pytest.fixture
+def stub_transformer(mock_config):
+    """기본 설정이 주입된 StubTransformer 인스턴스"""
+    return StubTransformer(mock_config)
+
+# ========================================================================================
+# 1. 초기화 테스트 (Initialization)
+# ========================================================================================
+
+def test_init_01_valid_config(mock_config):
+    """[INIT-01] [Standard] 유효한 ConfigManager 모의 객체로 초기화 시 인스턴스 정상 생성"""
+    # When
+    transformer = StubTransformer(mock_config)
+    
+    # Then
+    assert transformer.config == mock_config
+    assert transformer.logger is not None
+
+def test_init_02_missing_config():
+    """[INIT-02] [BVA] config 객체가 None인 상태로 초기화 시 에러 방어"""
+    # When & Then
+    with pytest.raises(ConfigurationError, match="초기화 실패: ConfigManager 인스턴스가 필요합니다"):
+        StubTransformer(None)
+
+# ========================================================================================
+# 2. 파이프라인 흐름 및 데이터 검증 테스트 (Flow & Data Verification)
+# ========================================================================================
+
+def test_flow_01_happy_path(stub_transformer, valid_df):
+    """[FLOW-01] [State Transition] 모든 단계가 성공할 때 템플릿 메서드 호출 순서 검증"""
+    # When
+    result_df = stub_transformer.transform(valid_df)
+    
+    # Then
+    assert stub_transformer.validate_call_count == 1
+    assert stub_transformer.apply_call_count == 1
+    assert isinstance(result_df, pd.DataFrame)
+    assert result_df.equals(valid_df)
+
+def test_data_01_empty_dataframe(stub_transformer, empty_df):
+    """[DATA-01] [BVA] 로우가 없는 빈 DataFrame이 들어와도 에러 없이 통과"""
+    # When
+    result_df = stub_transformer.transform(empty_df)
+    
+    # Then
+    assert result_df.empty
+    assert stub_transformer.validate_call_count == 1
+
+def test_data_02_invalid_return_type(stub_transformer, valid_df):
+    """[DATA-02] [Robustness] _apply_transform이 DataFrame이 아닌 값 반환 시 에러 방어"""
+    # Given: 반환값을 pd.Series로 강제 조작
+    stub_transformer.mock_return_value = pd.Series([1, 2, 3])
+    
+    # When & Then
+    with pytest.raises(TransformerError, match="반환 타입 오류: DataFrame이 아닙니다") as exc_info:
+        stub_transformer.transform(valid_df)
+        
+    assert exc_info.value.should_retry is False
+
+# ========================================================================================
+# 3. 예외 처리 테스트 (Error Handling)
+# ========================================================================================
+
+def test_err_01_domain_error_passthrough(stub_transformer, valid_df):
+    """[ERR-01] [Fault Injection] _validate 중 도메인 에러(ETLError) 발생 시 래핑 없이 통과"""
+    # Given
+    domain_error = ETLError("비즈니스 로직 위반")
+    stub_transformer.error_to_raise_in_validate = domain_error
+    
+    # When & Then
+    with pytest.raises(ETLError) as exc_info:
+        stub_transformer.transform(valid_df)
+        
+    # 원본 에러가 그대로 던져졌는지 확인
+    assert exc_info.value is domain_error
+
+def test_err_02_unknown_error_wrapping(stub_transformer, valid_df):
+    """[ERR-02] [Fault Injection] _apply_transform 중 알 수 없는 에러 발생 시 래핑하여 전파"""
+    # Given
+    raw_error = MemoryError("OOM 발생")
+    stub_transformer.error_to_raise_in_apply = raw_error
+    
+    # When & Then
+    with pytest.raises(TransformerError, match="예기치 않은 오류 발생") as exc_info:
+        stub_transformer.transform(valid_df)
+        
+    # 에러 래핑 상태 검증
+    transformer_err = exc_info.value
+    assert transformer_err.should_retry is False
+    assert transformer_err.original_exception is raw_error
+    assert transformer_err.details["raw_error"] == "OOM 발생"
+
+# ========================================================================================
+# 4. 상태 및 멱등성 테스트 (State & Idempotency)
+# ========================================================================================
+
+def test_stat_01_idempotency_on_multiple_calls(stub_transformer, valid_df, empty_df):
+    """[STAT-01] [State] 동일한 인스턴스를 여러 번 호출해도 독립적으로 성공하며 상태 비저장성 유지"""
+    # When: 서로 다른 데이터로 연속 호출
+    result_1 = stub_transformer.transform(valid_df)
+    result_2 = stub_transformer.transform(empty_df)
+    
+    # Then
+    assert stub_transformer.validate_call_count == 2
+    assert stub_transformer.apply_call_count == 2
+    
+    assert isinstance(result_1, pd.DataFrame)
+    assert not result_1.empty
+    
+    assert isinstance(result_2, pd.DataFrame)
+    assert result_2.empty
+
+# ========================================================================================
+# 5. 기반 메서드 테스트 (Base Method Specification)
+# ========================================================================================
+
+def test_base_01_abstract_methods_execution(stub_transformer, valid_df):
+    """[BASE-01] [Standard] 추상 클래스에 정의된 기본 메서드(pass)가 예외 없이 호출되는지 검증"""
+    # When
+    AbstractTransformer._validate(stub_transformer, valid_df)
+    result = AbstractTransformer._apply_transform(stub_transformer, valid_df)
+    
+    # Then
+    assert result is None

--- a/docs/TCS/data-pipeline/TCS-EXC-001.md
+++ b/docs/TCS/data-pipeline/TCS-EXC-001.md
@@ -8,8 +8,8 @@
 - **적용 전략:**
   - [x] **경계값 분석 (BVA):** 로그 축약(Truncation) 임계값인 500자를 기준으로 `Under`, `Exact`, `Over` 케이스 검증.
   - [x] **데이터 직렬화 (Serialization):** `to_dict()` 메서드가 LogManager가 요구하는 JSON 스키마를 정확히 준수하는지 검증.
-  - [x] **상속 계층 (Inheritance Hierarchy):** `try-except` 블록에서 상위 클래스(예: `ExtractorError`)로 하위 에러가 정상적으로 잡히는지 검증.
-  - [x] **재시도 정책 (Retry Policy):** 각 예외 클래스의 `should_retry` 속성이 설계 의도(네트워크=True, 설정=False 등)대로 설정되었는지 확인.
+  - [x] **상속 계층 (Inheritance Hierarchy):** `try-except` 블록에서 상위 클래스(예: `ExtractorError`, `TransformerError`)로 하위 에러가 정상적으로 잡히는지 검증.
+  - [x] **재시도 정책 (Retry Policy):** 각 예외 클래스의 `should_retry` 속성이 설계 의도대로 올바르게 고정되었는지 확인.
 
 ## 2. 로직 흐름도
 
@@ -31,29 +31,70 @@ classDiagram
     HttpError <|-- RateLimitError
     HttpError <|-- AuthError
 
+    TransformerError <|-- MergeKeyNotFoundError
+    TransformerError <|-- MergeColumnCollisionError
+    TransformerError <|-- MergeCardinalityError
+    TransformerError <|-- MergeExecutionError
+
     note for HttpError "Logic: Truncate body if len > 500"
     note for RateLimitError "Force: should_retry = True"
+    note for TransformerError "Force: should_retry = False (데이터 결함은 재시도 불가)"
 ```
 
 ## 3. BDD 테스트 시나리오
 
-**시나리오 요약 (총 12건):**
+### 3.1. 전역 기반 예외 (Global Base Exceptions)
 
-1.  **기반 로직 (Base Logic):** 3건 (JSON 직렬화, 원인 예외 체이닝, 콘솔 출력 포맷)
-2.  **데이터 축약 (Truncation):** 5건 (HTTP Body 경계값 [Under, Exact, Over], Null 처리, 스키마 데이터)
-3.  **계층 및 속성 (Hierarchy & Props):** 4건 (설정 키, 네트워크 URL, RateLimit 헤더, Auth 상속/재시도 정책)
+**시나리오 요약 (총 4건):**
 
-|  테스트 ID   | 분류 |   기법    | 전제 조건 (Given)                     | 수행 (When)                       | 검증 (Then)                                                                    | 입력 데이터 / 상황          |
-| :----------: | :--: | :-------: | :------------------------------------ | :-------------------------------- | :----------------------------------------------------------------------------- | :-------------------------- |
-| **BASE-01**  | 단위 |  직렬화   | `ETLError` 인스턴스 생성              | `to_dict()` 호출                  | 반환된 딕셔너리에 `error_type`, `message`, `should_retry` 키가 필수적으로 존재 | `msg="Base Error"`          |
-| **BASE-02**  | 단위 |  체이닝   | 하위 예외(`ValueError`)가 원인인 에러 | `to_dict()` 호출                  | `cause` 필드에 원본 예외의 문자열 표현(`str(e)`)이 포함됨                      | `original=ValueError("..")` |
-| **BASE-03**  | 단위 |  포맷팅   | `ETLError` 인스턴스 생성              | `str(error)` (콘솔 출력) 확인     | `[ETLError] 메시지 (Caused by: ..)` 형식의 디버깅용 문자열 반환                | `msg="Debug Check"`         |
-| **TRUNC-01** | 단위 |  **BVA**  | HTTP Body 길이가 **499자** (Under)    | `HttpError` 초기화 후 `to_dict()` | `details['response_body_preview']`에 원본 문자열이 **그대로** 저장됨           | `body="A" * 499`            |
-| **TRUNC-02** | 단위 |  **BVA**  | HTTP Body 길이가 **500자** (Exact)    | `HttpError` 초기화 후 `to_dict()` | 1. 문자열이 잘리지 않음<br>2. `...(truncated)` 접미사가 붙지 않음              | `body="A" * 500`            |
-| **TRUNC-03** | 단위 |  **BVA**  | HTTP Body 길이가 **501자** (Over)     | `HttpError` 초기화 후 `to_dict()` | 1. 문자열이 500자에서 잘림<br>2. 끝에 `...(truncated)` 접미사가 붙음           | `body="A" * 501`            |
-| **TRUNC-04** | 단위 |   방어    | HTTP Body가 `None` 또는 빈 값         | `HttpError` 초기화 후 `to_dict()` | 에러 없이 `preview` 값이 "Empty"로 안전하게 처리됨                             | `body=None`                 |
-| **TRUNC-05** | 단위 |    BVA    | 검증 실패 데이터가 매우 큰 딕셔너리   | `SchemaValidationError` 초기화    | `invalid_data_preview`가 문자열 변환 후 500자로 축약됨                         | `data={"k": "v"*100}`       |
-| **PROP-01**  | 단위 | 속성/분기 | `ConfigurationError` 생성             | `details` 속성 검사               | `key_name` 키가 `details` 딕셔너리에 올바르게 주입됨                           | `key_name="DB_HOST"`        |
-| **PROP-02**  | 단위 | 속성/분기 | `NetworkConnectionError` 생성         | `details` 속성 검사               | `url` 키가 `details` 딕셔너리에 올바르게 주입됨                                | `url="http://test.com"`     |
-| **PROP-03**  | 단위 | 속성/분기 | `RateLimitError` 생성                 | 인스턴스 속성 검사                | 1. `should_retry`가 **True**여야 함<br>2. `retry_after`가 `details`에 포함됨   | `retry_after=60`            |
-| **HIER-01**  | 단위 |   상속    | `AuthError` 인스턴스 생성             | `isinstance` 및 속성 체크         | 1. `HttpError`의 인스턴스임(True)<br>2. `should_retry`는 **False**여야 함      | `AuthError(...)`            |
+1. **기반 로직 검증:** 3건 (JSON 직렬화 필수 키, 예외 체이닝 원인 보존, 콘솔 출력 포맷)
+2. **설정 예외 검증:** 1건 (`ConfigurationError` 속성 주입)
+
+|   Test ID   | Category |   Technique   | Given                                 | When                | Then                                                                   | Input Data                  |
+| :---------: | :------: | :-----------: | :------------------------------------ | :------------------ | :--------------------------------------------------------------------- | :-------------------------- |
+| **BASE-01** |   Unit   | Serialization | `ETLError` 인스턴스 생성              | `to_dict()` 호출    | 반환된 딕셔너리에 `error_type`, `message`, `should_retry` 키 필수 존재 | `msg="Base Error"`          |
+| **BASE-02** |   Unit   |   Chaining    | 하위 예외(`ValueError`)가 원인인 에러 | `to_dict()` 호출    | `cause` 필드에 원본 예외의 문자열 표현(`str(e)`)이 포함됨              | `original=ValueError("..")` |
+| **BASE-03** |   Unit   |  Formatting   | `ETLError` 인스턴스 생성              | `str(error)` 확인   | `[ETLError] 메시지 (Caused by: ..)` 형식의 텍스트 반환                 | `msg="Debug Check"`         |
+| **BASE-04** |   Unit   |   Property    | `ConfigurationError` 생성             | `details` 속성 검사 | `key_name` 키가 `details` 딕셔너리에 올바르게 주입됨                   | `key_name="DB_HOST"`        |
+
+### 3.2. 데이터 축약 로직 (Log Noise Reduction)
+
+**시나리오 요약 (총 5건):**
+
+1. **HTTP Body 경계값 (BVA):** 3건 (500자 기준 Under, Exact, Over 검증)
+2. **데이터 방어 (Robustness):** 2건 (Null 입력 시 안전 처리, 스키마 딕셔너리 데이터 축약)
+
+|   Test ID    | Category | Technique  | Given                         | When                 | Then                                                      | Input Data           |
+| :----------: | :------: | :--------: | :---------------------------- | :------------------- | :-------------------------------------------------------- | :------------------- |
+| **TRUNC-01** |   Unit   |  **BVA**   | HTTP Body 길이가 **499자**    | `HttpError` 초기화   | `response_body_preview`에 원본 문자열이 **그대로** 저장됨 | `body="A" * 499`     |
+| **TRUNC-02** |   Unit   |  **BVA**   | HTTP Body 길이가 **500자**    | `HttpError` 초기화   | 문자열이 잘리지 않고 `...(truncated)` 접미사 없음         | `body="A" * 500`     |
+| **TRUNC-03** |   Unit   |  **BVA**   | HTTP Body 길이가 **501자**    | `HttpError` 초기화   | 500자에서 잘리며 끝에 `...(truncated)` 접미사 추가됨      | `body="A" * 501`     |
+| **TRUNC-04** |   Unit   | Robustness | HTTP Body가 `None` 또는 빈 값 | `HttpError` 초기화   | 에러 없이 `preview` 값이 "Empty"로 안전 처리됨            | `body=None`          |
+| **TRUNC-05** |   Unit   |  **BVA**   | 매우 큰 딕셔너리 데이터       | `SchemaError` 초기화 | 딕셔너리가 문자열 변환 후 500자로 축약됨                  | `data={"k":"v"*100}` |
+
+### 3.3. 수집 계층 예외 (Extractor Exceptions)
+
+**시나리오 요약 (총 3건):**
+
+1. **속성 및 재시도 검증:** 2건 (네트워크 URL 보존, RateLimit 재시도 속성 및 시간 강제)
+2. **상속 계층 검증:** 1건 (AuthError의 HttpError 상속 및 재시도 불가 확인)
+
+|  Test ID   | Category | Technique | Given                         | When                | Then                                                     | Input Data              |
+| :--------: | :------: | :-------: | :---------------------------- | :------------------ | :------------------------------------------------------- | :---------------------- |
+| **EXT-01** |   Unit   | Property  | `NetworkConnectionError` 생성 | `details` 속성 검사 | `url` 키가 딕셔너리에 보존되며 `should_retry` = **True** | `url="http://test.com"` |
+| **EXT-02** |   Unit   | Property  | `RateLimitError` 생성         | 인스턴스 검사       | `should_retry` = **True** 강제, `retry_after` 보존됨     | `retry_after=60`        |
+| **EXT-03** |   Unit   | Hierarchy | `AuthError` 인스턴스 생성     | `isinstance` 체크   | `HttpError` 인스턴스 인식 및 `should_retry` = **False**  | `AuthError(...)`        |
+
+### 3.4. 변환 계층 예외 (Transformer Exceptions)
+
+**시나리오 요약 (총 4건):**
+
+1. **속성 및 재시도 강제성:** 3건 (누락된 키 리스트, 충돌 컬럼 리스트, 병합 전후 튜플 형태 보존 및 재시도 불가 강제)
+2. **실행 예외 체이닝:** 1건 (Pandas 런타임 에러 원인 보존)
+
+|  Test ID   | Category | Technique | Given                            | When             | Then                                                              | Input Data                |
+| :--------: | :------: | :-------: | :------------------------------- | :--------------- | :---------------------------------------------------------------- | :------------------------ |
+| **TRF-01** |   Unit   | Property  | `MergeKeyNotFoundError` 생성     | `to_dict()` 호출 | `missing_keys` 리스트 보존, `should_retry` = **False**            | `missing_keys=["id"]`     |
+| **TRF-02** |   Unit   | Property  | `MergeColumnCollisionError` 생성 | `to_dict()` 호출 | `colliding_columns` 리스트 보존, `should_retry` = **False**       | `colliding_cols=["name"]` |
+| **TRF-03** |   Unit   | Property  | `MergeCardinalityError` 생성     | `to_dict()` 호출 | `left_shape`, `right_shape` 튜플 보존, `should_retry` = **False** | `left=(10,2)`             |
+| **TRF-04** |   Unit   | Chaining  | `MergeExecutionError` 생성       | `to_dict()` 호출 | `join_type` 보존, `original_exception` 전달 시 `cause` 기록       | `join_type="left"`        |

--- a/docs/TCS/data-pipeline/TCS-TRF-001.md
+++ b/docs/TCS/data-pipeline/TCS-TRF-001.md
@@ -1,0 +1,73 @@
+# AbstractTransformer 테스트 명세서
+
+## 1. 문서 정보 및 전략
+
+- **대상 모듈:** `src.transformer.processors.abstract_transformer.AbstractTransformer`
+- **복잡도 수준:** **높음 (High)** (모든 데이터 변환기의 기반이 되는 템플릿 메서드 패턴 적용 및 중앙 집중식 에러/로깅 처리)
+- **커버리지 목표:** 분기 커버리지 100%, 구문 커버리지 100%
+- **적용 전략:**
+  - [x] **상태 전이 (State Transition):** 템플릿 메서드의 실행 흐름(`_validate` -> `_apply_transform` -> 타입 검증) 순서 보장 검증.
+  - [x] **결함 주입 (Fault Injection):** 예측 가능한 도메인 예외(`ETLError`)와 예측 불가능한 런타임 예외(`Exception`) 상황 강제 시뮬레이션.
+  - [x] **Stubbing & Mocking:** 추상 클래스 테스트를 위한 구체 구현체(Stub) 정의 및 `ConfigManager`, 로거 모의 객체(Mock) 주입.
+  - [x] **경계값 분석 (BVA):** 빈 데이터프레임(Empty DataFrame) 입력 및 필수 의존성 누락(`None`) 방어 검증.
+
+## 2. 로직 흐름도
+
+```mermaid
+stateDiagram-v2
+    [*] --> Init: __init__(config)
+    Init --> RaiseConfigError: config is None
+    Init --> Ready: config is Valid
+
+    state "Template Method Execution" as TME {
+        Ready --> Validate: transform(data)
+        Validate --> ApplyTransform: _validate() Success
+        ApplyTransform --> VerifyResult: _apply_transform() Success
+
+        state "Exception Handling" as EH {
+            Validate --> HandleDomainErr: ETLError raised
+            Validate --> HandleUnknownErr: Exception raised
+            ApplyTransform --> HandleDomainErr: ETLError raised
+            ApplyTransform --> HandleUnknownErr: Exception raised
+        }
+
+        VerifyResult --> End: Result is pd.DataFrame
+        VerifyResult --> HandleTypeErr: Result is NOT pd.DataFrame
+    }
+
+    HandleDomainErr --> LogDomainErr: Log ERROR (Domain logic failed)
+    LogDomainErr --> Reraise: Reraise ETLError (as is)
+
+    HandleUnknownErr --> LogTrace: Log ERROR with exc_info=True
+    LogTrace --> RaiseWrapped: Raise TransformerError (from e)
+
+    HandleTypeErr --> RaiseWrapped: Raise TransformerError (Type mismatch)
+
+    End --> [*]: Return Transformed DataFrame
+    Reraise --> [*]
+    RaiseWrapped --> [*]
+    RaiseConfigError --> [*]
+```
+
+## 3. BDD 테스트 시나리오
+
+**시나리오 요약 (총 9건):**
+
+- **초기화 (Initialization):** 2건 (정상 인스턴스 생성, Config 누락 방어)
+- **정상 흐름 (Happy Path):** 1건 (템플릿 메서드 호출 순서 및 로깅)
+- **데이터 검증 (Data Verification):** 2건 (빈 DataFrame 통과, 반환 타입 방어)
+- **에러 핸들링 (Error Handling):** 2건 (도메인 에러 통과, 예측 불가 에러 래핑)
+- **상태 및 멱등성 (State & Idempotency):** 1건 (연속 호출 시 상태 비저장성 유지)
+- **기반 메서드 (Base Method):** 1건 (추상 클래스 기본 동작 확인)
+
+|  테스트 ID  | 분류 |   기법   | 전제 조건 (Given)                                   | 수행 (When)                                     | 검증 (Then)                                                                                                     | 입력 데이터 / 상황        |
+| :---------: | :--: | :------: | :-------------------------------------------------- | :---------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- | :------------------------ |
+| **INIT-01** | 단위 |   표준   | 유효한 `ConfigManager` 모의 객체                    | `StubTransformer(config)` 초기화                | 1. 인스턴스 정상 생성<br>2. 내부 로거가 해당 클래스명으로 초기화됨                                              | `config=MockConfig()`     |
+| **INIT-02** | 단위 |   BVA    | `config` 객체가 `None`인 상태                       | `StubTransformer(None)` 초기화                  | `ConfigurationError` 발생 (메시지: "초기화 실패...")                                                            | `config=None`             |
+| **FLOW-01** | 단위 |   상태   | 모든 단계가 성공하는 `StubTransformer`              | `transform(valid_df)` 호출                      | 1. `_validate` -> `_apply_transform` 순서대로 호출됨<br>2. 시작/종료 INFO 로그 기록됨<br>3. 결과 DataFrame 반환 | `valid_df (shape: 10, 5)` |
+| **DATA-01** | 단위 |   BVA    | 로우(Row)가 없는 빈 DataFrame                       | `transform(empty_df)` 호출                      | 에러 없이 파이프라인 정상 통과 및 반환                                                                          | `empty_df (shape: 0, 5)`  |
+| **DATA-02** | 단위 |  견고성  | `_apply_transform`이 DataFrame이 아닌 값 반환       | `transform(df)` 호출                            | 1. `TransformerError` 발생<br>2. `should_retry=False` 설정 확인                                                 | Stub Return: `pd.Series`  |
+| **ERR-01**  | 예외 | 결함주입 | `_validate` 중 `ETLError` 도메인 에러 발생          | `transform(df)` 호출                            | 1. 에러 래핑 없이 원본 `ETLError` 그대로 발생<br>2. ERROR 로그 기록 확인                                        | Raise `ETLError`          |
+| **ERR-02**  | 예외 | 결함주입 | `_apply_transform` 중 알 수 없는 `MemoryError` 발생 | `transform(df)` 호출                            | 1. `TransformerError`로 래핑되어 발생<br>2. ERROR 로그에 Stack Trace(`exc_info`) 포함                           | Raise `MemoryError`       |
+| **STAT-01** | 단위 |   상태   | 단일 `StubTransformer` 인스턴스 생성                | `transform(df1)`, `transform(df2)` 연속 호출    | 두 호출이 서로 간섭 없이 독립적으로 성공하며 멱등성 보장                                                        | `df1`, `df2`              |
+| **BASE-01** | 단위 |   표준   | 초기화된 `StubTransformer` 인스턴스                 | `AbstractTransformer`의 추상 메서드 명시적 호출 | `pass` 블록이 예외 없이 실행되며 반환값이 `None`임                                                              | `valid_df`                |


### PR DESCRIPTION
## 1. 🎫 PR 요약
> **데이터 변환 파이프라인의 표준화를 위한 `AbstractTransformer` 기반 클래스 구현 및 검증 체계 구축**
- 모든 변환기(Transformer)가 준수해야 할 '검증-변환-결과 확인'의 템플릿 메서드 패턴을 정의하고, 중앙 집중식 로깅 및 에러 핸들링 로직을 통합함.

## 2. 🛠 작업 내용
- **`AbstractTransformer` 추상 클래스 구현:** `ITransformer` 인터페이스를 상속받아 `transform` 템플릿 메서드를 정의하고, 하위 클래스가 구현할 추상 메서드(`_validate`, `_apply_transform`)를 선언함.
- **표준 에러 핸들링 로직 도입:** 비즈니스 에러(`ETLError`)는 투명하게 전달(Pass-through)하고, 예기치 못한 런타임 에러는 `TransformerError`로 래핑하여 추적성을 확보함.
- **자동 로깅 시스템 통합:** `LogManager`를 통해 변환 시작/종료 시점 및 데이터 Shape 변화를 자동으로 기록하는 기능을 내장함.
- **고가용성 테스트 스위트 구축:** `StubTransformer`를 활용해 정상 흐름, 경계값(빈 데이터), 결함 주입(Error Injection) 등 9종의 테스트 시나리오를 검증함.

## 3. 💡 기술적 의사결정 (Architecture & Tech Stack)
- **결정 배경 (Template Method Pattern):** 각 변환기마다 개별적으로 로깅과 예외 처리를 구현할 경우 발생하는 코드 중복과 운영상의 누락(Observability 결여)을 방지하기 위해 파이프라인 실행 흐름을 부모 클래스에서 강제함.
- **Trade-off:** - **장점:** 하위 클래스 개발자는 데이터 처리 알고리즘에만 집중할 수 있어 생산성이 향상되고, 전체 파이프라인의 에러 보고 규격이 통일됨.
    - **단점:** 파이썬의 특성상 `_`로 명명된 보호 속성의 오버라이딩을 언어 차원에서 완벽히 강제할 수 없으므로, 테스트 코드를 통한 구조 검증이 필수적임.
- **에러 래핑 전략:** `MemoryError`와 같은 시스템 레벨의 예외가 발생했을 때, 단순히 프로세스를 종료시키지 않고 발생 지점(Transformer Name)과 원본 예외를 포함한 `TransformerError`로 변환하여 디버깅 비용을 최소화함.

## 4. 📋 주요 변경점
- `src/transformer/processors/abstract_transformer.py`: 템플릿 메서드(`transform`) 및 추상 메서드 명세 정의.
- `tests/transformer/processors/test_abstract_transformer.py`: 상태 전이 및 결함 주입 기법을 적용한 유닛 테스트 구현.
- `TCS-TRF-001.md`: 상세 테스트 케이스 명세 및 상태 전이도 작성.

## 5. 📸 테스트 결과 / 스크린샷
- **Unit Test 통과 여부:** 총 9개 시나리오 모두 통과 (Passed).
- **코드 커버리지:** 구문 및 분기 커버리지 100% 달성.

### **[Coverage Report]**
| Name | Stmts | Miss | Branch | BrPart | Cover |
| :--- | :---: | :---: | :---: | :---: | :---: |
| `src/transformer/processors/abstract_transformer.py` | 37 | 0 | 4 | 0 | **100%** |
| **TOTAL** | **37** | **0** | **4** | **0** | **100%** |

## 6. 💬 리뷰 포인트 (Focus On)
- `transform` 메서드 내에서 `ETLError`를 별도로 포착하여 그대로 `raise`하는 로직이 도메인 에러 전파 전략과 부합하는지 검토 부탁드립니다.
- 반환 타입 검증 시 `pd.DataFrame` 여부만 확인하고 있습니다. 스키마 검증은 하위 클래스의 `_validate` 단계에서 수행하는 것이 적절한지에 대한 의견이 필요합니다.