### PR TITLE
[Feat] Loader Layer Specific Exception Handling Module Implementation

### DIFF
--- a/apps/data-pipeline/src/common/exceptions.py
+++ b/apps/data-pipeline/src/common/exceptions.py
@@ -1,13 +1,14 @@
 """
 [예외 처리 모듈 (Custom Exceptions)]
 
-ETL 파이프라인 전역에서 발생하는 예외를 정의하고, 구조화된 로깅(Structured Logging)을 지원하는 모듈입니다.
+ETL 파이프라인 전역(Extract, Transform, Load)에서 발생하는 예외를 정의하고, 구조화된 로깅(Structured Logging)을 지원하는 모듈입니다.
 LogManager(log.py)와 결합하여 ELK/Datadog 등의 시스템에서 즉시 쿼리 가능한 형태의 데이터를 제공합니다.
 
-설계 원칙:
-1. Pure Data Carrier: 시간(Timestamp) 로직은 배제하고, 에러의 문맥(Context) 정보 보존에 집중합니다.
-2. Noise Reduction: 로그 가독성을 해치는 대용량 데이터(Raw HTML 등)는 자동 축약(Truncate)합니다.
-3. Hierarchy: ETL 각 단계(Extract, Transform, Load)를 명확히 구분합니다.
+주요 기능:
+- Pure Data Carrier: 시간(Timestamp) 로직은 배제하고, 에러의 문맥(Context) 정보 보존에 집중합니다.
+- Noise Reduction: 로그 가독성을 해치는 대용량 데이터(Raw HTML 등)는 자동 축약(Truncate)합니다.
+- Layer Hierarchy: ETL 각 단계(Extract, Transform, Load)를 명확히 구분하여 장애 격리(Fault Isolation)를 수행합니다.
+- Retry Policy Encapsulation: 각 예외 클래스 내부에 재시도 가능 여부(should_retry)를 내장하여 파이프라인의 회복 탄력성을 높입니다.
 
 데이터 흐름:
 Exception 발생 -> to_dict() 호출 -> LogManager가 JSON 직렬화 및 시간(KST/UTC) 태깅 -> 로그 저장
@@ -229,4 +230,105 @@ class MergeExecutionError(TransformerError):
 # 6. Loader Layer Detailed Exceptions
 # ==============================================================================
 
+class LoaderValidationError(LoaderError):
+    """AbstractLoader의 DTO 검증(_validate_dto) 과정에서 발생하는 예외.
+    
+    적재 단계로 넘어온 ExtractedDTO 객체의 필수 데이터가 누락되었거나
+    스키마가 불일치할 때 발생합니다. 데이터 정합성 문제이므로 재시도하지 않습니다.
+    """
 
+    def __init__(
+        self, 
+        message: str, 
+        invalid_fields: List[str], 
+        dto_name: str = "ExtractedDTO"
+    ) -> None:
+        """LoaderValidationError 초기화.
+
+        Args:
+            message: 에러 상세 메시지.
+            invalid_fields: 유효성 검사를 통과하지 못한 필드명 목록. JSON 직렬화를 위해 List 사용.
+            dto_name: 검증에 실패한 DTO 객체의 이름 (기본값: ExtractedDTO).
+        """
+        details = {
+            "invalid_fields": invalid_fields,
+            "dto_name": dto_name
+        }
+        
+        # 데이터 누락/형식 오류는 네트워크 재시도로 해결되지 않으므로 should_retry=False
+        super().__init__(message, details=details, should_retry=False)
+
+
+class ZstdCompressionError(LoaderError):
+    """S3Loader의 zstd 스트림 압축(_compress_to_zstd_stream) 중 발생하는 예외.
+    
+    메모리 부족(OOM)이나 바이너리 데이터 인코딩 실패 등 압축 과정의 시스템/데이터 에러를 포착합니다.
+    """
+
+    def __init__(
+        self, 
+        message: str, 
+        data_size_bytes: Optional[int] = None, 
+        original_exception: Optional[Exception] = None
+    ) -> None:
+        """ZstdCompressionError 초기화.
+
+        Args:
+            message: 에러 상세 메시지.
+            data_size_bytes: 압축을 시도했던 원본 데이터의 크기(Byte). OOM 디버깅 용도.
+            original_exception: 발생한 원본 예외 (zstandard 에러 등).
+        """
+        details = {
+            "data_size_bytes": data_size_bytes
+        }
+        
+        # 압축 실패는 대부분 메모리나 데이터 손상 문제이므로 즉각적인 재시도보다는 알림이 필요함
+        super().__init__(
+            message, 
+            details=details, 
+            original_exception=original_exception, 
+            should_retry=False
+        )
+
+
+class S3UploadError(LoaderError):
+    """S3Loader의 S3 적재(_upload_stream, _execute_multipart_upload) 중 발생하는 예외.
+    
+    Boto3 클라이언트 네트워크 타임아웃, 권한 거부(Access Denied), 
+    또는 멀티파트 업로드 실패 시 발생하며 원인에 따라 재시도를 수행해야 합니다.
+    """
+
+    def __init__(
+        self, 
+        message: str, 
+        bucket_name: str, 
+        s3_key: str, 
+        upload_id: Optional[str] = None, 
+        is_multipart: bool = False,
+        original_exception: Optional[Exception] = None
+    ) -> None:
+        """S3UploadError 초기화.
+
+        Args:
+            message: 에러 상세 메시지.
+            bucket_name: 대상 S3 버킷 이름.
+            s3_key: 적재를 시도한 S3 Object Key.
+            upload_id: 멀티파트 업로드 시 부여된 고유 ID (실패 시 Abort 처리를 위한 추적용).
+            is_multipart: 멀티파트 업로드 여부.
+            original_exception: Boto3 등에서 발생한 원본 예외 (botocore.exceptions.ClientError 등).
+        """
+        details = {
+            "bucket_name": bucket_name,
+            "s3_key": s3_key,
+            "upload_id": upload_id,
+            "is_multipart": is_multipart
+        }
+        
+        # S3 업로드 실패의 대부분은 일시적인 네트워크 불안정이나 스로틀링(Throttling)이므로 재시도 권장
+        # 단, 권한 에러(403)의 경우 Exception Handler 단에서 original_exception을 분석하여 Retry를 중단하도록 설계함
+        super().__init__(
+            message, 
+            details=details, 
+            original_exception=original_exception, 
+            should_retry=True
+        )

--- a/apps/data-pipeline/tests/unit/common/test_exceptions.py
+++ b/apps/data-pipeline/tests/unit/common/test_exceptions.py
@@ -6,6 +6,8 @@ from src.common.exceptions import (
     ETLError,
     ConfigurationError,
     ExtractorError,
+    LoaderValidationError,
+    S3UploadError,
     TransformerError,
     LoaderError,
     NetworkConnectionError,
@@ -15,7 +17,8 @@ from src.common.exceptions import (
     MergeKeyNotFoundError,
     MergeColumnCollisionError,
     MergeCardinalityError,
-    MergeExecutionError
+    MergeExecutionError,
+    ZstdCompressionError
 )
 
 # ========================================================================================
@@ -289,3 +292,76 @@ def test_trf_04_merge_execution_chaining():
     assert result["details"]["join_type"] == join_type
     assert result["cause"] == "Out of memory during pandas merge"
     assert result["should_retry"] is False
+
+# ========================================================================================
+# 5. 적재 계층 예외 테스트 (Loader Exceptions)
+# ========================================================================================
+
+def test_ldr_01_validation_error():
+    """[LDR-01] [Property] LoaderValidationError 생성 시 invalid_fields 및 dto_name 보존, 재시도 불가 검증"""
+    # Given
+    invalid_fields = ["user_id", "transaction_amount"]
+    dto_name = "FinanceDTO"
+    
+    # When
+    error = LoaderValidationError(
+        message="Required fields are missing.",
+        invalid_fields=invalid_fields,
+        dto_name=dto_name
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["invalid_fields"] == invalid_fields
+    assert result["details"]["dto_name"] == dto_name
+    assert result["should_retry"] is False
+
+
+def test_ldr_02_compression_error():
+    """[LDR-02] [Chaining] ZstdCompressionError 생성 시 data_size 보존, 원본 예외 체이닝 및 재시도 불가 검증"""
+    # Given
+    data_size = 1024 * 1024  # 1MB
+    original = MemoryError("Out of memory during zstd compression")
+    
+    # When
+    error = ZstdCompressionError(
+        message="Compression failed.",
+        data_size_bytes=data_size,
+        original_exception=original
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["data_size_bytes"] == data_size
+    assert result["cause"] == "Out of memory during zstd compression"
+    assert error.original_exception is original
+    assert result["should_retry"] is False
+
+
+def test_ldr_03_s3_upload_error():
+    """[LDR-03] [Property] S3UploadError 생성 시 업로드 메타데이터 보존, 원본 예외 체이닝 및 재시도 강제 검증"""
+    # Given
+    bucket = "test-data-bucket"
+    key = "etl/2026/data.csv.zst"
+    upload_id = "abc123_multipart_id"
+    original = ConnectionError("Read timeout on endpoint URL")
+    
+    # When
+    error = S3UploadError(
+        message="S3 multipart upload failed.",
+        bucket_name=bucket,
+        s3_key=key,
+        upload_id=upload_id,
+        is_multipart=True,
+        original_exception=original
+    )
+    result = error.to_dict()
+    
+    # Then
+    assert result["details"]["bucket_name"] == bucket
+    assert result["details"]["s3_key"] == key
+    assert result["details"]["upload_id"] == upload_id
+    assert result["details"]["is_multipart"] is True
+    assert result["cause"] == "Read timeout on endpoint URL"
+    assert error.original_exception is original
+    assert result["should_retry"] is True

--- a/docs/TCS/data-pipeline/TCS-EXC-001.md
+++ b/docs/TCS/data-pipeline/TCS-EXC-001.md
@@ -98,3 +98,17 @@ classDiagram
 | **TRF-02** |   Unit   | Property  | `MergeColumnCollisionError` 생성 | `to_dict()` 호출 | `colliding_columns` 리스트 보존, `should_retry` = **False**       | `colliding_cols=["name"]` |
 | **TRF-03** |   Unit   | Property  | `MergeCardinalityError` 생성     | `to_dict()` 호출 | `left_shape`, `right_shape` 튜플 보존, `should_retry` = **False** | `left=(10,2)`             |
 | **TRF-04** |   Unit   | Chaining  | `MergeExecutionError` 생성       | `to_dict()` 호출 | `join_type` 보존, `original_exception` 전달 시 `cause` 기록       | `join_type="left"`        |
+
+### 3.5. 적재 계층 예외 (Loader Exceptions)
+
+**시나리오 요약 (총 3건):**
+
+1. **유효성 검증 실패 (Validation):** 1건 (필수 데이터 누락 확인 및 재시도 불가 강제 검증)
+2. **압축 처리 예외 (Compression):** 1건 (OOM/인코딩 에러 원인 보존 및 재시도 불가 강제 검증)
+3. **S3 업로드 예외 (Upload):** 1건 (Boto3 에러 체이닝, 멀티파트 메타데이터 보존 및 재시도 강제 검증)
+
+|  Test ID   | Category | Technique | Given                        | When             | Then                                                                          | Input Data              |
+| :--------: | :------: | :-------: | :--------------------------- | :--------------- | :---------------------------------------------------------------------------- | :---------------------- |
+| **LDR-01** |   Unit   | Property  | `LoaderValidationError` 생성 | `to_dict()` 호출 | `invalid_fields`, `dto_name` 보존, `should_retry` = **False**                 | `invalid_fields=["id"]` |
+| **LDR-02** |   Unit   | Chaining  | `ZstdCompressionError` 생성  | `to_dict()` 호출 | `data_size_bytes` 보존, `cause`에 예외 기록, `should_retry` = **False**       | `data_size=1024`        |
+| **LDR-03** |   Unit   | Property  | `S3UploadError` 생성         | `to_dict()` 호출 | `bucket`, `key`, `is_multipart` 등 메타데이터 보존, `should_retry` = **True** | `bucket="test-bucket"`  |


### PR DESCRIPTION
# [PR] ETL 공통 예외 처리 모듈 고도화 및 Loader 계층 예외 추가

## 1. 🎫 PR 요약
> **ETL 파이프라인 전역(E-T-L)의 예외 구조를 표준화하고, Loader 계층의 세부 예외 정의 및 구조화된 로깅(Structured Logging) 기능을 강화하였습니다.**
- 데이터 적재(Load) 단계의 유효성 검증, 압축, S3 업로드 실패 상황에 대응하는 예외 클래스를 추가하고, 모든 예외에 대해 재시도 정책(`should_retry`)과 로그 노이즈 방지 로직을 적용하였습니다.

## 2. 🛠 작업 내용
- **Loader 계층 전용 예외 클래스 구현**: `LoaderValidationError`, `ZstdCompressionError`, `S3UploadError` 추가
- **구조화된 로깅 지원**: 모든 예외 객체에 `to_dict()` 메서드를 구현하여 ELK/Datadog 등 로그 시스템과의 호환성 확보
- **로그 노이즈 감소(Noise Reduction)**: `HttpError` 및 하위 클래스에서 대용량 응답 본문(Response Body)을 500자로 제한하는 Truncate 로직 적용
- **재시도 정책 캡슐화**: 각 예외 상황별 성격(일시적 vs 영구적)에 따라 `should_retry` 속성을 내장하여 파이프라인 회복 탄력성 제어
- **단위 테스트 및 커버리지**: 경계값 분석(BVA)을 포함한 19종의 시나리오 테스트 작성 및 구문/분기 커버리지 100% 달성

## 3. 💡 기술적 의사결정 (Architecture & Tech Stack)
- **결정 배경: 왜 Exception 내부에 재시도 로직을 포함했는가?**
    - 상위 오케스트레이터(Airflow, Prefect 등)나 공통 Retry Decorator가 예외의 타입을 분석하여 재시도 여부를 결정하는 로직을 분산시키지 않기 위함입니다. 예외 자체가 "나는 재시도 가능한 오류인가"에 대한 메타데이터를 가짐으로써 비즈니스 로직이 간결해집니다.
- **Trade-off: 데이터 축약(Truncation) 임계값 설정**
    - HTTP Body 전체를 기록할 경우 로그 저장소의 비용 상승 및 가독성 저하 문제가 발생합니다. 디버깅에 필요한 최소한의 컨텍스트를 유지하면서 시스템 부하를 최소화하기 위해 임계값을 **500자**로 설정하였습니다.
- **데이터 직렬화 전략**: 
    - 로그 시스템 전송 시 JSON 직렬화 오류를 방지하기 위해 `Set` 자료형 대신 `List` 사용을 강제하였으며, 원본 예외(Chained Exception)는 문자열로 변환하여 기록하도록 설계하였습니다.

## 4. 📋 주요 변경점
- `src/common/exceptions.py`: 
    - `ETLError`: 전역 최상위 예외 및 직렬화/포맷팅 로직 구현
    - `HttpError`: 500자 축약 로직 및 HTTP 상태 코드 기록 기능 포함
    - `TransformerError` 군: 데이터 정합성(Merge Key, Cardinality) 관련 예외(재시도 불가) 정의
    - `LoaderError` 군: 유효성 검증, Zstd 압축, S3 멀티파트 업로드 실패 관련 예외 정의
- `tests/test_exceptions.py`: 
    - 경계값 분석(499자, 500자, 501자)을 통한 Truncate 로직 검증
    - 상속 계층 구조(`isinstance`) 및 재시도 플래그 정확성 검증

## 5. 📸 테스트 결과 / 스크린샷

### [Unit Test & Coverage Result]
제공된 모든 테스트 시나리오(19건)가 통과되었으며, 핵심 모듈에 대해 결함 없는 커버리지를 확인하였습니다.

| Name | Stmts | Miss | Branch | BrPart | Cover |
| :--- | :---: | :---: | :---: | :---: | :---: |
| `src/common/exceptions.py` | 75 | 0 | 6 | 0 | **100%** |
| **TOTAL** | **75** | **0** | **6** | **0** | **100%** |

> **Test Summary:** `19 passed in 0.28s`

## 6. 💬 리뷰 포인트 (Focus On)
- **S3UploadError의 재시도 정책**: 현재 네트워크 이슈를 고려하여 `should_retry=True`로 설정되어 있습니다. 권한 문제(403)와 같은 영구적 오류는 Exception Handler에서 `original_exception`을 분석하여 필터링할 예정인데, 이 구조가 적절한지 검토 부탁드립니다.
- **Truncate 임계값**: 현재 500자로 설정된 제한 수치가 API 응답 분석에 충분한지, 혹은 추가적인 확장이 필요한지 의견 주시기 바랍니다.