### PR TITLE
[Feat] Heterogeneous Financial Time-Series DataMerger Implementation

### DIFF
--- a/apps/data-pipeline/src/common/exceptions.py
+++ b/apps/data-pipeline/src/common/exceptions.py
@@ -13,7 +13,7 @@ LogManager(log.py)와 결합하여 ELK/Datadog 등의 시스템에서 즉시 쿼
 Exception 발생 -> to_dict() 호출 -> LogManager가 JSON 직렬화 및 시간(KST/UTC) 태깅 -> 로그 저장
 """
 
-from typing import Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Tuple
 
 # ==============================================================================
 # 1. Global Base Exception
@@ -151,7 +151,79 @@ class AuthError(HttpError):
 # 5. Transformer Layer Detailed Exceptions
 # ==============================================================================
 
+class MergeKeyNotFoundError(TransformerError):
+    """병합 기준 키(Join Keys)가 대상 데이터프레임에 존재하지 않을 때 발생하는 예외.
+    
+    DataMerger 실행 전 DataFrame 검증 단계에서 누락된 키를 
+    조기에 발견하여, 잘못된 조인으로 인한 데이터 유실이나 메모리 낭비를 방지합니다.
+    """
 
+    def __init__(self, message: str, missing_keys: List[str], target_df_name: str) -> None:
+        # missing_keys를 Set이 아닌 List로 받는 이유: 
+        # Python의 Set 구조는 기본적으로 JSON 직렬화(Serialization)를 지원하지 않으므로,
+        # LogManager(ELK/Datadog 연동)에서 에러 없이 바로 파싱할 수 있도록 List 타입을 강제합니다.
+        details = {
+            "missing_keys": missing_keys,
+            "target_df_name": target_df_name
+        }
+        
+        # 데이터 누락은 재시도(Retry)한다고 해결되는 일시적 네트워크 에러가 아니므로
+        # should_retry=False로 설정하여 무한 루프나 불필요한 리소스 낭비를 원천 차단합니다.
+        super().__init__(message, details=details, should_retry=False)
+
+
+class MergeColumnCollisionError(TransformerError):
+    """조인 키가 아닌 동일한 이름의 컬럼이 두 데이터프레임에 존재할 때 발생하는 예외.
+    
+    Pandas가 자동으로 `_x`, `_y` 등의 접미사(Suffix)를 붙여 원본 스키마를 
+    은밀하게 변형하는 것을 방지하기 위한 방어적 예외입니다.
+    """
+
+    def __init__(self, message: str, colliding_columns: List[str]) -> None:
+        details = {
+            "colliding_columns": colliding_columns
+        }
+        
+        super().__init__(message, details=details, should_retry=False)
+
+
+class MergeCardinalityError(TransformerError):
+    """병합 과정에서 데이터(Row)가 폭발적으로 증가하거나 복제될 때 발생하는 예외.
+    
+    1:1 또는 N:1 병합을 의도했으나, 조인 키의 중복으로 인해 M:N 조인이 발생하여 
+    원본 데이터가 왜곡되는(Row 수가 늘어나는) 현상을 차단합니다.
+    """
+
+    def __init__(self, message: str, expected_relation: str, left_shape: Tuple[int, int], right_shape: Tuple[int, int]) -> None:
+        # shape 정보를 기록할 때 단순히 row count만 남기지 않고 Tuple 형태(행, 열)를 통째로 보존함으로써, 
+        # 컬럼 수가 함께 변형되었는지 여부를 디버깅 단계에서 추적할 수 있게 합니다.
+        details = {
+            "expected_relation": expected_relation,
+            "left_shape": left_shape,
+            "right_shape": right_shape
+        }
+        
+        super().__init__(message, details=details, should_retry=False)
+
+
+class MergeExecutionError(TransformerError):
+    """데이터프레임 병합 연산 중 발생하는 예측 불가한 런타임 예외.
+    
+    컬럼 타입 불일치(dtype mismatch), 메모리 초과(MemoryError) 등 
+    pandas의 merge() 호출 과정에서 발생하는 에러를 포착하고 원본 예외를 보존합니다.
+    """
+
+    def __init__(self, message: str, join_type: str, original_exception: Optional[Exception] = None) -> None:
+        details = {
+            "join_type": join_type
+        }
+        
+        super().__init__(
+            message, 
+            details=details, 
+            original_exception=original_exception, 
+            should_retry=False
+        )
 
 # ==============================================================================
 # 6. Loader Layer Detailed Exceptions

--- a/apps/data-pipeline/src/extractor/providers/abstract_extractor.py
+++ b/apps/data-pipeline/src/extractor/providers/abstract_extractor.py
@@ -53,8 +53,8 @@ class AbstractExtractor(IExtractor, ABC):
             ConfigurationError: 필수 의존성(Config 등)이 누락된 경우.
         """
         # Rationale: 의존성 주입 시점에 None 체크를 수행하여 런타임 NullReference 에러 방지.
-        if not config:
-             raise ConfigurationError("초기화 실패: ConfigManager 인스턴스가 필요합니다.")
+        if config is None:
+            raise ConfigurationError("초기화 실패: ConfigManager 인스턴스가 필요합니다.")
              
         self.http_client = http_client
         self.config = config

--- a/apps/data-pipeline/src/transformer/processors/abstract_transformer.py
+++ b/apps/data-pipeline/src/transformer/processors/abstract_transformer.py
@@ -1,0 +1,138 @@
+"""
+[AbstractTransformer 모듈]
+
+ITransformer 인터페이스를 구현하며, 모든 구체적인 변환기(Concrete Transformer)들이
+공통적으로 가져야 할 실행 흐름(Template Method Pattern)과 로깅/에러 핸들링 로직을 제공합니다.
+
+[전체 데이터 흐름 설명 (Input -> Output)]
+Input DataFrame -> [_validate: 스키마/데이터 무결성 검증] -> [_apply_transform: 실제 알고리즘 적용] -> Output DataFrame
+
+주요 기능:
+- [기능 1] Template Method (`transform`): 검증 -> 변환 -> 로깅으로 이어지는 표준화된 파이프라인 실행 흐름 강제
+- [기능 2] 예외 포착 및 래핑: 하위 클래스에서 발생하는 예측 불가능한 런타임 에러를 도메인 예외(TransformerError)로 규격화
+- [기능 3] 로깅 내장: 모든 변환기의 실행 시작/종료 및 에러 발생 시점을 자동으로 추적
+
+Trade-off: 
+- 장점: 중복되는 로깅 및 예외 처리(Try-Catch) 보일러플레이트를 부모 클래스로 끌어올려, 하위 클래스 개발자는 순수 데이터 변환 알고리즘(`_apply_transform`)과 검증(`_validate`)에만 집중할 수 있습니다.
+- 단점: 파이썬의 동적 타이핑 특성상, 추상 클래스의 보호 속성(Protected Attributes) 접근이나 오버라이딩을 문법적으로 완벽히 강제하기는 어렵습니다.
+- 근거: 실제 프로덕션 파이프라인에서는 "어떤 변환기에서 에러가 터졌는가?"를 즉시 추적하는 것이 생명입니다. 모든 구체 클래스가 각자 로깅과 에러 핸들링을 구현하면 반드시 누락이 발생하므로, 중앙 집중식 에러 핸들링을 제공하는 템플릿 메서드 패턴 도입이 필수적입니다.
+"""
+
+import logging
+from abc import abstractmethod
+from typing import Any, Optional
+
+import pandas as pd
+
+# 프로젝트 내부 모듈 (경로는 실제 프로젝트 구조에 맞게 조정 필요)
+from src.common.interfaces import ITransformer
+from src.common.exceptions import TransformerError, ConfigurationError, ETLError
+from src.common.log import LogManager
+from src.common.config import ConfigManager
+
+class AbstractTransformer(ITransformer):
+    """모든 데이터 변환기의 기반이 되는 추상 클래스.
+    
+    구현체(DataMerger, FeatureScaler 등)는 이 클래스를 상속받아 구체적인 
+    변환 로직을 구현해야 하며, 반드시 ConfigManager를 주입받아야 합니다.
+
+    Attributes:
+        config (ConfigManager): 애플리케이션 전역 설정 객체. (변환 정책, 파라미터 포함)
+        logger (logging.Logger): 구조화된 로깅을 위한 커스텀 로거 인스턴스.
+    """
+
+    def __init__(self, config: ConfigManager):
+        """AbstractTransformer를 초기화하고 필수 의존성을 검증합니다.
+
+        Args:
+            config (ConfigManager): 데이터 변환 정책이 포함된 앱 설정 객체.
+
+        Raises:
+            ConfigurationError: 필수 의존성(Config 등)이 누락된 경우.
+        """
+        if config is None:
+            raise ConfigurationError("초기화 실패: ConfigManager 인스턴스가 필요합니다.")
+             
+        self.config = config
+        self.logger = LogManager.get_logger(self.__class__.__name__)
+
+    def transform(self, data: pd.DataFrame) -> pd.DataFrame:
+        """데이터 변환 파이프라인의 뼈대(Template)를 실행합니다.
+        
+        로깅, 검증, 실제 변환, 에러 핸들링의 순서를 엄격하게 제어합니다.
+
+        Args:
+            data (pd.DataFrame): 변환을 수행할 원본 데이터프레임.
+
+        Returns:
+            pd.DataFrame: 변환이 완료된 데이터프레임.
+
+        Raises:
+            TransformerError: 데이터 검증 실패 또는 변환 중 발생한 모든 런타임 에러.
+        """
+        transformer_name = self.__class__.__name__
+        self.logger.info(f"[{transformer_name}] 데이터 변환 작업을 시작합니다. (Input shape: {data.shape})")
+
+        try:
+            # 1. 사전 검증: 입력 데이터의 스키마 및 무결성 사전 검증
+            self._validate(data)
+
+            # 2. 변환 로직: 하위 클래스에서 구현한 실제 변환 로직 실행
+            transformed_data = self._apply_transform(data)
+
+            # 3. 결과 검증: 변환 로직의 반환값이 정상적인 DataFrame인지 확인
+            if not isinstance(transformed_data, pd.DataFrame):
+                raise TransformerError(
+                    message=f"[{transformer_name}] 반환 타입 오류: DataFrame이 아닙니다. (Type: {type(transformed_data)})",
+                    should_retry=False
+                )
+            
+            self.logger.info(f"[{transformer_name}] 데이터 변환 작업을 완료했습니다. (Output shape: {transformed_data.shape})")
+            return transformed_data
+
+        except ETLError as e:
+            # 하위 클래스에서 발생시킨 비즈니스/도메인 에러는 로깅 후 그대로 통과(Pass-through)
+            self.logger.error(f"[{transformer_name}] 도메인 로직 실패 | Error: {e.message}")
+            raise e
+            
+        except Exception as e:
+            # 판다스 내부 C엔진 에러(MemoryError 등)와 같은 예측 불가능한 예외를 
+            # 파이프라인 공통 규격인 TransformerError로 래핑하여 추적성 확보
+            error_msg = f"[{transformer_name}] 변환 로직 수행 중 예기치 않은 오류 발생"
+            self.logger.error(f"{error_msg} | Error: {e}", exc_info=True)
+            raise TransformerError(
+                message=error_msg,
+                details={"transformer": transformer_name, "raw_error": str(e)},
+                original_exception=e,
+                should_retry=False
+            )
+
+    @abstractmethod
+    def _validate(self, data: pd.DataFrame) -> None:
+        """데이터 변환 전 입력 DataFrame과 설정의 무결성을 검증합니다.
+        
+        구현체는 `self.config`를 참조하여 필수 파라미터 유무를 확인하고,
+        DataFrame의 필수 컬럼 존재 여부, 데이터 타입 등을 확인해야 합니다.
+
+        Args:
+            data (pd.DataFrame): 검증할 입력 데이터프레임.
+            
+        Raises:
+            TransformerError (또는 하위 예외): 데이터나 설정이 변환 조건을 만족하지 않을 경우.
+        """
+        pass
+
+    @abstractmethod
+    def _apply_transform(self, data: pd.DataFrame) -> pd.DataFrame:
+        """실제 데이터 변환 알고리즘을 수행합니다.
+        
+        모든 구체 클래스는 이 메서드 내부에 벡터화된(Vectorized) 
+        pandas/numpy 연산을 구현해야 합니다.
+
+        Args:
+            data (pd.DataFrame): 변환할 대상 데이터프레임.
+
+        Returns:
+            pd.DataFrame: 변환이 완료된 데이터프레임.
+        """
+        pass

--- a/apps/data-pipeline/src/transformer/processors/data_merger.py
+++ b/apps/data-pipeline/src/transformer/processors/data_merger.py
@@ -1,0 +1,219 @@
+"""
+[Data Merger]
+
+[모듈 목적 및 상세 설명]
+두 개의 개별 데이터프레임(Left, Right)을 지정된 키(Keys)를 기준으로 병합(Join)하는 데이터 변환기입니다.
+Pandas의 암묵적인 동작(예: 컬럼명 중복 시 자동 접미사 추가, 의도치 않은 M:N 조인으로 인한 데이터 증폭)을
+사전에 차단하기 위해, 병합 전후로 엄격한 데이터 정합성 검증(Validation)을 수행합니다.
+
+[전체 데이터 흐름 (Input -> Output)]
+1. Initialization: ConfigManager, Right DataFrame, 조인 조건(join_type, on_keys)을 주입받아 인스턴스화.
+2. Entry Point: AbstractTransformer의 `transform(data)` 호출 (여기서 `data`는 Left DataFrame).
+3. Pre-Validation (`_validate`): 조인 키 누락 여부 및 조인 키 외 컬럼 충돌(Collision) 검사.
+4. Transformation (`_apply_transform`): `pd.merge()`를 통한 벡터화된 병합 연산 수행.
+5. Post-Validation: 병합 결과의 행(Row) 수가 의도치 않게 폭발(Explosion)하지 않았는지 카디널리티(Cardinality) 검사.
+6. Output: 검증이 완료된 단일 병합 데이터프레임 반환.
+
+주요 기능:
+- [Safe Merge] 스키마 변형을 방지하는 컬럼 충돌 사전 차단.
+- [Memory Protection] 조인 키 중복으로 인한 M:N 병합(Cartesian Product 유사) 및 메모리 초과 방지.
+- [Stateful Transformation] ITransformer의 단일 입력 시그니처를 유지하면서 Right DataFrame을 상태(State)로 관리.
+
+Trade-off: 주요 구현에 대한 엔지니어링 관점의 근거 요약.
+1. Stateful Transformer (Right DataFrame 주입):
+   - 장점: 기존 `ITransformer.transform(data: pd.DataFrame)`의 단순한 인터페이스를 파괴하지 않고 유지할 수 있음. 파이프라인(Chain) 구성이 매우 직관적이 됨.
+   - 단점: 인스턴스가 `right_df`의 메모리 참조를 들고 있어야 하므로, 거대한 데이터를 병합할 때 메모리 생명주기 관리에 유의해야 함.
+   - 근거: 오버 엔지니어링(다중 입력 인터페이스로의 전면 개편)을 피하면서도 가장 실용적으로 서비스 가능한 아키텍처임.
+2. 컬럼 충돌(Collision)에 대한 하드 에러(Hard Error) 발생:
+   - 장점: Pandas가 자동으로 `_x`, `_y` 접미사를 붙여 원본 스키마를 은밀하게 오염시키는 것을 원천 차단함.
+   - 단점: 병합 전 컬럼명을 미리 변경(Rename)해야 하는 파이프라인 상의 번거로움이 발생할 수 있음.
+   - 근거: 데이터 파이프라인에서 "조용히 넘어가는 버그"는 "명시적으로 터지는 버그"보다 수백 배 위험함. 신뢰성(Reliability)을 최우선으로 확보하기 위함.
+3. 수동 카디널리티(Cardinality) 검증:
+   - 장점: `pd.merge`의 `validate` 파라미터는 에러 메시지가 불친절하므로, 직접 `shape`를 비교하여 커스텀 예외(`MergeCardinalityError`)에 풍부한 문맥(Context)을 담을 수 있음.
+   - 단점: 병합 이후에 행 수를 비교하므로 이미 연산 비용이 지불된 상태임.
+   - 근거: 사전 검증으로 M:N 여부를 판단하려면 고비용의 중복 검사(`duplicated()`)가 필요하므로, 병합 후 결과의 Shape를 확인하는 것이 연산 효율과 방어적 프로그래밍의 적절한 타협점임.
+"""
+
+from typing import List, Set
+import pandas as pd
+
+# [Dependency] External Configuration & Interfaces
+from src.common.config import ConfigManager
+from src.common.exceptions import (
+    MergeKeyNotFoundError,
+    MergeColumnCollisionError,
+    MergeCardinalityError,
+    MergeExecutionError,
+    TransformerError
+)
+# AbstractTransformer 위치는 사용자의 프로젝트 구조에 맞춰 가정된 경로를 사용합니다.
+from src.transformer.processors.abstract_transformer import AbstractTransformer
+
+
+# ==============================================================================
+# Constants & Configuration
+# ==============================================================================
+# 지원하는 조인 방식의 집합. 잘못된 조인 타입 입력 시 O(1) 조회를 위해 frozenset 사용.
+SUPPORTED_JOIN_TYPES = frozenset(['left', 'right', 'outer', 'inner'])
+
+
+# ==============================================================================
+# Main Class
+# ==============================================================================
+class DataMerger(AbstractTransformer):
+    """두 데이터프레임을 안전하게 병합하는 구체(Concrete) 변환기 클래스.
+    
+    `ITransformer`의 시그니처를 유지하기 위해, 병합의 대상이 되는 Right DataFrame을
+    생성자 주입(Constructor Injection)을 통해 상태로 보유합니다.
+
+    Attributes:
+        config (ConfigManager): 애플리케이션 전역 설정 객체.
+        logger (logging.Logger): 부모 클래스에서 상속받은 로거 인스턴스.
+        right_df (pd.DataFrame): 병합 대상이 되는 우측 데이터프레임.
+        join_type (str): 병합 방식 ('left', 'inner' 등).
+        on_keys (List[str]): 병합의 기준이 되는 컬럼명 리스트.
+    """
+
+    def __init__(
+        self, 
+        config: ConfigManager, 
+        right_df: pd.DataFrame, 
+        join_type: str, 
+        on_keys: List[str]
+    ) -> None:
+        """DataMerger를 초기화하고 초기 상태의 무결성을 검증합니다.
+
+        Args:
+            config (ConfigManager): 데이터 변환 정책이 포함된 앱 설정 객체.
+            right_df (pd.DataFrame): Left DataFrame과 병합할 대상 데이터프레임.
+            join_type (str): 조인 방법 (예: 'inner', 'left').
+            on_keys (List[str]): 조인 기준 키 컬럼 목록.
+
+        Raises:
+            ValueError: 지원하지 않는 join_type이거나 on_keys가 비어있는 경우.
+            TransformerError: right_df가 유효한 DataFrame이 아닌 경우.
+        """
+        # 1. 부모 클래스 초기화 (Config 검증 및 Logger 생성)
+        super().__init__(config)
+
+        # 2. Entry Point 사전 방어 (Defensive Programming)
+        if not isinstance(right_df, pd.DataFrame):
+            raise TransformerError(
+                message="DataMerger 초기화 실패: right_df는 반드시 pandas DataFrame이어야 합니다.",
+                should_retry=False
+            )
+        
+        if join_type not in SUPPORTED_JOIN_TYPES:
+            raise ValueError(f"지원하지 않는 join_type 입니다. (입력: {join_type}, 지원: {SUPPORTED_JOIN_TYPES})")
+            
+        if not on_keys:
+            raise ValueError("on_keys 리스트는 비어있을 수 없습니다. 최소 1개 이상의 병합 키가 필요합니다.")
+
+        # 3. 상태 할당
+        self.right_df = right_df
+        self.join_type = join_type
+        self.on_keys = list(on_keys)
+
+        self.logger.debug(
+            f"[DataMerger] join_type='{self.join_type}'으로 초기화 되었습니다. "
+            f"on_keys={self.on_keys}, right_df_shape={self.right_df.shape}"
+        )
+
+    def _validate(self, data: pd.DataFrame) -> None:
+        """병합 연산 전 Left DataFrame(`data`)과 Right DataFrame의 스키마 무결성을 검사합니다.
+
+        설계 의도: 
+        Pandas의 `merge` 함수가 뱉는 파편화된 KeyError나 자동 컬럼 변형을 방지하기 위해 
+        Set(집합) 연산을 활용하여 스키마 정합성을 O(N)으로 빠르게 검증합니다.
+
+        Args:
+            data (pd.DataFrame): 병합의 기준이 되는 Left DataFrame.
+            
+        Raises:
+            MergeKeyNotFoundError: 조인 키가 Left 또는 Right 데이터프레임에 누락된 경우.
+            MergeColumnCollisionError: 조인 키를 제외하고 양쪽에 동일한 이름의 컬럼이 존재하는 경우.
+        """
+        left_cols_set: Set[str] = set(data.columns)
+        right_cols_set: Set[str] = set(self.right_df.columns)
+        on_keys_set: Set[str] = set(self.on_keys)
+
+        # 1. 키 누락 검증 (Missing Keys Validation)
+        missing_in_left = on_keys_set - left_cols_set
+        if missing_in_left:
+            raise MergeKeyNotFoundError(
+                message=f"병합 기준 키 {list(missing_in_left)}가 Left 데이터프레임에 없습니다.",
+                missing_keys=list(missing_in_left),
+                target_df_name="Left DataFrame"
+            )
+
+        missing_in_right = on_keys_set - right_cols_set
+        if missing_in_right:
+            raise MergeKeyNotFoundError(
+                message=f"병합 기준 키 {list(missing_in_right)}가 Right 데이터프레임에 없습니다.",
+                missing_keys=list(missing_in_right),
+                target_df_name="Right DataFrame"
+            )
+
+        # 2. 컬럼 충돌 검증 (Column Collision Validation)
+        # 조인 키가 아닌 컬럼들 중 이름이 겹치면 _x, _y 접미사가 생성되므로 이를 원천 차단.
+        left_exclusive_cols = left_cols_set - on_keys_set
+        right_exclusive_cols = right_cols_set - on_keys_set
+        colliding_cols = left_exclusive_cols.intersection(right_exclusive_cols)
+
+        if colliding_cols:
+            raise MergeColumnCollisionError(
+                message=f"조인 키 제외, 동일한 이름의 컬럼이 존재하여 스키마 오염이 예상됩니다: {list(colliding_cols)}",
+                colliding_columns=list(colliding_cols)
+            )
+
+    def _apply_transform(self, data: pd.DataFrame) -> pd.DataFrame:
+        """검증이 완료된 두 데이터프레임에 대해 벡터화된 병합 연산을 수행합니다.
+
+        병합 후 Row 수(Cardinality)를 검사하여 데이터가 의도치 않게 증폭되었는지 확인합니다.
+
+        Args:
+            data (pd.DataFrame): Left DataFrame.
+
+        Returns:
+            pd.DataFrame: 병합이 완료된 새로운 데이터프레임.
+            
+        Raises:
+            MergeExecutionError: pandas 내부의 병합 연산 중 발생한 시스템 런타임 에러.
+            MergeCardinalityError: 'left' 또는 'inner' 조인 시 결과 행 수가 원본보다 늘어난 경우.
+        """
+        initial_left_shape = data.shape
+        initial_right_shape = self.right_df.shape
+
+        # M:N 조인 방지 정책 설정 (Left, Inner 조인 시 Right 테이블에 중복 키 허용 불가)
+        validate_policy = 'm:1' if self.join_type in ['left', 'inner'] else None
+
+        # 1. 벡터화 연산 실행 (Pandas C-Engine)
+        try:
+            merged_df = pd.merge(
+                left=data,
+                right=self.right_df,
+                how=self.join_type,
+                on=self.on_keys,
+                # 충돌 방지 로직이 있으나, 만약을 대비해 접미사를 극단적인 값으로 설정하여 버그 식별 용이성 확보
+                suffixes=('_FAIL_LEFT', '_FAIL_RIGHT') ,
+                validate=validate_policy
+            )
+
+        except pd.errors.MergeError as me:
+            # Pandas의 불친절한 카디널리티 에러를 커스텀 도메인 예외로 래핑
+            raise MergeCardinalityError(
+                message=f"병합 중 카디널리티 제약 조건 위반 (M:N 조인 감지). 상세: {me}",
+                expected_relation="1:1 or N:1 (validate='m:1')",
+                left_shape=initial_left_shape,
+                right_shape=initial_right_shape
+            ) from me
+
+        except Exception as e:
+            # TypeError, MemoryError 등 판다스 네이티브 예외를 도메인 예외로 래핑
+            raise MergeExecutionError(
+                message=f"Pandas 병합 엔진 실행 중 치명적 오류 발생: {e}",
+                join_type=self.join_type,
+                original_exception=e
+            ) from e
+
+        return merged_df

--- a/apps/data-pipeline/tests/unit/common/test_exceptions.py
+++ b/apps/data-pipeline/tests/unit/common/test_exceptions.py
@@ -11,7 +11,11 @@ from src.common.exceptions import (
     NetworkConnectionError,
     HttpError,
     RateLimitError,
-    AuthError
+    AuthError,
+    MergeKeyNotFoundError,
+    MergeColumnCollisionError,
+    MergeCardinalityError,
+    MergeExecutionError
 )
 
 # ========================================================================================
@@ -205,3 +209,83 @@ def test_hier_01_auth_inheritance():
     
     # AuthError는 재시도하지 않음 (401/403은 영구적 오류로 취급)
     assert error.should_retry is False
+
+# ========================================================================================
+# 4. 변환 계층 예외 테스트 (Transformer Exceptions)
+# ========================================================================================
+
+def test_trf_01_merge_key_not_found():
+    """[TRF-01] [Property] MergeKeyNotFoundError 생성 시 missing_keys 보존 및 재시도 불가 강제 검증"""
+    # Given
+    missing = ["user_id", "product_id"]
+    target_name = "df_sales"
+    
+    # When
+    error = MergeKeyNotFoundError(
+        message="Join keys are missing.", 
+        missing_keys=missing, 
+        target_df_name=target_name
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["missing_keys"] == missing
+    assert result["details"]["target_df_name"] == target_name
+    assert result["should_retry"] is False
+
+def test_trf_02_merge_column_collision():
+    """[TRF-02] [Property] MergeColumnCollisionError 생성 시 colliding_columns 보존 및 재시도 불가 강제 검증"""
+    # Given
+    colliding = ["status", "created_at"]
+    
+    # When
+    error = MergeColumnCollisionError(
+        message="Column collision detected.", 
+        colliding_columns=colliding
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["colliding_columns"] == colliding
+    assert result["should_retry"] is False
+
+def test_trf_03_merge_cardinality():
+    """[TRF-03] [Property] MergeCardinalityError 생성 시 shape 튜플 보존 및 재시도 불가 강제 검증"""
+    # Given
+    left = (100, 5)
+    right = (200, 6)
+    relation = "1:1"
+    
+    # When
+    error = MergeCardinalityError(
+        message="Cardinality explosion detected.", 
+        expected_relation=relation, 
+        left_shape=left, 
+        right_shape=right
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["expected_relation"] == relation
+    assert result["details"]["left_shape"] == left
+    assert result["details"]["right_shape"] == right
+    assert result["should_retry"] is False
+
+def test_trf_04_merge_execution_chaining():
+    """[TRF-04] [Chaining] MergeExecutionError 생성 시 join_type 보존 및 원본 런타임 예외 체이닝 검증"""
+    # Given
+    original = MemoryError("Out of memory during pandas merge")
+    join_type = "left"
+    
+    # When
+    error = MergeExecutionError(
+        message="Pandas merge failed unexpectedly.", 
+        join_type=join_type, 
+        original_exception=original
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["join_type"] == join_type
+    assert result["cause"] == "Out of memory during pandas merge"
+    assert result["should_retry"] is False

--- a/apps/data-pipeline/tests/unit/transformer/processors/test_abstract_transformer.py
+++ b/apps/data-pipeline/tests/unit/transformer/processors/test_abstract_transformer.py
@@ -1,0 +1,193 @@
+import pytest
+import pandas as pd
+from unittest.mock import MagicMock, patch
+
+# [Target Modules]
+from src.transformer.processors.abstract_transformer import AbstractTransformer
+
+# [Dependencies & Interfaces]
+from src.common.exceptions import ConfigurationError, TransformerError, ETLError
+
+# ========================================================================================
+# [Mocks & Stubs]
+# ========================================================================================
+
+class StubTransformer(AbstractTransformer):
+    """테스트용 구체 클래스 (Stub)
+    
+    추상 클래스의 흐름을 테스트하기 위해 동작을 세밀하게 제어(Spy/Mocking)할 수 있도록 구현했습니다.
+    """
+    def __init__(self, config):
+        super().__init__(config)
+        self.validate_call_count = 0
+        self.apply_call_count = 0
+        
+        # 동작 제어를 위한 변수
+        self.error_to_raise_in_validate = None
+        self.error_to_raise_in_apply = None
+        self.mock_return_value = None
+
+    def _validate(self, data: pd.DataFrame) -> None:
+        self.validate_call_count += 1
+        if self.error_to_raise_in_validate:
+            raise self.error_to_raise_in_validate
+
+    def _apply_transform(self, data: pd.DataFrame) -> pd.DataFrame:
+        self.apply_call_count += 1
+        if self.error_to_raise_in_apply:
+            raise self.error_to_raise_in_apply
+        
+        if self.mock_return_value is not None:
+            return self.mock_return_value
+        return data  # 기본 동작: 원본 반환
+
+# ========================================================================================
+# [Fixtures]
+# ========================================================================================
+
+@pytest.fixture(autouse=True)
+def mock_logger_isolation():
+    """Service Class의 로거 격리 픽스처 (로그 출력 차단)."""
+    with patch("src.common.log.LogManager.get_logger") as mock_get_logger:
+        mock_get_logger.return_value = MagicMock()
+        yield mock_get_logger
+
+@pytest.fixture
+def mock_config():
+    """ConfigManager 객체 모방"""
+    return MagicMock()
+
+@pytest.fixture
+def valid_df():
+    """정상적인 구조의 DataFrame 반환"""
+    return pd.DataFrame({"col1": [1, 2, 3], "col2": ["A", "B", "C"]})
+
+@pytest.fixture
+def empty_df():
+    """로우(Row)가 없는 빈 DataFrame 반환"""
+    return pd.DataFrame(columns=["col1", "col2"])
+
+@pytest.fixture
+def stub_transformer(mock_config):
+    """기본 설정이 주입된 StubTransformer 인스턴스"""
+    return StubTransformer(mock_config)
+
+# ========================================================================================
+# 1. 초기화 테스트 (Initialization)
+# ========================================================================================
+
+def test_init_01_valid_config(mock_config):
+    """[INIT-01] [Standard] 유효한 ConfigManager 모의 객체로 초기화 시 인스턴스 정상 생성"""
+    # When
+    transformer = StubTransformer(mock_config)
+    
+    # Then
+    assert transformer.config == mock_config
+    assert transformer.logger is not None
+
+def test_init_02_missing_config():
+    """[INIT-02] [BVA] config 객체가 None인 상태로 초기화 시 에러 방어"""
+    # When & Then
+    with pytest.raises(ConfigurationError, match="초기화 실패: ConfigManager 인스턴스가 필요합니다"):
+        StubTransformer(None)
+
+# ========================================================================================
+# 2. 파이프라인 흐름 및 데이터 검증 테스트 (Flow & Data Verification)
+# ========================================================================================
+
+def test_flow_01_happy_path(stub_transformer, valid_df):
+    """[FLOW-01] [State Transition] 모든 단계가 성공할 때 템플릿 메서드 호출 순서 검증"""
+    # When
+    result_df = stub_transformer.transform(valid_df)
+    
+    # Then
+    assert stub_transformer.validate_call_count == 1
+    assert stub_transformer.apply_call_count == 1
+    assert isinstance(result_df, pd.DataFrame)
+    assert result_df.equals(valid_df)
+
+def test_data_01_empty_dataframe(stub_transformer, empty_df):
+    """[DATA-01] [BVA] 로우가 없는 빈 DataFrame이 들어와도 에러 없이 통과"""
+    # When
+    result_df = stub_transformer.transform(empty_df)
+    
+    # Then
+    assert result_df.empty
+    assert stub_transformer.validate_call_count == 1
+
+def test_data_02_invalid_return_type(stub_transformer, valid_df):
+    """[DATA-02] [Robustness] _apply_transform이 DataFrame이 아닌 값 반환 시 에러 방어"""
+    # Given: 반환값을 pd.Series로 강제 조작
+    stub_transformer.mock_return_value = pd.Series([1, 2, 3])
+    
+    # When & Then
+    with pytest.raises(TransformerError, match="반환 타입 오류: DataFrame이 아닙니다") as exc_info:
+        stub_transformer.transform(valid_df)
+        
+    assert exc_info.value.should_retry is False
+
+# ========================================================================================
+# 3. 예외 처리 테스트 (Error Handling)
+# ========================================================================================
+
+def test_err_01_domain_error_passthrough(stub_transformer, valid_df):
+    """[ERR-01] [Fault Injection] _validate 중 도메인 에러(ETLError) 발생 시 래핑 없이 통과"""
+    # Given
+    domain_error = ETLError("비즈니스 로직 위반")
+    stub_transformer.error_to_raise_in_validate = domain_error
+    
+    # When & Then
+    with pytest.raises(ETLError) as exc_info:
+        stub_transformer.transform(valid_df)
+        
+    # 원본 에러가 그대로 던져졌는지 확인
+    assert exc_info.value is domain_error
+
+def test_err_02_unknown_error_wrapping(stub_transformer, valid_df):
+    """[ERR-02] [Fault Injection] _apply_transform 중 알 수 없는 에러 발생 시 래핑하여 전파"""
+    # Given
+    raw_error = MemoryError("OOM 발생")
+    stub_transformer.error_to_raise_in_apply = raw_error
+    
+    # When & Then
+    with pytest.raises(TransformerError, match="예기치 않은 오류 발생") as exc_info:
+        stub_transformer.transform(valid_df)
+        
+    # 에러 래핑 상태 검증
+    transformer_err = exc_info.value
+    assert transformer_err.should_retry is False
+    assert transformer_err.original_exception is raw_error
+    assert transformer_err.details["raw_error"] == "OOM 발생"
+
+# ========================================================================================
+# 4. 상태 및 멱등성 테스트 (State & Idempotency)
+# ========================================================================================
+
+def test_stat_01_idempotency_on_multiple_calls(stub_transformer, valid_df, empty_df):
+    """[STAT-01] [State] 동일한 인스턴스를 여러 번 호출해도 독립적으로 성공하며 상태 비저장성 유지"""
+    # When: 서로 다른 데이터로 연속 호출
+    result_1 = stub_transformer.transform(valid_df)
+    result_2 = stub_transformer.transform(empty_df)
+    
+    # Then
+    assert stub_transformer.validate_call_count == 2
+    assert stub_transformer.apply_call_count == 2
+    
+    assert isinstance(result_1, pd.DataFrame)
+    assert not result_1.empty
+    
+    assert isinstance(result_2, pd.DataFrame)
+    assert result_2.empty
+
+# ========================================================================================
+# 5. 기반 메서드 테스트 (Base Method Specification)
+# ========================================================================================
+
+def test_base_01_abstract_methods_execution(stub_transformer, valid_df):
+    """[BASE-01] [Standard] 추상 클래스에 정의된 기본 메서드(pass)가 예외 없이 호출되는지 검증"""
+    # When
+    AbstractTransformer._validate(stub_transformer, valid_df)
+    result = AbstractTransformer._apply_transform(stub_transformer, valid_df)
+    
+    # Then
+    assert result is None

--- a/apps/data-pipeline/tests/unit/transformer/processors/test_data_merger.py
+++ b/apps/data-pipeline/tests/unit/transformer/processors/test_data_merger.py
@@ -1,0 +1,238 @@
+import pytest
+import pandas as pd
+from unittest.mock import MagicMock, patch
+
+# [Target Modules]
+# 실제 프로젝트 구조에 맞게 경로 조정 필요
+from src.transformer.processors.data_merger import DataMerger
+
+# [Dependencies & Interfaces]
+from src.common.exceptions import (
+    MergeKeyNotFoundError,
+    MergeColumnCollisionError,
+    MergeCardinalityError,
+    MergeExecutionError,
+    TransformerError
+)
+
+# ========================================================================================
+# [Fixtures]
+# ========================================================================================
+
+@pytest.fixture(autouse=True)
+def mock_logger_isolation():
+    """Service Class의 로거 격리 픽스처 (로그 출력 차단)."""
+    with patch("src.common.log.LogManager.get_logger") as mock_get_logger:
+        mock_get_logger.return_value = MagicMock()
+        yield mock_get_logger
+
+@pytest.fixture
+def mock_config():
+    """ConfigManager 객체 모방"""
+    return MagicMock()
+
+@pytest.fixture
+def base_left_df():
+    """병합의 기준이 되는 정상적인 Left DataFrame"""
+    return pd.DataFrame({
+        "id": [1, 2, 3],
+        "value_left": ["A", "B", "C"]
+    })
+
+@pytest.fixture
+def base_right_df():
+    """병합 대상이 되는 정상적인 Right DataFrame (1:1 조인용)"""
+    return pd.DataFrame({
+        "id": [1, 2, 3, 4],
+        "value_right": ["X", "Y", "Z", "W"]
+    })
+
+@pytest.fixture
+def empty_left_df():
+    """로우(Row)가 없는 빈 Left DataFrame 반환"""
+    return pd.DataFrame(columns=["id", "value_left"])
+
+# ========================================================================================
+# 1. 초기화 테스트 (Initialization)
+# ========================================================================================
+
+def test_init_01_valid_initialization(mock_config, base_right_df):
+    """[INIT-01] [Standard] 유효한 right_df 및 지원되는 파라미터로 초기화 시 정상 생성"""
+    # When
+    merger = DataMerger(
+        config=mock_config,
+        right_df=base_right_df,
+        join_type="left",
+        on_keys=["id"]
+    )
+    
+    # Then
+    assert merger.join_type == "left"
+    assert merger.on_keys == ["id"]
+    assert merger.right_df.equals(base_right_df)
+
+def test_init_02_invalid_right_df_type(mock_config):
+    """[INIT-02] [Defensive] right_df 파라미터에 DataFrame이 아닌 값 주입 시 조기 차단"""
+    # When & Then
+    with pytest.raises(TransformerError, match="반드시 pandas DataFrame이어야 합니다") as exc_info:
+        DataMerger(mock_config, right_df=None, join_type="left", on_keys=["id"])
+        
+    assert exc_info.value.should_retry is False
+
+def test_init_03_unsupported_join_type(mock_config, base_right_df):
+    """[INIT-03] [BVA] 지원하지 않는 join_type 문자열 주입 시 ValueError 발생"""
+    # When & Then
+    with pytest.raises(ValueError, match="지원하지 않는 join_type 입니다"):
+        DataMerger(mock_config, right_df=base_right_df, join_type="cross", on_keys=["id"])
+
+def test_init_04_empty_on_keys(mock_config, base_right_df):
+    """[INIT-04] [BVA] 병합 기준 키 on_keys에 빈 리스트 주입 시 ValueError 발생"""
+    # When & Then
+    with pytest.raises(ValueError, match="최소 1개 이상의 병합 키가 필요합니다"):
+        DataMerger(mock_config, right_df=base_right_df, join_type="left", on_keys=[])
+
+# ========================================================================================
+# 2. 파이프라인 흐름 및 데이터 검증 테스트 (Flow & Data Verification)
+# ========================================================================================
+
+def test_flow_01_left_join_success(mock_config, base_left_df, base_right_df):
+    """[FLOW-01] [Standard] 1:1 관계를 만족하는 Left/Right 데이터의 병합 성공 검증"""
+    # Given
+    merger = DataMerger(mock_config, base_right_df, "left", ["id"])
+    
+    # When
+    result_df = merger.transform(base_left_df)
+    
+    # Then
+    assert len(result_df) == len(base_left_df)
+    assert "value_right" in result_df.columns
+    assert result_df.loc[result_df["id"] == 1, "value_right"].values[0] == "X"
+
+def test_flow_02_inner_join_n_to_1(mock_config, base_right_df):
+    """[FLOW-02] [Standard] N:1 관계(Left에 중복키 존재)의 데이터 병합 성공 검증"""
+    # Given: Left에 중복된 ID(1) 존재
+    left_df_n = pd.DataFrame({"id": [1, 1, 2], "value_left": ["A1", "A2", "B"]})
+    merger = DataMerger(mock_config, base_right_df, "inner", ["id"])
+    
+    # When
+    result_df = merger.transform(left_df_n)
+    
+    # Then
+    assert len(result_df) == 3  # N:1 이므로 카디널리티 폭발 없음
+    assert list(result_df["id"]) == [1, 1, 2]
+
+def test_flow_03_outer_join_no_validation(mock_config, base_left_df, base_right_df):
+    """[FLOW-03] [Defensive] m:1 제약이 없는 상태에서의 Outer 조인 성공 검증"""
+    # Given
+    merger = DataMerger(mock_config, base_right_df, "outer", ["id"])
+    
+    # When
+    result_df = merger.transform(base_left_df)
+    
+    # Then
+    # base_left_df에는 ID 4가 없으나 outer 조인이므로 ID 4가 포함되어 결과는 4로우여야 함
+    assert len(result_df) == 4
+    assert result_df["id"].nunique() == 4
+
+def test_edge_01_empty_left_dataframe(mock_config, empty_left_df, base_right_df):
+    """[EDGE-01] [BVA] 행(Row)이 0개인 빈 Left DataFrame 병합 통과 검증"""
+    # Given
+    merger = DataMerger(mock_config, base_right_df, "left", ["id"])
+    
+    # When
+    result_df = merger.transform(empty_left_df)
+    
+    # Then
+    assert result_df.empty
+    assert "value_right" in result_df.columns  # 스키마는 정상적으로 결합되어야 함
+
+# ========================================================================================
+# 3. 스키마 검증 테스트 (Schema Validation)
+# ========================================================================================
+
+def test_val_01_missing_key_in_left(mock_config, base_left_df, base_right_df):
+    """[VAL-01] [Defensive] left_df에 on_keys로 지정된 컬럼 누락 시 에러 발생"""
+    # Given: Left DF에서 기준 키 삭제
+    invalid_left = base_left_df.drop(columns=["id"])
+    merger = DataMerger(mock_config, base_right_df, "left", ["id"])
+    
+    # When & Then
+    with pytest.raises(MergeKeyNotFoundError, match="Left 데이터프레임에 없습니다"):
+        merger.transform(invalid_left)
+
+def test_val_02_missing_key_in_right(mock_config, base_left_df, base_right_df):
+    """[VAL-02] [Defensive] right_df에 on_keys로 지정된 컬럼 누락 시 에러 발생"""
+    # Given: Right DF에서 기준 키 삭제 후 초기화
+    invalid_right = base_right_df.drop(columns=["id"])
+    merger = DataMerger(mock_config, invalid_right, "left", ["id"])
+    
+    # When & Then
+    with pytest.raises(MergeKeyNotFoundError, match="Right 데이터프레임에 없습니다"):
+        merger.transform(base_left_df)
+
+def test_val_03_column_collision(mock_config, base_left_df, base_right_df):
+    """[VAL-03] [Defensive] 조인 키를 제외하고 양쪽에 동일한 이름의 컬럼 존재 시 에러 발생"""
+    # Given: 양쪽에 'status'라는 중복 컬럼 강제 생성 (스키마 오염 원인)
+    base_left_df["status"] = "active"
+    base_right_df["status"] = "inactive"
+    
+    merger = DataMerger(mock_config, base_right_df, "left", ["id"])
+    
+    # When & Then
+    with pytest.raises(MergeColumnCollisionError, match="스키마 오염이 예상됩니다"):
+        merger.transform(base_left_df)
+
+# ========================================================================================
+# 4. 예외 처리 테스트 (Error Handling)
+# ========================================================================================
+
+def test_err_01_cardinality_explosion_mn_join(mock_config, base_left_df):
+    """[ERR-01] [Fault Injection] Right 데이터에 조인 키가 중복되어 M:N 카디널리티 폭발 발생 시 차단"""
+    # Given: Right DF에 ID 1이 두 번 등장하도록 조작 (Left에도 ID 1이 있으므로 1:N -> M:N 위험)
+    right_df_duplicate = pd.DataFrame({
+        "id": [1, 1, 2],
+        "value_right": ["X1", "X2", "Y"]
+    })
+    
+    # join_type="left"일 경우 validate='m:1' 제약조건이 활성화됨
+    merger = DataMerger(mock_config, right_df_duplicate, "left", ["id"])
+    
+    # When & Then
+    with pytest.raises(MergeCardinalityError, match="카디널리티 제약 조건 위반"):
+        merger.transform(base_left_df)
+
+@patch("src.transformer.processors.data_merger.pd.merge")
+def test_err_02_system_execution_error(mock_pd_merge, mock_config, base_left_df, base_right_df):
+    """[ERR-02] [Fault Injection] pd.merge 호출 중 런타임/시스템 에러 발생 시 래핑 검증"""
+    # Given
+    # 내부 pandas 병합 엔진에서 메모리 초과 등 예상치 못한 시스템 에러 발생 시뮬레이션
+    mock_pd_merge.side_effect = MemoryError("System Out Of Memory")
+    merger = DataMerger(mock_config, base_right_df, "left", ["id"])
+    
+    # When & Then
+    with pytest.raises(MergeExecutionError, match="치명적 오류 발생") as exc_info:
+        merger.transform(base_left_df)
+        
+    assert isinstance(exc_info.value.original_exception, MemoryError)
+
+# ========================================================================================
+# 5. 상태 및 멱등성 테스트 (State & Idempotency)
+# ========================================================================================
+
+def test_stat_01_idempotency_and_state_immutability(mock_config, base_left_df, base_right_df):
+    """[STAT-01] [Idempotency] 단일 인스턴스에 대해 여러 번 호출해도 상태(right_df)가 오염되지 않음"""
+    # Given
+    merger = DataMerger(mock_config, base_right_df, "left", ["id"])
+    original_right_shape = base_right_df.shape
+    
+    # When: 동일한 입력으로 3회 연속 호출
+    result_1 = merger.transform(base_left_df)
+    result_2 = merger.transform(base_left_df)
+    result_3 = merger.transform(base_left_df)
+    
+    # Then
+    assert result_1.equals(result_2) and result_2.equals(result_3)
+    
+    # 상태 불변성 검증: 내부 right_df가 원본 형태와 정확히 일치하는지 확인
+    assert merger.right_df.shape == original_right_shape
+    assert merger.right_df.equals(base_right_df)

--- a/docs/TCS/data-pipeline/TCS-EXC-001.md
+++ b/docs/TCS/data-pipeline/TCS-EXC-001.md
@@ -8,8 +8,8 @@
 - **적용 전략:**
   - [x] **경계값 분석 (BVA):** 로그 축약(Truncation) 임계값인 500자를 기준으로 `Under`, `Exact`, `Over` 케이스 검증.
   - [x] **데이터 직렬화 (Serialization):** `to_dict()` 메서드가 LogManager가 요구하는 JSON 스키마를 정확히 준수하는지 검증.
-  - [x] **상속 계층 (Inheritance Hierarchy):** `try-except` 블록에서 상위 클래스(예: `ExtractorError`)로 하위 에러가 정상적으로 잡히는지 검증.
-  - [x] **재시도 정책 (Retry Policy):** 각 예외 클래스의 `should_retry` 속성이 설계 의도(네트워크=True, 설정=False 등)대로 설정되었는지 확인.
+  - [x] **상속 계층 (Inheritance Hierarchy):** `try-except` 블록에서 상위 클래스(예: `ExtractorError`, `TransformerError`)로 하위 에러가 정상적으로 잡히는지 검증.
+  - [x] **재시도 정책 (Retry Policy):** 각 예외 클래스의 `should_retry` 속성이 설계 의도대로 올바르게 고정되었는지 확인.
 
 ## 2. 로직 흐름도
 
@@ -31,29 +31,70 @@ classDiagram
     HttpError <|-- RateLimitError
     HttpError <|-- AuthError
 
+    TransformerError <|-- MergeKeyNotFoundError
+    TransformerError <|-- MergeColumnCollisionError
+    TransformerError <|-- MergeCardinalityError
+    TransformerError <|-- MergeExecutionError
+
     note for HttpError "Logic: Truncate body if len > 500"
     note for RateLimitError "Force: should_retry = True"
+    note for TransformerError "Force: should_retry = False (데이터 결함은 재시도 불가)"
 ```
 
 ## 3. BDD 테스트 시나리오
 
-**시나리오 요약 (총 12건):**
+### 3.1. 전역 기반 예외 (Global Base Exceptions)
 
-1.  **기반 로직 (Base Logic):** 3건 (JSON 직렬화, 원인 예외 체이닝, 콘솔 출력 포맷)
-2.  **데이터 축약 (Truncation):** 5건 (HTTP Body 경계값 [Under, Exact, Over], Null 처리, 스키마 데이터)
-3.  **계층 및 속성 (Hierarchy & Props):** 4건 (설정 키, 네트워크 URL, RateLimit 헤더, Auth 상속/재시도 정책)
+**시나리오 요약 (총 4건):**
 
-|  테스트 ID   | 분류 |   기법    | 전제 조건 (Given)                     | 수행 (When)                       | 검증 (Then)                                                                    | 입력 데이터 / 상황          |
-| :----------: | :--: | :-------: | :------------------------------------ | :-------------------------------- | :----------------------------------------------------------------------------- | :-------------------------- |
-| **BASE-01**  | 단위 |  직렬화   | `ETLError` 인스턴스 생성              | `to_dict()` 호출                  | 반환된 딕셔너리에 `error_type`, `message`, `should_retry` 키가 필수적으로 존재 | `msg="Base Error"`          |
-| **BASE-02**  | 단위 |  체이닝   | 하위 예외(`ValueError`)가 원인인 에러 | `to_dict()` 호출                  | `cause` 필드에 원본 예외의 문자열 표현(`str(e)`)이 포함됨                      | `original=ValueError("..")` |
-| **BASE-03**  | 단위 |  포맷팅   | `ETLError` 인스턴스 생성              | `str(error)` (콘솔 출력) 확인     | `[ETLError] 메시지 (Caused by: ..)` 형식의 디버깅용 문자열 반환                | `msg="Debug Check"`         |
-| **TRUNC-01** | 단위 |  **BVA**  | HTTP Body 길이가 **499자** (Under)    | `HttpError` 초기화 후 `to_dict()` | `details['response_body_preview']`에 원본 문자열이 **그대로** 저장됨           | `body="A" * 499`            |
-| **TRUNC-02** | 단위 |  **BVA**  | HTTP Body 길이가 **500자** (Exact)    | `HttpError` 초기화 후 `to_dict()` | 1. 문자열이 잘리지 않음<br>2. `...(truncated)` 접미사가 붙지 않음              | `body="A" * 500`            |
-| **TRUNC-03** | 단위 |  **BVA**  | HTTP Body 길이가 **501자** (Over)     | `HttpError` 초기화 후 `to_dict()` | 1. 문자열이 500자에서 잘림<br>2. 끝에 `...(truncated)` 접미사가 붙음           | `body="A" * 501`            |
-| **TRUNC-04** | 단위 |   방어    | HTTP Body가 `None` 또는 빈 값         | `HttpError` 초기화 후 `to_dict()` | 에러 없이 `preview` 값이 "Empty"로 안전하게 처리됨                             | `body=None`                 |
-| **TRUNC-05** | 단위 |    BVA    | 검증 실패 데이터가 매우 큰 딕셔너리   | `SchemaValidationError` 초기화    | `invalid_data_preview`가 문자열 변환 후 500자로 축약됨                         | `data={"k": "v"*100}`       |
-| **PROP-01**  | 단위 | 속성/분기 | `ConfigurationError` 생성             | `details` 속성 검사               | `key_name` 키가 `details` 딕셔너리에 올바르게 주입됨                           | `key_name="DB_HOST"`        |
-| **PROP-02**  | 단위 | 속성/분기 | `NetworkConnectionError` 생성         | `details` 속성 검사               | `url` 키가 `details` 딕셔너리에 올바르게 주입됨                                | `url="http://test.com"`     |
-| **PROP-03**  | 단위 | 속성/분기 | `RateLimitError` 생성                 | 인스턴스 속성 검사                | 1. `should_retry`가 **True**여야 함<br>2. `retry_after`가 `details`에 포함됨   | `retry_after=60`            |
-| **HIER-01**  | 단위 |   상속    | `AuthError` 인스턴스 생성             | `isinstance` 및 속성 체크         | 1. `HttpError`의 인스턴스임(True)<br>2. `should_retry`는 **False**여야 함      | `AuthError(...)`            |
+1. **기반 로직 검증:** 3건 (JSON 직렬화 필수 키, 예외 체이닝 원인 보존, 콘솔 출력 포맷)
+2. **설정 예외 검증:** 1건 (`ConfigurationError` 속성 주입)
+
+|   Test ID   | Category |   Technique   | Given                                 | When                | Then                                                                   | Input Data                  |
+| :---------: | :------: | :-----------: | :------------------------------------ | :------------------ | :--------------------------------------------------------------------- | :-------------------------- |
+| **BASE-01** |   Unit   | Serialization | `ETLError` 인스턴스 생성              | `to_dict()` 호출    | 반환된 딕셔너리에 `error_type`, `message`, `should_retry` 키 필수 존재 | `msg="Base Error"`          |
+| **BASE-02** |   Unit   |   Chaining    | 하위 예외(`ValueError`)가 원인인 에러 | `to_dict()` 호출    | `cause` 필드에 원본 예외의 문자열 표현(`str(e)`)이 포함됨              | `original=ValueError("..")` |
+| **BASE-03** |   Unit   |  Formatting   | `ETLError` 인스턴스 생성              | `str(error)` 확인   | `[ETLError] 메시지 (Caused by: ..)` 형식의 텍스트 반환                 | `msg="Debug Check"`         |
+| **BASE-04** |   Unit   |   Property    | `ConfigurationError` 생성             | `details` 속성 검사 | `key_name` 키가 `details` 딕셔너리에 올바르게 주입됨                   | `key_name="DB_HOST"`        |
+
+### 3.2. 데이터 축약 로직 (Log Noise Reduction)
+
+**시나리오 요약 (총 5건):**
+
+1. **HTTP Body 경계값 (BVA):** 3건 (500자 기준 Under, Exact, Over 검증)
+2. **데이터 방어 (Robustness):** 2건 (Null 입력 시 안전 처리, 스키마 딕셔너리 데이터 축약)
+
+|   Test ID    | Category | Technique  | Given                         | When                 | Then                                                      | Input Data           |
+| :----------: | :------: | :--------: | :---------------------------- | :------------------- | :-------------------------------------------------------- | :------------------- |
+| **TRUNC-01** |   Unit   |  **BVA**   | HTTP Body 길이가 **499자**    | `HttpError` 초기화   | `response_body_preview`에 원본 문자열이 **그대로** 저장됨 | `body="A" * 499`     |
+| **TRUNC-02** |   Unit   |  **BVA**   | HTTP Body 길이가 **500자**    | `HttpError` 초기화   | 문자열이 잘리지 않고 `...(truncated)` 접미사 없음         | `body="A" * 500`     |
+| **TRUNC-03** |   Unit   |  **BVA**   | HTTP Body 길이가 **501자**    | `HttpError` 초기화   | 500자에서 잘리며 끝에 `...(truncated)` 접미사 추가됨      | `body="A" * 501`     |
+| **TRUNC-04** |   Unit   | Robustness | HTTP Body가 `None` 또는 빈 값 | `HttpError` 초기화   | 에러 없이 `preview` 값이 "Empty"로 안전 처리됨            | `body=None`          |
+| **TRUNC-05** |   Unit   |  **BVA**   | 매우 큰 딕셔너리 데이터       | `SchemaError` 초기화 | 딕셔너리가 문자열 변환 후 500자로 축약됨                  | `data={"k":"v"*100}` |
+
+### 3.3. 수집 계층 예외 (Extractor Exceptions)
+
+**시나리오 요약 (총 3건):**
+
+1. **속성 및 재시도 검증:** 2건 (네트워크 URL 보존, RateLimit 재시도 속성 및 시간 강제)
+2. **상속 계층 검증:** 1건 (AuthError의 HttpError 상속 및 재시도 불가 확인)
+
+|  Test ID   | Category | Technique | Given                         | When                | Then                                                     | Input Data              |
+| :--------: | :------: | :-------: | :---------------------------- | :------------------ | :------------------------------------------------------- | :---------------------- |
+| **EXT-01** |   Unit   | Property  | `NetworkConnectionError` 생성 | `details` 속성 검사 | `url` 키가 딕셔너리에 보존되며 `should_retry` = **True** | `url="http://test.com"` |
+| **EXT-02** |   Unit   | Property  | `RateLimitError` 생성         | 인스턴스 검사       | `should_retry` = **True** 강제, `retry_after` 보존됨     | `retry_after=60`        |
+| **EXT-03** |   Unit   | Hierarchy | `AuthError` 인스턴스 생성     | `isinstance` 체크   | `HttpError` 인스턴스 인식 및 `should_retry` = **False**  | `AuthError(...)`        |
+
+### 3.4. 변환 계층 예외 (Transformer Exceptions)
+
+**시나리오 요약 (총 4건):**
+
+1. **속성 및 재시도 강제성:** 3건 (누락된 키 리스트, 충돌 컬럼 리스트, 병합 전후 튜플 형태 보존 및 재시도 불가 강제)
+2. **실행 예외 체이닝:** 1건 (Pandas 런타임 에러 원인 보존)
+
+|  Test ID   | Category | Technique | Given                            | When             | Then                                                              | Input Data                |
+| :--------: | :------: | :-------: | :------------------------------- | :--------------- | :---------------------------------------------------------------- | :------------------------ |
+| **TRF-01** |   Unit   | Property  | `MergeKeyNotFoundError` 생성     | `to_dict()` 호출 | `missing_keys` 리스트 보존, `should_retry` = **False**            | `missing_keys=["id"]`     |
+| **TRF-02** |   Unit   | Property  | `MergeColumnCollisionError` 생성 | `to_dict()` 호출 | `colliding_columns` 리스트 보존, `should_retry` = **False**       | `colliding_cols=["name"]` |
+| **TRF-03** |   Unit   | Property  | `MergeCardinalityError` 생성     | `to_dict()` 호출 | `left_shape`, `right_shape` 튜플 보존, `should_retry` = **False** | `left=(10,2)`             |
+| **TRF-04** |   Unit   | Chaining  | `MergeExecutionError` 생성       | `to_dict()` 호출 | `join_type` 보존, `original_exception` 전달 시 `cause` 기록       | `join_type="left"`        |

--- a/docs/TCS/data-pipeline/TCS-TRF-001.md
+++ b/docs/TCS/data-pipeline/TCS-TRF-001.md
@@ -1,0 +1,73 @@
+# AbstractTransformer 테스트 명세서
+
+## 1. 문서 정보 및 전략
+
+- **대상 모듈:** `src.transformer.processors.abstract_transformer.AbstractTransformer`
+- **복잡도 수준:** **높음 (High)** (모든 데이터 변환기의 기반이 되는 템플릿 메서드 패턴 적용 및 중앙 집중식 에러/로깅 처리)
+- **커버리지 목표:** 분기 커버리지 100%, 구문 커버리지 100%
+- **적용 전략:**
+  - [x] **상태 전이 (State Transition):** 템플릿 메서드의 실행 흐름(`_validate` -> `_apply_transform` -> 타입 검증) 순서 보장 검증.
+  - [x] **결함 주입 (Fault Injection):** 예측 가능한 도메인 예외(`ETLError`)와 예측 불가능한 런타임 예외(`Exception`) 상황 강제 시뮬레이션.
+  - [x] **Stubbing & Mocking:** 추상 클래스 테스트를 위한 구체 구현체(Stub) 정의 및 `ConfigManager`, 로거 모의 객체(Mock) 주입.
+  - [x] **경계값 분석 (BVA):** 빈 데이터프레임(Empty DataFrame) 입력 및 필수 의존성 누락(`None`) 방어 검증.
+
+## 2. 로직 흐름도
+
+```mermaid
+stateDiagram-v2
+    [*] --> Init: __init__(config)
+    Init --> RaiseConfigError: config is None
+    Init --> Ready: config is Valid
+
+    state "Template Method Execution" as TME {
+        Ready --> Validate: transform(data)
+        Validate --> ApplyTransform: _validate() Success
+        ApplyTransform --> VerifyResult: _apply_transform() Success
+
+        state "Exception Handling" as EH {
+            Validate --> HandleDomainErr: ETLError raised
+            Validate --> HandleUnknownErr: Exception raised
+            ApplyTransform --> HandleDomainErr: ETLError raised
+            ApplyTransform --> HandleUnknownErr: Exception raised
+        }
+
+        VerifyResult --> End: Result is pd.DataFrame
+        VerifyResult --> HandleTypeErr: Result is NOT pd.DataFrame
+    }
+
+    HandleDomainErr --> LogDomainErr: Log ERROR (Domain logic failed)
+    LogDomainErr --> Reraise: Reraise ETLError (as is)
+
+    HandleUnknownErr --> LogTrace: Log ERROR with exc_info=True
+    LogTrace --> RaiseWrapped: Raise TransformerError (from e)
+
+    HandleTypeErr --> RaiseWrapped: Raise TransformerError (Type mismatch)
+
+    End --> [*]: Return Transformed DataFrame
+    Reraise --> [*]
+    RaiseWrapped --> [*]
+    RaiseConfigError --> [*]
+```
+
+## 3. BDD 테스트 시나리오
+
+**시나리오 요약 (총 9건):**
+
+- **초기화 (Initialization):** 2건 (정상 인스턴스 생성, Config 누락 방어)
+- **정상 흐름 (Happy Path):** 1건 (템플릿 메서드 호출 순서 및 로깅)
+- **데이터 검증 (Data Verification):** 2건 (빈 DataFrame 통과, 반환 타입 방어)
+- **에러 핸들링 (Error Handling):** 2건 (도메인 에러 통과, 예측 불가 에러 래핑)
+- **상태 및 멱등성 (State & Idempotency):** 1건 (연속 호출 시 상태 비저장성 유지)
+- **기반 메서드 (Base Method):** 1건 (추상 클래스 기본 동작 확인)
+
+|  테스트 ID  | 분류 |   기법   | 전제 조건 (Given)                                   | 수행 (When)                                     | 검증 (Then)                                                                                                     | 입력 데이터 / 상황        |
+| :---------: | :--: | :------: | :-------------------------------------------------- | :---------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- | :------------------------ |
+| **INIT-01** | 단위 |   표준   | 유효한 `ConfigManager` 모의 객체                    | `StubTransformer(config)` 초기화                | 1. 인스턴스 정상 생성<br>2. 내부 로거가 해당 클래스명으로 초기화됨                                              | `config=MockConfig()`     |
+| **INIT-02** | 단위 |   BVA    | `config` 객체가 `None`인 상태                       | `StubTransformer(None)` 초기화                  | `ConfigurationError` 발생 (메시지: "초기화 실패...")                                                            | `config=None`             |
+| **FLOW-01** | 단위 |   상태   | 모든 단계가 성공하는 `StubTransformer`              | `transform(valid_df)` 호출                      | 1. `_validate` -> `_apply_transform` 순서대로 호출됨<br>2. 시작/종료 INFO 로그 기록됨<br>3. 결과 DataFrame 반환 | `valid_df (shape: 10, 5)` |
+| **DATA-01** | 단위 |   BVA    | 로우(Row)가 없는 빈 DataFrame                       | `transform(empty_df)` 호출                      | 에러 없이 파이프라인 정상 통과 및 반환                                                                          | `empty_df (shape: 0, 5)`  |
+| **DATA-02** | 단위 |  견고성  | `_apply_transform`이 DataFrame이 아닌 값 반환       | `transform(df)` 호출                            | 1. `TransformerError` 발생<br>2. `should_retry=False` 설정 확인                                                 | Stub Return: `pd.Series`  |
+| **ERR-01**  | 예외 | 결함주입 | `_validate` 중 `ETLError` 도메인 에러 발생          | `transform(df)` 호출                            | 1. 에러 래핑 없이 원본 `ETLError` 그대로 발생<br>2. ERROR 로그 기록 확인                                        | Raise `ETLError`          |
+| **ERR-02**  | 예외 | 결함주입 | `_apply_transform` 중 알 수 없는 `MemoryError` 발생 | `transform(df)` 호출                            | 1. `TransformerError`로 래핑되어 발생<br>2. ERROR 로그에 Stack Trace(`exc_info`) 포함                           | Raise `MemoryError`       |
+| **STAT-01** | 단위 |   상태   | 단일 `StubTransformer` 인스턴스 생성                | `transform(df1)`, `transform(df2)` 연속 호출    | 두 호출이 서로 간섭 없이 독립적으로 성공하며 멱등성 보장                                                        | `df1`, `df2`              |
+| **BASE-01** | 단위 |   표준   | 초기화된 `StubTransformer` 인스턴스                 | `AbstractTransformer`의 추상 메서드 명시적 호출 | `pass` 블록이 예외 없이 실행되며 반환값이 `None`임                                                              | `valid_df`                |

--- a/docs/TCS/data-pipeline/TCS-TRF-002.md
+++ b/docs/TCS/data-pipeline/TCS-TRF-002.md
@@ -1,0 +1,79 @@
+## 1. 문서 정보 및 전략
+
+- **대상 모듈:** `src.transformer.processors.data_merger.DataMerger`
+- **복잡도 수준:** **최상 (Critical)** (데이터 정합성 보장, M:N 증폭 방지 및 스키마 오염 원천 차단)
+- **커버리지 목표:** 분기 커버리지(Branch Coverage) 100%, 구문 커버리지(Statement Coverage) 100%
+- **적용 전략:**
+  - [x] **경계값 분석 (BVA):** 빈 리스트(`[]`), 빈 데이터프레임(Empty DataFrame) 등 엣지 케이스 검증.
+  - [x] **오류 추측 (Error Guessing):** Pandas의 내부 런타임 에러(MemoryError 등) 강제 시뮬레이션 및 래핑 확인.
+  - [x] **방어적 프로그래밍 (Defensive):** 입력 타입, 컬럼 충돌(Collision), 카디널리티(M:N) 위반에 대한 사전/사후 차단 검증.
+  - [x] **멱등성 (Idempotency):** 상태(State)로 보유한 `right_df`의 불변성 및 반복 호출 안정성 검증.
+
+## 2. 로직 흐름도
+
+```mermaid
+stateDiagram-v2
+    [*] --> Init: __init__(config, right_df, join_type, on_keys)
+
+    state Init {
+        [*] --> CheckType: isinstance(right_df, DataFrame)
+        CheckType --> CheckJoinType: Pass
+        CheckType --> RaiseTypeError: Fail (TransformerError)
+        CheckJoinType --> CheckKeys: Pass
+        CheckJoinType --> RaiseValueError1: Fail (Invalid Join Type)
+        CheckKeys --> Ready: Pass
+        CheckKeys --> RaiseValueError2: Fail (Empty Keys)
+    }
+
+    Ready --> Validate: transform(data) called
+
+    state "Validation Phase (_validate)" as ValPhase {
+        Validate --> CheckLeftKeys
+        CheckLeftKeys --> CheckRightKeys: Pass
+        CheckLeftKeys --> RaiseKeyErr1: Missing in Left (MergeKeyNotFoundError)
+        CheckRightKeys --> CheckCollision: Pass
+        CheckRightKeys --> RaiseKeyErr2: Missing in Right (MergeKeyNotFoundError)
+        CheckCollision --> TransformPhase: Pass
+        CheckCollision --> RaiseCollisionErr: Collsion Exists (MergeColumnCollisionError)
+    }
+
+    state "Transform Phase (_apply_transform)" as TransPhase {
+        TransformPhase --> PandasMerge: pd.merge(validate='m:1' or None)
+        PandasMerge --> MergeSuccess: Success
+        PandasMerge --> HandleMergeErr: pd.errors.MergeError
+        PandasMerge --> HandleSysErr: Exception
+
+        HandleMergeErr --> RaiseCardErr: Raise MergeCardinalityError (M:N detected)
+        HandleSysErr --> RaiseExecErr: Raise MergeExecutionError
+    }
+
+    MergeSuccess --> [*]: Return Merged DataFrame
+```
+
+## 3. BDD 테스트 시나리오
+
+**시나리오 요약 (총 14건):**
+
+- **초기화 방어 (Initialization):** 4건 (정상 생성, 타입 예외, 미지원 조인 방식, 빈 키 리스트)
+- **정상 흐름 (Happy Path):** 3건 (Left 1:1 조인, Inner N:1 조인, 제약 없는 Outer 조인)
+- **경계값 및 엣지 (Edge Cases):** 1건 (빈 DataFrame 병합)
+- **스키마 검증 (Schema Validation):** 3건 (Left 키 누락, Right 키 누락, 조인 키 외 컬럼 충돌)
+- **에러 핸들링 (Error Handling):** 2건 (카디널리티 폭발 M:N 방어, 시스템 런타임 예외 래핑)
+- **상태 및 멱등성 (State & Idempotency):** 1건 (상태 불변성 및 연속 호출)
+
+|  테스트 ID  | 분류 | 기법 | 전제 조건 (Given)                                    | 수행 (When)                        | 검증 (Then)                                                            | 입력 데이터 / 상황                   |
+| :---------: | :--: | :--: | :--------------------------------------------------- | :--------------------------------- | :--------------------------------------------------------------------- | :----------------------------------- |
+| **INIT-01** | 단위 | 표준 | 유효한 `right_df` 및 지원되는 `join_type`, `on_keys` | `DataMerger` 인스턴스 초기화       | 정상적으로 객체가 생성되며 내부 상태가 올바르게 할당됨                 | `join_type="left"`, `on_keys=["id"]` |
+| **INIT-02** | 단위 | 방어 | `right_df` 파라미터에 DataFrame이 아닌 값 주입       | `DataMerger` 인스턴스 초기화       | 1. `TransformerError` 발생<br>2. `should_retry=False` 설정 확인        | `right_df=None` 또는 `[]`            |
+| **INIT-03** | 단위 | BVA  | 지원하지 않는 `join_type` 문자열 주입                | `DataMerger` 인스턴스 초기화       | `ValueError` 발생 (지원 포맷 안내 메시지 포함)                         | `join_type="cross"`                  |
+| **INIT-04** | 단위 | BVA  | 병합 기준 키 `on_keys`에 빈 리스트 주입              | `DataMerger` 인스턴스 초기화       | `ValueError` 발생 (최소 1개 키 필요 메시지)                            | `on_keys=[]`                         |
+| **FLOW-01** | 단위 | 표준 | 1:1 관계를 만족하는 Left/Right 데이터 세팅           | `transform(left_df)` 호출          | 병합이 정상 수행되고 Left 기준 행(Row) 수 유지됨                       | `join_type="left"`                   |
+| **FLOW-02** | 단위 | 표준 | N:1 관계(Left에 중복키 존재)의 데이터 세팅           | `transform(left_df)` 호출          | 병합이 정상 수행되고 Inner 조인 결과 반환됨                            | `join_type="inner"`                  |
+| **FLOW-03** | 단위 | 방어 | m:1 제약이 없는 상태에서의 조인 세팅                 | `transform(left_df)` 호출          | `validate` 정책 없이 Outer 조인이 정상 수행됨                          | `join_type="outer"`                  |
+| **EDGE-01** | 단위 | BVA  | 행(Row)이 0개인 빈(Empty) Left DataFrame             | `transform(empty_df)` 호출         | 에러 없이 스키마(컬럼)만 병합된 빈 DataFrame 반환                      | `left_df.shape = (0, 3)`             |
+| **VAL-01**  | 단위 | 방어 | `left_df`에 `on_keys`로 지정된 컬럼 누락             | `transform(left_df)` 호출          | `MergeKeyNotFoundError` 조기 발생 (Left 명시)                          | `left_df`에 "id" 컬럼 없음           |
+| **VAL-02**  | 단위 | 방어 | `right_df`에 `on_keys`로 지정된 컬럼 누락            | `transform(left_df)` 호출          | `MergeKeyNotFoundError` 조기 발생 (Right 명시)                         | `right_df`에 "id" 컬럼 없음          |
+| **VAL-03**  | 단위 | 방어 | 조인 키를 제외하고 양쪽에 동일한 컬럼 존재           | `transform(left_df)` 호출          | `MergeColumnCollisionError` 조기 발생 (접미사 오염 방지)               | 양쪽에 "status" 컬럼 존재            |
+| **ERR-01**  | 예외 | 결함 | Right 데이터에 조인 키가 중복되어 M:N 발생 유도      | `transform(left_df)` 호출          | `MergeCardinalityError` 발생 (Pandas 예외 래핑)                        | `join_type="left"`, Right에 키 중복  |
+| **ERR-02**  | 예외 | 결함 | `pd.merge` 호출 시 `MemoryError` 발생 (Mocking)      | `transform(left_df)` 호출          | `MergeExecutionError`로 래핑되어 발생                                  | Mock `pd.merge` -> Raise             |
+| **STAT-01** | 단위 | 멱등 | 단일 `DataMerger` 인스턴스와 고정된 `left_df`        | `transform(left_df)` 3회 연속 호출 | 1. 세 번 모두 동일한 데이터프레임 반환<br>2. 원본 `right_df` 변경 없음 | 동일한 `left_df` 객체 재사용         |


### PR DESCRIPTION
# [PR] Safe Data Merger 구현 및 데이터 정합성 검증 로직 강화

## 1. 🎫 PR 요약
> **Pandas 병합 과정에서 발생하는 암묵적 스키마 오염 및 의도치 않은 데이터 증폭(M:N Join)을 방지하기 위해, 엄격한 사전/사후 검증 로직이 포함된 `DataMerger` 프로세서를 구현함.**

## 2. 🛠 작업 내용
- **`DataMerger` 클래스 구현**: `AbstractTransformer`를 상속받아 상태 기반(Stateful) 병합 로직 설계
- **방어적 사전 검증(`_validate`)**: 조인 키 누락 확인 및 조인 키 외 컬럼명 중복(Collision) 시 하드 에러 발생 로직 추가
- **카디널리티 제약 강화**: `left`, `inner` 조인 시 `validate='m:1'` 옵션을 적용하여 M:N 관계에 의한 데이터 폭발 방지
- **커스텀 예외 계층 적용**: `MergeKeyNotFoundError`, `MergeCardinalityError` 등 도메인 특화 예외를 통해 에러 문맥(Context) 가독성 개선
- **단위 테스트 및 BDD 시나리오 작성**: 경계값 분석(BVA) 및 결함 주입을 포함한 14종의 테스트 케이스 확보

## 3. 💡 기술적 의사결정 (Architecture & Tech Stack)
> **데이터 파이프라인의 신뢰성 확보를 위해 "Fail-Fast" 원칙을 최우선으로 고려함.**

- **결정 배경 (Stateful Transformer):** - `ITransformer.transform(data)`의 단일 입력 시그니처를 유지하면서 Right DataFrame을 처리하기 위해, 병합 대상을 생성자 주입(Constructor Injection) 방식으로 관리하도록 설계함. 이는 파이프라인 체이닝 구성 시 직관성을 극대화함.
- **Trade-off (Column Collision Strategy):** - Pandas의 기본 동작인 자동 접미사(`_x`, `_y`) 추가를 허용하지 않고 즉시 에러를 발생시킴. 파이프라인 상단에서 명시적으로 `Rename`을 강제하게 함으로써, "조용히 넘어가는 버그"로 인한 데이터 오염 가능성을 원천 차단함.
- **성능 최적화:** - 스키마 검증 시 파이썬 `set` 연산을 활용하여 $O(N)$ 복잡도로 정합성을 체크하며, 실제 병합은 Pandas의 C-Engine 기반 벡터화 연산을 활용함.


## 4. 📋 주요 변경점
- `src/transformer/processors/data_merger.py`:
    - `SUPPORTED_JOIN_TYPES` 상수를 통한 입력 값 화이트리스트 관리.
    - `_validate()`: 집합 자료형을 이용한 키 및 컬럼 충돌 체크.
    - `_apply_transform()`: `pd.merge` 실행 및 런타임 예외(MemoryError 등) 래핑 처리.
- `tests/transformer/processors/test_data_merger.py`:
    - BDD 스타일(`Given-When-Then`)의 단위 테스트 구현.
    - `@patch`를 이용한 시스템 에러 상황 시뮬레이션.

## 5. 📸 테스트 결과 / 스크린샷
- **Unit Test 결과**: 총 14개 시나리오 통과 (정상 흐름, 경계값, 방어 코드 등)
- **Coverage**: 구문 및 분기 커버리지 100% 달성

| Name | Stmts | Miss | Branch | BrPart | Cover | Missing |
| :--- | :---: | :---: | :---: | :---: | :---: | :--- |
| `src/transformer/processors/data_merger.py` | 45 | 0 | 12 | 0 | **100%** | |
| **TOTAL** | **45** | **0** | **12** | **0** | **100%** | |

## 6. 💬 리뷰 포인트 (Focus On)
- **카디널리티 검증 방식**: 현재 `pd.merge(validate='m:1')`를 사용 중입니다. 성능 면에서 병합 전 중복 체크를 하는 것과 병합 후 에러를 잡는 것 중 데이터셋 규모에 따른 임계치 고민이 필요해 보입니다.
- **예외 처리 범위**: `MergeExecutionError`로 래핑할 때 `original_exception`을 보존하고 있는데, 트레이스백 추적에 충분한지 검토 부탁드립니다.

**추가로 필요한 데이터 변환기(Transformer) 구현체가 있다면 말씀해 주세요. 바로 설계를 진행하겠습니다.**