### PR TITLE
[Test] 대규모 실시간 파이프라인 통합 테스트 및 API 명세 최종 점검

### DIFF
--- a/apps/server-stock/README.md
+++ b/apps/server-stock/README.md
@@ -75,3 +75,28 @@
     * `cumulativeAmount`: 누적 거래대금 (String)
     * `cumulativeVolume`: 누적 거래량 (String)
 > 모든 필드는 String 타입입니다.
+
+--- 
+### C. 실시간 급등락 알림 데이터 (전역 알림용)
+특정 종목의 주가가 지정된 기준치(현재 기준: ±10%) 이상 급등하거나 급락했을 때, 알림 쿨타임(스로틀링)이 적용된 상태로 실시간 알림 데이터를 브로드캐스트합니다. 사이트 전역의 상단 알림 바(Toast) 또는 푸시 알림 용도로 사용됩니다.
+
+* **Destination:** `/topic/surge-alerts`
+* **Response Payload (JSON):**
+```json
+{
+  "stockCode": "005930",
+  "stockName": "삼성전자",
+  "rate": "+10%",
+  "currentPrice": "82500",
+  "changeRate": "10.5",
+  "alertTime": "2026-03-17T09:30:15.123"
+}
+```
+* **필드 설명:**
+  * `stockCode`: 종목코드 (String)
+  * `stockName`: 종목 이름 (String)
+  * `rate`: 발생한 알림의 기준 등락률 (String, 예: "+10%", "-10%")
+  * `currentPrice`: 알림 발생 시점의 현재가 (String)
+  * `changeRate`: 알림 발생 시점의 전일 대비 등락률 (String)
+  * `alertTime`: 알림이 발생한 서버 시간 (String, ISO-8601 포맷 `YYYY-MM-DDThh:mm:ss.SSS`)
+> 모든 필드는 String 타입으로 제공됩니다.

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/StompAlertMessagingAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/StompAlertMessagingAdapter.java
@@ -26,8 +26,8 @@ public class StompAlertMessagingAdapter implements AlertMessagingPort {
                 .stockCode(event.stockCode())
                 .stockName(provider.getStockName(event.stockCode()))
                 .rate(rate)
-                .currentPrice(event.currentPrice())
-                .changeRate(event.changeRate())
+                .currentPrice(String.valueOf(event.currentPrice()))
+                .changeRate(String.valueOf(event.changeRate()))
                 .alertTime(LocalDateTime.now())
                 .build();
         messagingTemplate.convertAndSend("/topic/surge-alerts", response);

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/StockSurgeAlertResponse.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/StockSurgeAlertResponse.java
@@ -8,8 +8,8 @@ public record StockSurgeAlertResponse(
         String stockCode,           // 종목 코드
         String stockName,           // 종목 이름
         String rate,                // "급등" 또는 "급락"
-        Long currentPrice,          // 현재가
-        Double changeRate,          // 등락률
+        String currentPrice,          // 현재가
+        String changeRate,          // 등락률
         LocalDateTime alertTime     // 알림 발생 시간
 ) {
 


### PR DESCRIPTION
## 📌 작업 내용
- **웹소켓(STOMP) API 명세 업데이트:** 프론트엔드 연동을 위해 실시간 급등락 알림(`/topic/surge-alerts`)에 대한 STOMP API 채널 및 페이로드 명세서를 백엔드 Readme에 추가했습니다.
- **API 응답 DTO 타입 일관성(String) 확보:** 프론트엔드 파싱 편의성을 위해 클라이언트로 브로드캐스트되는 알림 데이터(`StockSurgeAlertResponse`)의 모든 숫자형 필드(현재가, 등락률 등)를 `String` 타입으로 통일했습니다.

## 🏗 기술적 의사결정 및 설계 (Core Design)

### 1. STOMP API 응답 DTO 타입 일관성(String) 확보
> **목적:** 프론트엔드 파싱 에러 방지 및 데이터 표현의 일관성 유지

- **문제:** 기존 DTO의 `currentPrice`나 `changeRate` 필드가 `Long`, `Double` 등의 숫자형으로 선언되어 있어, JavaScript 환경에서 부동소수점 정밀도 문제가 발생하거나 화면 렌더링 시 포맷팅을 별도로 처리해야 하는 번거로움이 존재했습니다.
- **해결:** KIS API가 원본 데이터를 String으로 내려주는 정책에 착안하여, 백엔드에서 프론트엔드로 브로드캐스트하는 모든 실시간 데이터 모델(`StockSurgeAlertResponse`)의 숫자 필드를 `String`으로 캐스팅하여 전송하도록 통일했습니다. 이를 통해 클라이언트 측의 타입 에러 가능성을 원천 차단하고 렌더링을 단순화했습니다.

## 테스트 및 검증 전략 (Testing Strategy)
- **통합 테스트 완료:** KIS 데이터 수신부터 STOMP 알림 전송까지의 전체 파이프라인 E2E 통합 테스트 및 스프링 이벤트 검증은 **이전 PR에서 이미 완료**되었습니다.
- **부하 테스트 진행 시점 조정 (다음 스프린트로 이관):** - 초당 수백 건의 대규모 부하 테스트(Load Test)는 현재의 단일 DB 테이블 구조에서 진행할 경우 DB 디스크 I/O 병목으로 인해 정확한 웹소켓 수신부의 성능 측정이 불가하다고 판단했습니다. 
  - 따라서 본격적인 파이프라인 부하 점검은 **다음 스프린트(Redis 1분 인메모리 집계 및 DB 파티셔닝 도입) 완료 후**, 최적화된 아키텍처 환경에서 진행할 예정입니다.

## ✅ 주요 변경점
- **Adapter (Infrastructure / Presentation):**
    - `StompAlertMessagingAdapter`: 프론트엔드 전송용 DTO 변환 시 `currentPrice`, `changeRate` 필드에 대해 `String.valueOf()`를 통한 형변환 적용.
- **Presentation (DTO):**
    - `StockSurgeAlertResponse`: 내부 숫자형 필드의 데이터 타입을 `String`으로 변경.
- **Docs:**
    - 실시간 주식 STOMP API 명세서(Markdown)에 전역 알림용 채널(`/topic/surge-alerts`) 및 JSON 페이로드 스펙 추가 완료.

## 📝 리뷰 포인트
- **API 페이로드 타입 정책:** 프론트엔드 연동 편의성을 위해 웹소켓 응답 DTO의 숫자 필드를 모두 `String`으로 감싸서 내려주도록 변경했습니다. 이 방식이 클라이언트 측 렌더링 및 파싱에 최적인지 프론트엔드 관점에서의 피드백 부탁드립니다.
- **API 명세 직관성:** 새롭게 추가된 급등락 알림 API 명세서의 필드 설명(특히 `alertTime` 포맷 등)이 프론트엔드 개발 시 혼동 없이 명확한지 리뷰 부탁드립니다.