### PR TITLE
[FEAT] PostgreSQL 동적 캔들 롤업(Roll-up) 및 파티셔닝 구현

### DIFF
--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/ServerStockApplication.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/ServerStockApplication.java
@@ -3,7 +3,9 @@ package com.assetmind.server_stock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class ServerStockApplication {
 

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/CandleRollupService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/CandleRollupService.java
@@ -1,0 +1,112 @@
+package com.assetmind.server_stock.stock.application;
+
+import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
+import com.assetmind.server_stock.stock.domain.enums.CandleType;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+/**
+ * 1분봉 또는 1일봉 캔들을 상위 타임 캔들(1일봉, 3분봉, 5분동, 월봉 등등)으로 압축하는 Service
+ */
+@Service
+public class CandleRollupService {
+
+    /**
+     * 1분봉 캔들 리스트를 받아서 원하는 캔들타입으로 롤업
+     * @param sourceCandles 원본 캔들 리스트(1분봉 또는 1일봉)
+     * @param targetType 만들어낼 목표 캔들 타입 (1일봉, 5분봉, 월봉 ..등등)
+     * @return 롤업이 완료된 새로운 캔들 리스트
+     */
+    public List<OhlcvDto> rollup(List<OhlcvDto> sourceCandles, CandleType targetType) {
+        if (sourceCandles == null || sourceCandles.isEmpty()) {
+            return List.of();
+        }
+
+        // 타겟 시간(3분봉, 5분봉, 월봉 등등)에 맞춰 1분봉 또는 1일봉 캔들들을 그룹핑
+        Map<LocalDateTime, List<OhlcvDto>> groupedCandles = sourceCandles.stream()
+                .collect(Collectors.groupingBy(candle ->
+                        calculateBucketTime(candle.candleTimestamp(), targetType)
+                ));
+
+        List<OhlcvDto> rolledUpCandles = new ArrayList<>();
+
+        // 그룹별(3분봉, 5분봉 등등 ..)로 시/고/저/종가/거래량 압축
+        for (Map.Entry<LocalDateTime, List<OhlcvDto>> entry : groupedCandles.entrySet()) {
+            LocalDateTime bucketTime = entry.getKey();
+            List<OhlcvDto> candlesInBucket = entry.getValue();
+
+            // 시간순으로 정렬, 첫 캔들이 시가, 마지막 캔들이 종가
+            candlesInBucket.sort(Comparator.comparing(OhlcvDto::candleTimestamp));
+
+            String stockCode = candlesInBucket.getFirst().stockCode();
+
+            // 롤업 계산: 시가는 처음, 종가는 마지막, 고/저가는 Max/Min, 거래량은 합산
+            Double openPrice = candlesInBucket.getFirst().openPrice();
+            Double closePrice = candlesInBucket.getLast().closePrice();
+
+            Double highPrice = candlesInBucket.stream()
+                    .mapToDouble(OhlcvDto::highPrice).max().orElse(openPrice);
+            Double lowPrice = candlesInBucket.stream()
+                    .mapToDouble(OhlcvDto::lowPrice).min().orElse(openPrice);
+
+            Long totalVolume = candlesInBucket.stream()
+                    .mapToLong(OhlcvDto::volume).sum();
+
+            // 압축된 캔들을 DTO로 새로 생성
+            OhlcvDto dto = new OhlcvDto(
+                    stockCode, bucketTime, openPrice, highPrice, lowPrice, closePrice, totalVolume
+            );
+
+            rolledUpCandles.add(dto);
+        }
+
+        // 최종 결과를 시간순으로 오름차순 정렬
+        rolledUpCandles.sort(Comparator.comparing(OhlcvDto::candleTimestamp));
+        return rolledUpCandles;
+
+    }
+
+    // 특정 시간이 어느 캔들 그룹에 속하는지 계산
+    private LocalDateTime calculateBucketTime(LocalDateTime timestamp, CandleType targetType) {
+        return switch (targetType) {
+            // 분봉 (예: 5분봉이면 9:03 -> 9:00 으로 내림)
+            // 1분봉: 분 단위만 맞추면 됨
+            case MIN_1 -> timestamp.truncatedTo(ChronoUnit.MINUTES); // timestamp를 분단위 까지 맞춤, 2026-03-28 15:30:45 -> 2026-03-28 15:30:00
+            // N분봉: 00분을 기준으로 N분에 해당하는 값을 나눈 후 곱한 뒤 N분봉 그룹핑
+            case MIN_3, MIN_5, MIN_15 -> {
+                int minute = timestamp.getMinute();
+                int bucketMinute = (minute / targetType.getWindowMinutes()) * targetType.getWindowMinutes();
+                yield timestamp.withMinute(bucketMinute).truncatedTo(ChronoUnit.MINUTES);
+            }
+
+            // 일봉: 시간, 분, 초를 모두 버리고 해당 날의 00:00:00으로 맞춤
+            case DAY_1 -> timestamp.truncatedTo(ChronoUnit.DAYS);
+
+            // N일봉: 기준일(1970년 1월 1일)로부터 며칠째인지 계산해서 그룹핑
+            case DAY_3, DAY_5 -> {
+                long epochDay = timestamp.toLocalDate().toEpochDay();
+                int daysWindow = targetType.getWindowMinutes() / 1440; // 3일봉(4320), 5일봉(7200)인지 계산
+                long bucketEpochDay = (epochDay / daysWindow) * daysWindow;
+                yield LocalDate.ofEpochDay(bucketEpochDay).atStartOfDay();
+            }
+
+            // 주봉: 그 주의 월요일 00:00:00으로 묶음
+            case WEEK_1 -> timestamp.with(DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS);
+
+            // 월봉: 그 달의 1일 00:00:00으로 묶음
+            case MONTH_1 -> timestamp.with(TemporalAdjusters.firstDayOfMonth()).truncatedTo(ChronoUnit.DAYS);
+
+            // 년봉: 그 해의 1월 1일 00:00:00으로 묶음
+            case YEAR_1 -> timestamp.with(TemporalAdjusters.firstDayOfYear()).truncatedTo(ChronoUnit.DAYS);
+        };
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/scheduler/CandleFlushScheduler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/scheduler/CandleFlushScheduler.java
@@ -1,11 +1,16 @@
 package com.assetmind.server_stock.stock.application.scheduler;
 
+import com.assetmind.server_stock.stock.application.CandleRollupService;
+import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import com.assetmind.server_stock.stock.domain.enums.CandleType;
 import com.assetmind.server_stock.stock.domain.repository.CandleRepository;
+import com.assetmind.server_stock.stock.domain.repository.Ohlcv1dRepository;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1mRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +27,15 @@ public class CandleFlushScheduler {
 
     // 1분봉 저장 어댑터
     private final Ohlcv1mRepository ohlcv1mRepository;
+
+    // 1일봉 저장 어댑터
+    private final Ohlcv1dRepository ohlcv1dRepository;
+
+    // 주식 종목 메타 데이터 Provider
+    private final StockMetadataProvider stockMetadataProvider;
+
+    // 1분봉, 1일봉을 롤업해주는 Service
+    private final CandleRollupService candleRollupService;
 
     private static final DateTimeFormatter MINUTE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
 
@@ -51,6 +65,24 @@ public class CandleFlushScheduler {
      */
     @Scheduled(cron = "30 00 16 * * MON-FRI")
     public void flushDailyCandles() {
-        // TODO: 1일봉 롤업 로직
+        LocalDate today = LocalDate.now();
+
+        // 서비스 중인 모든 종목 코드 조회
+        List<String> allStockCodes = stockMetadataProvider.getAllStockCodes();
+
+        List<OhlcvDto> allDailyCandles = new ArrayList<>();
+
+        // 종목 마다 돌면서 1분봉을 가져와 1일봉으로 롤업
+        for (String stockCode : allStockCodes) {
+            List<OhlcvDto> oneMinuteCandles = ohlcv1mRepository.findCandlesByDate(stockCode, today);
+
+            // 1분봉을 1일봉으로 압축
+            List<OhlcvDto> rolledUpDaily = candleRollupService.rollup(oneMinuteCandles, CandleType.DAY_1);
+
+            allDailyCandles.addAll(rolledUpDaily);
+        }
+
+        ohlcv1dRepository.saveAll(allDailyCandles);
+        log.info("[CandleFlushScheduler] 1일봉 캔들 {}개 DB(ohlcv_1d) 롤업 및 저장 완료", allDailyCandles.size());
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/scheduler/PartitionCreationScheduler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/scheduler/PartitionCreationScheduler.java
@@ -1,0 +1,40 @@
+package com.assetmind.server_stock.stock.application.scheduler;
+
+import com.assetmind.server_stock.stock.domain.repository.PartitionRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 실시간 체결 데이터(raw_tick) 파티션 테이블 생성을 자동화 하는 스케줄러
+ * 해당 날짜의 파티션 테이블이 존재하지 않으면 DB에서 "no partition of relation" 에러가 발생하는 것을 방지하기 위해
+ * 서버 실행 시 또는 자정 전에 필요한 날짜의 파티션 테이블을 미리 준비한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PartitionCreationScheduler {
+
+    private final PartitionRepository partitionRepository;
+
+    /**
+     * 스프링 컨텍스트가 모두 로드되고 서버의 준비가 끝난 후에
+     * DB 파티션 생성 쿼리를 실행
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void initPartitionsOnReady() {
+        partitionRepository.createTickPartitionTable(LocalDate.now());
+        partitionRepository.createTickPartitionTable(LocalDate.now().plusDays(1));
+    }
+
+    @Scheduled(cron = "0 0 23 * * *")
+    public void scheduleCreationNextDayPartition() {
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+        partitionRepository.createTickPartitionTable(tomorrow);
+    }
+
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/enums/CandleType.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/enums/CandleType.java
@@ -6,12 +6,24 @@ import lombok.Getter;
 
 @Getter
 public enum CandleType {
-    MIN_1("1m");
+    MIN_1("1m", 1), // 1분봉
+    MIN_3("3m", 3), // 3분봉
+    MIN_5("5m", 5), // 5분봉
+    MIN_15("15m", 15), // 15분봉
+    DAY_1("1d", 1440), // 1일봉
+    DAY_3("3d", 4320), // 3일봉
+    DAY_5("5d", 7200), // 5일봉
+
+    WEEK_1("1w", 0),  // 주봉
+    MONTH_1("1M", 0), // 월봉
+    YEAR_1("1y", 0); // 년봉
 
     private final String value;
+    private final int windowMinutes;
 
-    CandleType(String value) {
+    CandleType(String value, int windowMinutes) {
         this.value = value;
+        this.windowMinutes = windowMinutes;
     }
 
     public static CandleType from(String value) {

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/Ohlcv1dRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/Ohlcv1dRepository.java
@@ -1,0 +1,32 @@
+package com.assetmind.server_stock.stock.domain.repository;
+
+import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 실시간 체결 데이터의 1일봉 캔들 데이터를 저장하고 조회하기 위한 도메인 레포지토리 인터페이스
+ */
+public interface Ohlcv1dRepository {
+
+    /**
+     * 1일봉 여러종목 캔들 데이터들을 한번에 저장
+     * @param dtoList 1일봉 데이터가 담긴 여러 종목의 OhlcvDto
+     */
+    void saveAll(List<OhlcvDto> dtoList);
+
+    /**
+     * 완성된 1일봉 캔들 데이터를 저장
+     * @param ohlcvDto 1일봉 데이터가 담긴 Ohclv DTO
+     */
+    void save(OhlcvDto ohlcvDto);
+
+    /**
+     * DB에 저장되어있는 1일봉 캔들 데이터를 조회한다.
+     * 3일봉, 5일봉, 주봉, 월봉, 년봉 등등 롤업 계산에도 사용
+     * @param stockCode 종목 코드
+     * @param date 조회 날짜
+     */
+    Optional<OhlcvDto> findCandleByDay(String stockCode, LocalDate date);
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/PartitionRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/PartitionRepository.java
@@ -1,0 +1,18 @@
+package com.assetmind.server_stock.stock.domain.repository;
+
+import java.time.LocalDate;
+
+/**
+ * 실시간 틱 데이터(raw_tick) 저장을 위한 파티션 테이블을 관리하는 도메인 레포지토리 인터페이스.
+ * 특정 데이터베이스 기술(JPA, JDBC 등)에 종속되지 않도록 의존성을 역전(DIP)시키기 위해 사용
+ * 스케줄러(Application Layer)는 이 인터페이스만 바라보고 파티션 생성을 요청
+ */
+public interface PartitionRepository {
+    /**
+     * 특정 날짜의 틱 데이터를 저장할 파티션 테이블이 존재하지 않으면 생성
+     * (멱등성 보장: 이미 테이블이 존재할 경우 아무 작업도 수행하지 않음)
+     *
+     * @param targetDate 파티션 테이블을 생성할 대상 날짜
+     */
+    void createTickPartitionTable(LocalDate targetDate);
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jdbc/PartitionJdbcAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jdbc/PartitionJdbcAdapter.java
@@ -1,0 +1,46 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.jdbc;
+
+import com.assetmind.server_stock.stock.domain.repository.PartitionRepository;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * {@link PartitionRepository} 인터페이스를 Spring JDBC 기술로 구현한 어댑터.
+ * PostgreSQL의 고유 기능인 테이블 파티셔닝(Range Partition) DDL을 동적으로 실행하기 위해
+ * JPA(Hibernate) 대신 Native Query 전송에 유리한 JdbcTemplate을 사용
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class PartitionJdbcAdapter implements PartitionRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void createTickPartitionTable(LocalDate targetDate) {
+        // 파티션 테이블의 기간(Range) 설정
+        LocalDate nextDate = targetDate.plusDays(1);
+
+        // 파티션 테이블명 생성 (raw_tick_{yyyyMMdd}, 예: raw_tick_20260331)
+        String partitionSuffix = targetDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String tableName = "raw_tick_" + partitionSuffix;
+
+        // PostgreSQL 전용 파티션 생성 Native Query
+        String sql = String.format(
+                "CREATE TABLE IF NOT EXISTS %s PARTITION OF raw_tick "
+                        + "FOR VALUES FROM ('%s 00:00:00') TO ('%s 00:00:00')",
+                tableName, targetDate, nextDate
+        );
+
+        try {
+            jdbcTemplate.execute(sql);
+            log.info("[PartitionJdbcAdapter] 파티션 테이블 생성 완료: {}", tableName);
+        } catch (Exception e) {
+            log.error("[PartitionJdbcAdapter] 파티션 테이블 생성 중 오류 발생 {}", tableName, e);
+        }
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaAdapter.java
@@ -1,0 +1,73 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.jpa;
+
+import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
+import com.assetmind.server_stock.stock.domain.repository.Ohlcv1dRepository;
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1dJpaEntity;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+/**
+ * {@link Ohlcv1dRepository} 인터페이스를 JPA 기술로 구현한 어탭터 구현체
+ *
+ * 도메인 계층에서 전달받은 순수 DTO {@link OhlcvDto}를
+ * 영속성 객체 {@link com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1dJpaEntity}로 변환하여 DB에 저장
+ *
+ */
+@Repository
+@RequiredArgsConstructor
+public class Ohlcv1dJpaAdapter implements Ohlcv1dRepository {
+
+    private final Ohlcv1dJpaRepository ohlcv1dJpaRepository;
+
+    @Override
+    public void saveAll(List<OhlcvDto> dtoList) {
+        List<Ohlcv1dJpaEntity> entities = dtoList.stream()
+                .map(this::toEntity)
+                .toList();
+
+        ohlcv1dJpaRepository.saveAll(entities);
+    }
+
+    @Override
+    public void save(OhlcvDto ohlcvDto) {
+        ohlcv1dJpaRepository.save(toEntity(ohlcvDto));
+    }
+
+    @Override
+    public Optional<OhlcvDto> findCandleByDay(String stockCode, LocalDate date) {
+        // (00:00:00 ~ 다음날 00:00:00)로 변환
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.plusDays(1).atStartOfDay();
+
+        return ohlcv1dJpaRepository.findCandleByDay(stockCode, startOfDay, endOfDay)
+                .map(this::toDto);
+    }
+
+    private Ohlcv1dJpaEntity toEntity(OhlcvDto dto) {
+        return Ohlcv1dJpaEntity.builder()
+                .stockCode(dto.stockCode())
+                .candleTimestamp(dto.candleTimestamp())
+                .openPrice(dto.openPrice())
+                .highPrice(dto.highPrice())
+                .lowPrice(dto.lowPrice())
+                .closePrice(dto.closePrice())
+                .volume(dto.volume())
+                .build();
+    }
+
+    private OhlcvDto toDto(Ohlcv1dJpaEntity entity) {
+        return new OhlcvDto(
+                entity.getStockCode(),
+                entity.getCandleTimestamp(),
+                entity.getOpenPrice(),
+                entity.getHighPrice(),
+                entity.getLowPrice(),
+                entity.getClosePrice(),
+                entity.getVolume()
+        );
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaRepository.java
@@ -1,0 +1,22 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.jpa;
+
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1dJpaEntity;
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.keys.OhlcvId;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface Ohlcv1dJpaRepository extends JpaRepository<Ohlcv1dJpaEntity, OhlcvId> {
+
+    @Query("SELECT o FROM Ohlcv1dJpaEntity o"
+            + " WHERE o.stockCode = :stockCode"
+            + " AND o.candleTimestamp >= :startDay"
+            + " AND o.candleTimestamp < :endDay")
+    Optional<Ohlcv1dJpaEntity> findCandleByDay(
+            @Param("stockCode") String stockCode,
+            @Param("startDay") LocalDateTime startDay,
+            @Param("endDay") LocalDateTime endDay
+    );
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
@@ -2,8 +2,10 @@ package com.assetmind.server_stock.stock.infrastructure.persistence.jpa;
 
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1mRepository;
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1dJpaEntity;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1mJpaEntity;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -41,7 +43,26 @@ public class Ohlcv1mJpaAdapter implements Ohlcv1mRepository {
 
     @Override
     public List<OhlcvDto> findCandlesByDate(String stockCode, LocalDate date) {
-        // TODO: 1일봉 롤업 스케줄러 개발 시 구현 예정
-        return List.of();
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.plusDays(1).atStartOfDay();
+
+        List<Ohlcv1mJpaEntity> entities = ohlcv1mJpaRepository.findCandlesByTimeRange(
+                stockCode, startOfDay, endOfDay);
+
+        return entities.stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    private OhlcvDto toDto(Ohlcv1mJpaEntity entity) {
+        return new OhlcvDto(
+                entity.getStockCode(),
+                entity.getCandleTimestamp(),
+                entity.getOpenPrice(),
+                entity.getHighPrice(),
+                entity.getLowPrice(),
+                entity.getClosePrice(),
+                entity.getVolume()
+        );
     }
 }

--- a/apps/server-stock/src/main/resources/application.yml
+++ b/apps/server-stock/src/main/resources/application.yml
@@ -42,6 +42,10 @@ spring:
       database-platform: org.hibernate.dialect.PostgreSQLDialect
       defer-datasource-initialization: true
 
+logging:
+  file:
+    name: ./logs/error-tracking.log
+
 
 kis:
   token-expiration: 86400

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/CandleRollupServiceTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/CandleRollupServiceTest.java
@@ -1,0 +1,123 @@
+package com.assetmind.server_stock.stock.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
+import com.assetmind.server_stock.stock.domain.enums.CandleType;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class CandleRollupServiceTest {
+
+    private final CandleRollupService candleRollupService = new CandleRollupService();
+
+    @Test
+    @DisplayName("1분봉 3개를 5분봉 1개로 롤업한다.")
+    void given1mCandles_whenRollupTo5m_thenReturn5mCandles() {
+        // Given: 09:00, 09:01, 09:02 캔들 준비
+        List<OhlcvDto> sourceCandles = List.of(
+                new OhlcvDto("005930", LocalDateTime.of(2026, 3, 30, 9, 0), 1000.0, 1100.0, 900.0, 1050.0, 10L),
+                new OhlcvDto("005930", LocalDateTime.of(2026, 3, 30, 9, 1), 1050.0, 1200.0, 1000.0, 1150.0, 20L),
+                new OhlcvDto("005930", LocalDateTime.of(2026, 3, 30, 9, 2), 1150.0, 1150.0, 800.0, 850.0, 30L)
+        );
+
+        // When
+        List<OhlcvDto> result = candleRollupService.rollup(sourceCandles, CandleType.MIN_5);
+
+        // Then
+        assertThat(result).hasSize(1);
+        OhlcvDto rolledUp = result.getFirst();
+        assertThat(rolledUp.candleTimestamp()).isEqualTo(LocalDateTime.of(2026, 3, 30, 9, 0)); // 00분 바구니
+        assertThat(rolledUp.openPrice()).isEqualTo(1000.0);  // 첫 시가
+        assertThat(rolledUp.highPrice()).isEqualTo(1200.0);  // 최고가
+        assertThat(rolledUp.lowPrice()).isEqualTo(800.0);    // 최저가
+        assertThat(rolledUp.closePrice()).isEqualTo(850.0);  // 마지막 종가
+        assertThat(rolledUp.volume()).isEqualTo(60L);        // 5분간의 누적 거래량
+    }
+
+    @Test
+    @DisplayName("1일봉 2개를 주봉 1개로 월요일 기준에 맞춰 롤업한다.")
+    void given1dCandles_whenRollupTo1w_thenReturn1wCandles() {
+        // Given: 3월 25일(수), 3월 27일(금) 캔들 준비
+        List<OhlcvDto> sourceCandles = List.of(
+                new OhlcvDto("005930", LocalDateTime.of(2026, 3, 25, 0, 0), 100.0, 150.0, 90.0, 120.0, 1000L),
+                new OhlcvDto("005930", LocalDateTime.of(2026, 3, 27, 0, 0), 120.0, 200.0, 110.0, 180.0, 2000L)
+        );
+
+        // When
+        List<OhlcvDto> result = candleRollupService.rollup(sourceCandles, CandleType.WEEK_1);
+
+        // Then
+        assertThat(result).hasSize(1);
+        OhlcvDto rolledUp = result.getFirst();
+
+        // 2026년 3월 25일(수)가 속한 주의 월요일은 3월 23일
+        assertThat(rolledUp.candleTimestamp()).isEqualTo(LocalDateTime.of(2026, 3, 23, 0, 0));
+        assertThat(rolledUp.openPrice()).isEqualTo(100.0);
+        assertThat(rolledUp.closePrice()).isEqualTo(180.0);
+        assertThat(rolledUp.volume()).isEqualTo(3000L);
+    }
+
+    @Test
+    @DisplayName("1일봉 2개를 월봉 1개로 달력 기준에 맞춰 롤업한다.")
+    void given1dCandles_whenRollupTo1m_thenReturn1mCandles() {
+        // Given: 3월 5일, 3월 28일 캔들 준비
+        List<OhlcvDto> sourceCandles = List.of(
+                new OhlcvDto("005930", LocalDateTime.of(2026, 3, 5, 0, 0), 500.0, 520.0, 490.0, 510.0, 500L),
+                new OhlcvDto("005930", LocalDateTime.of(2026, 3, 28, 0, 0), 510.0, 600.0, 480.0, 580.0, 1500L)
+        );
+
+        // When
+        List<OhlcvDto> result = candleRollupService.rollup(sourceCandles, CandleType.MONTH_1);
+
+        // Then
+        assertThat(result).hasSize(1);
+        OhlcvDto rolledUp = result.getFirst();
+        // 해당 월의 1일로 맞춰져야 함
+        assertThat(rolledUp.candleTimestamp()).isEqualTo(LocalDateTime.of(2026, 3, 1, 0, 0));
+        assertThat(rolledUp.openPrice()).isEqualTo(500.0);
+        assertThat(rolledUp.highPrice()).isEqualTo(600.0);
+        assertThat(rolledUp.lowPrice()).isEqualTo(480.0);
+        assertThat(rolledUp.closePrice()).isEqualTo(580.0);
+        assertThat(rolledUp.volume()).isEqualTo(2000L);
+    }
+
+    @Test
+    @DisplayName("1일봉 2개를 년봉 1개로 해당 년도 1월 1일 기준에 맞춰 롤업한다.")
+    void given1dCandles_whenRollupTo1y_thenReturn1yCandles() {
+        // Given: 2026년 3월, 2026년 11월 캔들 준비
+        List<OhlcvDto> sourceCandles = List.of(
+                new OhlcvDto("005930", LocalDateTime.of(2026, 3, 15, 0, 0), 1000.0, 2000.0, 800.0, 1500.0, 10000L),
+                new OhlcvDto("005930", LocalDateTime.of(2026, 11, 20, 0, 0), 1500.0, 3000.0, 1400.0, 2800.0, 20000L)
+        );
+
+        // When
+        List<OhlcvDto> result = candleRollupService.rollup(sourceCandles, CandleType.YEAR_1);
+
+        // Then
+        assertThat(result).hasSize(1);
+        OhlcvDto rolledUp = result.getFirst();
+        // 해당 연도의 1월 1일로 맞춰져야 함
+        assertThat(rolledUp.candleTimestamp()).isEqualTo(LocalDateTime.of(2026, 1, 1, 0, 0));
+        assertThat(rolledUp.openPrice()).isEqualTo(1000.0);
+        assertThat(rolledUp.highPrice()).isEqualTo(3000.0);
+        assertThat(rolledUp.lowPrice()).isEqualTo(800.0);
+        assertThat(rolledUp.closePrice()).isEqualTo(2800.0);
+        assertThat(rolledUp.volume()).isEqualTo(30000L);
+    }
+
+    @Test
+    @DisplayName("빈 리스트가 들어오면 빈 리스트를 반환한다.")
+    void givenEmptyCandles_whenRollup_thenReturnEmptyList() {
+        // Given
+        List<OhlcvDto> emptyList = List.of();
+
+        // When
+        List<OhlcvDto> result = candleRollupService.rollup(emptyList, CandleType.MIN_5);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/scheduler/CandleFlushSchedulerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/scheduler/CandleFlushSchedulerTest.java
@@ -8,11 +8,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.assetmind.server_stock.stock.application.CandleRollupService;
+import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import com.assetmind.server_stock.stock.domain.enums.CandleType;
 import com.assetmind.server_stock.stock.domain.repository.CandleRepository;
+import com.assetmind.server_stock.stock.domain.repository.Ohlcv1dRepository;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1mRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +34,15 @@ class CandleFlushSchedulerTest {
 
     @Mock
     private Ohlcv1mRepository ohlcv1mRepository;
+
+    @Mock
+    private Ohlcv1dRepository ohlcv1dRepository;
+
+    @Mock
+    private StockMetadataProvider stockMetadataProvider;
+
+    @Mock
+    private CandleRollupService candleRollupService;
 
     @InjectMocks
     private CandleFlushScheduler candleFlushScheduler;
@@ -65,5 +79,54 @@ class CandleFlushSchedulerTest {
 
         // Then: 저장 로직(saveAll)이 호출되지 않는지 검증
         verify(ohlcv1mRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("1일봉 스케줄러 실행 시, 모든 종목의 1분봉을 1일봉으로 롤업하여 DB에 일괄 저장한다.")
+    void givenStockCodesAnd1mCandles_whenFlushDailyCandles_thenRollupAndSaveAll() {
+        // Given
+        LocalDate today = LocalDate.now();
+        List<String> stockCodes = List.of("005930", "000660"); // 삼성전자, SK하이닉스 2개 종목 세팅
+
+        when(stockMetadataProvider.getAllStockCodes()).thenReturn(stockCodes);
+
+        // 삼성전자 데이터 세팅
+        List<OhlcvDto> samsung1mCandles = List.of(new OhlcvDto("005930", LocalDateTime.now(), 1.0, 2.0, 0.5, 1.5, 100L));
+        List<OhlcvDto> samsung1dCandle = List.of(new OhlcvDto("005930", today.atStartOfDay(), 1.0, 2.0, 0.5, 1.5, 100L));
+
+        when(ohlcv1mRepository.findCandlesByDate("005930", today)).thenReturn(samsung1mCandles);
+        when(candleRollupService.rollup(samsung1mCandles, CandleType.DAY_1)).thenReturn(samsung1dCandle);
+
+        // SK하이닉스 데이터 세팅
+        List<OhlcvDto> hynix1mCandles = List.of(new OhlcvDto("000660", LocalDateTime.now(), 5.0, 6.0, 4.0, 5.5, 200L));
+        List<OhlcvDto> hynix1dCandle = List.of(new OhlcvDto("000660", today.atStartOfDay(), 5.0, 6.0, 4.0, 5.5, 200L));
+
+        when(ohlcv1mRepository.findCandlesByDate("000660", today)).thenReturn(hynix1mCandles);
+        when(candleRollupService.rollup(hynix1mCandles, CandleType.DAY_1)).thenReturn(hynix1dCandle);
+
+        // When
+        candleFlushScheduler.flushDailyCandles();
+
+        // Then: 2개 종목의 롤업 결과가 하나의 리스트로 합쳐져서 saveAll로 들어갔는지 검증
+        List<OhlcvDto> expectedSavedCandles = new ArrayList<>();
+        expectedSavedCandles.addAll(samsung1dCandle);
+        expectedSavedCandles.addAll(hynix1dCandle);
+
+        verify(ohlcv1dRepository, times(1)).saveAll(expectedSavedCandles);
+    }
+
+    @Test
+    @DisplayName("조회된 종목이 없으면 빈 리스트로 saveAll을 호출하며 에러 없이 종료된다.")
+    void givenNoStockCodes_whenFlushDailyCandles_thenSaveEmptyList() {
+        // Given
+        when(stockMetadataProvider.getAllStockCodes()).thenReturn(List.of());
+
+        // When
+        candleFlushScheduler.flushDailyCandles();
+
+        // Then
+        verify(ohlcv1mRepository, never()).findCandlesByDate(anyString(), any(LocalDate.class));
+        verify(candleRollupService, never()).rollup(any(), any());
+        verify(ohlcv1dRepository, times(1)).saveAll(List.of()); // 빈 리스트 저장 호출 확인
     }
 }

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/scheduler/PartitionCreationSchedulerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/scheduler/PartitionCreationSchedulerTest.java
@@ -1,0 +1,51 @@
+package com.assetmind.server_stock.stock.application.scheduler;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.assetmind.server_stock.stock.domain.repository.PartitionRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PartitionCreationSchedulerTest {
+
+    @Mock
+    private PartitionRepository partitionRepository;
+
+    @InjectMocks
+    private PartitionCreationScheduler partitionCreationScheduler;
+
+    @Test
+    @DisplayName("서버 기동 완료 시(ApplicationReady), 오늘과 내일의 파티션 생성을 각각 1번씩 호출한다.")
+    void givenApplicationReady_whenInitPartitions_thenCreatesTodayAndTomorrow() {
+        // Given
+        LocalDate today = LocalDate.now();
+        LocalDate tomorrow = today.plusDays(1);
+
+        // When
+        partitionCreationScheduler.initPartitionsOnReady();
+
+        // Then
+        verify(partitionRepository, times(1)).createTickPartitionTable(today);
+        verify(partitionRepository, times(1)).createTickPartitionTable(tomorrow);
+    }
+
+    @Test
+    @DisplayName("매일 밤 11시 정기 스케줄러 가동 시, 내일 날짜의 파티션 생성을 1번 호출한다.")
+    void givenScheduledTime_whenScheduleCreation_thenCreatesTomorrow() {
+        // Given
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+
+        // When
+        partitionCreationScheduler.scheduleCreationNextDayPartition();
+
+        // Then
+        verify(partitionRepository, times(1)).createTickPartitionTable(tomorrow);
+    }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/domain/enums/CandleTypeTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/domain/enums/CandleTypeTest.java
@@ -1,0 +1,56 @@
+package com.assetmind.server_stock.stock.domain.enums;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.assetmind.server_stock.stock.exception.InvalidStockParameterException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class CandleTypeTest {
+    @ParameterizedTest
+    @CsvSource({
+            "1m, MIN_1",
+            "3m, MIN_3",
+            "5m, MIN_5",
+            "15m, MIN_15",
+            "1d, DAY_1",
+            "1w, WEEK_1",
+            "1M, MONTH_1",
+            "1y, YEAR_1"
+    })
+    @DisplayName("올바른 파라미터 문자열이 들어오면 해당하는 CandleType Enum을 반환한다.")
+    void givenValidString_whenFrom_thenReturnCandleType(String input, CandleType expected) {
+        // When
+        CandleType actual = CandleType.from(input);
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 파라미터 문자열이 들어오면 예외를 발생시킨다.")
+    void givenInvalidString_whenFrom_thenThrowsException() {
+        // Given
+        String invalidInput = "10m"; // enum에 존재하지 않는 10분봉 요청
+        String weirdInput = "1900000000000000m";
+
+        // When & Then
+        assertThatThrownBy(() -> CandleType.from(invalidInput))
+                .isInstanceOf(InvalidStockParameterException.class)
+                .hasMessageContaining("지원하지 않는 캔들 타입입니다");
+
+        assertThatThrownBy(() -> CandleType.from(weirdInput))
+                .isInstanceOf(InvalidStockParameterException.class);
+    }
+
+    @Test
+    @DisplayName("null이 들어오면 예외를 발생시킨다.")
+    void givenNull_whenFrom_thenThrowsException() {
+        // When & Then
+        assertThatThrownBy(() -> CandleType.from(null))
+                .isInstanceOf(InvalidStockParameterException.class);
+    }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jdbc/PartitionJdbcAdapterTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jdbc/PartitionJdbcAdapterTest.java
@@ -1,0 +1,68 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class PartitionJdbcAdapterTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    private PartitionJdbcAdapter partitionJdbcAdapter;
+
+    @Test
+    @DisplayName("특정 날짜가 주어지면, 해당 날짜에 맞는 파티션 생성 DDL 쿼리를 정확히 생성하여 실행한다.")
+    void givenDate_whenCreateTickPartitionTable_thenExecutesCorrectSql() {
+        // Given: 2026년 3월 31일이라는 타겟 날짜 설정
+        LocalDate targetDate = LocalDate.of(2026, 3, 31);
+
+        // When: 어댑터 메서드 호출
+        partitionJdbcAdapter.createTickPartitionTable(targetDate);
+
+        // Then: JdbcTemplate의 execute() 메서드가 호출될 때 전달된 SQL 문자열을 낚아챔
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate, times(1)).execute(sqlCaptor.capture());
+
+        String executedSql = sqlCaptor.getValue();
+
+        // 생성된 쿼리가 의도한 DDL과 완벽히 일치하는지 검증
+        assertThat(executedSql).contains("CREATE TABLE IF NOT EXISTS raw_tick_20260331");
+        assertThat(executedSql).contains("PARTITION OF raw_tick");
+        assertThat(executedSql).contains("FOR VALUES FROM ('2026-03-31 00:00:00') TO ('2026-04-01 00:00:00')");
+    }
+
+    @Test
+    @DisplayName("DB 쿼리 실행 중 에러가 발생하더라도, 예외를 삼키고(catch) 스케줄러를 중단시키지 않는다.")
+    void givenDbException_whenCreateTickPartitionTable_thenCatchesExceptionAndDoesNotThrow() {
+        // Given: DB에 일시적인 장애가 발생했다고 가정
+        LocalDate targetDate = LocalDate.of(2026, 3, 31);
+
+        // jdbcTemplate이 어떤 SQL을 받든 무조건 DB 에러(DataAccessException)를 뱉도록 Mocking
+        doThrow(new org.springframework.dao.DataAccessResourceFailureException("임의의 DB 연결 실패 에러"))
+                .when(jdbcTemplate).execute(anyString());
+
+        // When & Then: 어댑터 메서드를 호출했을 때, 밖으로 에러가 터져 나오지 않는지 검증
+        assertDoesNotThrow(() -> {
+            partitionJdbcAdapter.createTickPartitionTable(targetDate);
+        });
+
+        // 실제로 execute()가 1번 호출되긴 했는지 검증 (예외가 발생했어도 시도는 했어야 함)
+        verify(jdbcTemplate, times(1)).execute(anyString());
+        }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaAdapterTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaAdapterTest.java
@@ -1,0 +1,104 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1dJpaEntity;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(Ohlcv1dJpaAdapter.class)
+@TestPropertySource(properties = "spring.sql.init.mode=never")
+class Ohlcv1dJpaAdapterTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    private Ohlcv1dJpaAdapter ohlcv1dJpaAdapter;
+
+    @Autowired
+    private Ohlcv1dJpaRepository ohlcv1dJpaRepository;
+
+    @Test
+    @DisplayName("OhlcvDto 리스트가 주어지면 JpaEntity로 변환하여 DB에 성공적으로 일괄 저장(saveAll)한다.")
+    void givenDtoList_whenSaveAll_thenSavedToDatabase() {
+        // Given
+        OhlcvDto dto1 = new OhlcvDto("005930", LocalDateTime.of(2026, 3, 30, 0, 0), 75000.0, 76000.0, 74000.0, 75500.0, 1000L);
+        OhlcvDto dto2 = new OhlcvDto("000660", LocalDateTime.of(2026, 3, 30, 0, 0), 150000.0, 151000.0, 149000.0, 150500.0, 500L);
+
+        // When
+        ohlcv1dJpaAdapter.saveAll(List.of(dto1, dto2));
+
+        // Then
+        List<Ohlcv1dJpaEntity> savedEntities = ohlcv1dJpaRepository.findAll();
+        assertThat(savedEntities).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("단건 OhlcvDto가 주어지면 JpaEntity로 변환하여 DB에 성공적으로 저장(save)한다.")
+    void givenSingleDto_whenSave_thenSavedToDatabase() {
+        // Given
+        OhlcvDto dto = new OhlcvDto("005930", LocalDateTime.of(2026, 3, 31, 0, 0), 100.0, 120.0, 90.0, 110.0, 5000L);
+
+        // When
+        ohlcv1dJpaAdapter.save(dto);
+
+        // Then
+        List<Ohlcv1dJpaEntity> savedEntities = ohlcv1dJpaRepository.findAll();
+        assertThat(savedEntities).hasSize(1);
+        assertThat(savedEntities.getFirst().getStockCode()).isEqualTo("005930");
+        assertThat(savedEntities.getFirst().getClosePrice()).isEqualTo(110.0);
+    }
+
+    @Test
+    @DisplayName("특정 날짜(LocalDate)로 조회 시, 해당 날짜의 1일봉 데이터를 Optional로 정확히 반환한다.")
+    void givenDate_whenFindCandleByDay_thenReturnOptionalCandle() {
+        // Given: 3월 30일 1일봉 데이터 DB 저장
+        String stockCode = "005930";
+        LocalDate targetDate = LocalDate.of(2026, 3, 30);
+
+        OhlcvDto savedDto = new OhlcvDto(stockCode, LocalDateTime.of(2026, 3, 30, 0, 0), 75000.0, 76000.0, 74000.0, 75500.0, 1000L);
+        ohlcv1dJpaAdapter.save(savedDto);
+
+        // When: 3월 30일 데이터 조회 요청
+        Optional<OhlcvDto> result = ohlcv1dJpaAdapter.findCandleByDay(stockCode, targetDate);
+
+        // Then: 데이터가 존재해야 하며, 저장한 값과 정확히 일치해야 함
+        assertThat(result).isPresent();
+        assertThat(result.get().candleTimestamp()).isEqualTo(LocalDateTime.of(2026, 3, 30, 0, 0));
+        assertThat(result.get().stockCode()).isEqualTo(stockCode);
+        assertThat(result.get().closePrice()).isEqualTo(75500.0);
+    }
+
+    @Test
+    @DisplayName("조회하려는 날짜에 데이터가 없으면 Optional.empty()를 반환한다.")
+    void givenDateWithNoData_whenFindCandleByDay_thenReturnEmptyOptional() {
+        // Given: DB는 텅 빈 상태
+        String stockCode = "005930";
+        LocalDate emptyDate = LocalDate.of(2026, 3, 31);
+
+        // When
+        Optional<OhlcvDto> result = ohlcv1dJpaAdapter.findCandleByDay(stockCode, emptyDate);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapterTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapterTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1mJpaEntity;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -64,5 +65,33 @@ class Ohlcv1mJpaAdapterTest {
 
         assertThat(savedSamsung.getClosePrice()).isEqualTo(75500.0);
         assertThat(savedSamsung.getVolume()).isEqualTo(1000L);
+    }
+
+    @Test
+    @DisplayName("특정 날짜를 주면 해당 날짜의 00:00:00 ~ 23:59:59 사이의 캔들만 정확히 조회한다.")
+    void givenSpecificDate_whenFindCandlesByDate_thenReturnOnlyThatDatesCandles() {
+        // Given: 어제, 오늘, 내일의 1분봉 데이터를 섞어서 준비
+        String stockCode = "005930";
+        LocalDate today = LocalDate.of(2026, 3, 30);
+
+        OhlcvDto yesterdayDto = new OhlcvDto(stockCode, LocalDateTime.of(2026, 3, 29, 23, 59), 100.0, 100.0, 100.0, 100.0, 10L);
+        OhlcvDto todayDto1 = new OhlcvDto(stockCode, LocalDateTime.of(2026, 3, 30, 9, 0), 200.0, 200.0, 200.0, 200.0, 20L);
+        OhlcvDto todayDto2 = new OhlcvDto(stockCode, LocalDateTime.of(2026, 3, 30, 15, 30), 300.0, 300.0, 300.0, 300.0, 30L);
+        OhlcvDto tomorrowDto = new OhlcvDto(stockCode, LocalDateTime.of(2026, 3, 31, 9, 0), 400.0, 400.0, 400.0, 400.0, 40L);
+
+        // 어댑터의 saveAll을 활용해 실제 PostgreSQL 컨테이너에 INSERT
+        ohlcv1mJpaAdapter.saveAll(List.of(yesterdayDto, todayDto1, todayDto2, tomorrowDto));
+
+        // When: 3월 30일 데이터만 달라고 조회
+        List<OhlcvDto> result = ohlcv1mJpaAdapter.findCandlesByDate(stockCode, today);
+
+        // Then: 29일, 31일 데이터는 제외되고 정확히 오늘 데이터 2개만 반환되어야 함
+        assertThat(result).hasSize(2);
+        assertThat(result)
+                .extracting(OhlcvDto::candleTimestamp)
+                .containsExactlyInAnyOrder(
+                        LocalDateTime.of(2026, 3, 30, 9, 0),
+                        LocalDateTime.of(2026, 3, 30, 15, 30)
+                );
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
- **실시간 1분봉 캔들 파이프라인 구축:** 초당 수백 건의 틱 데이터를 DB에 직접 꽂지 않고, Redis를 인메모리 버퍼로 활용하여 1분봉 단위로 압축 후 DB에 적재하는 파이프라인 완성
- **1일봉(Daily) 롤업 스케줄러 구축:** 매일 장 마감 후, DB에 적재된 당일 1분봉 데이터를 취합하여 1일봉으로 압축(Roll-up) 및 저장하는 배치 파이프라인 완성
- **대용량 틱 데이터(`raw_tick`)를 위한 PostgreSQL 파티셔닝 도입:** 대용량 체결 데이터의 조회 성능 극대화 및 유연한 데이터 삭제를 위해 일별 파티셔닝(Daily Range Partitioning) 적용
- **파티션 테이블 자동 생성 스케줄러 구축:** 파티션 부재 에러(`no partition of relation`)를 완벽히 방지하기 위해 매일 자정 전에 익일 파티션 테이블을 자동 생성하는 방어 로직 구현
- **Port & Adapter (Hexagonal) 패턴 적용:** 향후 DB 기술 변경 및 성능 최적화를 대비하여, 비즈니스 로직(스케줄러/서비스)과 영속성 기술(JPA/JDBC/Redis)을 완전히 분리

---

## 🏗 기술적 의사결정 및 설계 (Core Design)

### 1. 메모리 최적화 및 기본 캔들(1분/1일) 전략
- **문제:** 모든 타임프레임(3분, 5분, 주봉 등)의 캔들을 개별 배치로 만들어 DB에 저장하면 공간 낭비 및 관리 포인트 급증.
- **해결:** - Redis는 영구 저장소가 아닌 "1분 버퍼링(TTL)" 공간으로만 활용하여 메모리 누수 방지 (`CandleFlushScheduler`가 1분마다 DB로 이관).
  - DB에는 가장 기초가 되는 **1분봉**과 **1일봉**만 적재(`DailyRollupScheduler` 활용)하고, 프론트엔드에서 N분봉/주/월봉 요청 시 런타임에 동적으로 조합(Aggregation)하여 서빙하는 유연한 아키텍처 설계.

### 2. 무한 확장 틱 데이터를 위한 파티셔닝 전략 및 예외 방어
- **문제:** 수억 건의 데이터가 쌓이는 단일 테이블의 심각한 성능 저하 및 과거 데이터 삭제 시 DB Lock 발생. 야간 무중단 배포 시 스케줄러 누락 사각지대 존재.
- **해결:** `trade_timestamp` 기준 Range Partitioning 적용. `@Scheduled` 뿐만 아니라 `@EventListener(ApplicationReadyEvent.class)`를 도입하여 서버 기동 시 무조건 오늘/내일 파티션을 보장하도록 설계 (`IF NOT EXISTS` 및 Exception Catch로 멱등성 및 서버 안정성 확보).

### 3. 영속성 계층 완벽 격리 (Port & Adapter)
- **문제:** 파티션 DDL 처리를 위해 `JdbcTemplate` 사용이 불가피하나, 비즈니스 로직이 특정 DB 기술에 종속되는 문제.
- **해결:** 도메인 계층에 `PartitionRepository` 등의 순수 인터페이스(Port)를 두고, 인프라 계층에 `PartitionJdbcAdapter`, `Ohlcv1dJpaAdapter` 등을 구현하여 기술 종속성 완벽 격리.

---

## 🧪 테스트 및 검증 전략 (Testing Strategy)
- **모든 Core 컴포넌트 단위 테스트 커버:**
  - `CandleRollupService`, `CandleType`: 날짜 경계 및 비즈니스 로직 롤업 정확도 검증.
  - `PartitionCreationScheduler`, `CandleFlushScheduler`, `DailyRollupScheduler`: Mockito `verify()`를 통한 스케줄러 실행 시점 및 파라미터 멱등성 검증.
- **동시성(Concurrency) 100개 스레드 스트레스 테스트:**
  - `CandleRedisAdapter`에 `ExecutorService`를 활용해 100개의 스레드가 동시에 틱 데이터를 밀어 넣을 때 Race Condition 없이 데이터가 정확히 갱신됨을 증명.
- **Mockito ArgumentCaptor 및 방어 로직 검증:**
  - `PartitionJdbcAdapter` 내 동적 DDL SQL 생성 오타 검증 및 DB 에러 시 예외 억제(`assertDoesNotThrow`) 검증 완료.

---

## ✅ 주요 변경점
- **Domain & Application:**
  - `CandleType.java`: 캔들 타입 정의 Enum
  - `CandleRollupService.java`: 1분봉 -> 1일봉 압축 핵심 비즈니스 로직
  - `PartitionRepository.java`: 파티션 도메인 Port 인터페이스
  - `CandleFlushScheduler.java`: 1분봉 이관 배치 스케줄러
  - `DailyRollupScheduler.java`: 1일봉 롤업 배치 스케줄러
  - `PartitionCreationScheduler.java`: 파티션 자동 생성 스케줄러
- **Infrastructure (Adapters):**
  - `CandleRedisAdapter.java`: 틱 데이터 수집 및 Lua 연산 담당 Redis 어댑터
  - `Ohlcv1dJpaAdapter.java`: 1일봉 영속성 JPA 어댑터
  - `PartitionJdbcAdapter.java`: 파티셔닝 DDL 쿼리 전용 JDBC 어댑터
- **Test:**
  - 위 명시된 모든 클래스에 대한 단위/통합 테스트 코드 추가 완료

---

## 📝 리뷰 포인트
- **동적 조합 기반 아키텍처:** 1분봉/1일봉만을 DB 원천 데이터로 두고 나머지는 조회 시 조합한다는 전략에 대한 피드백을 부탁드립니다.
- **스케줄러 방어 로직:** 파티션 생성 시점을 23:00 정규 스케줄링 + 서버 기동 시점(`ApplicationReadyEvent`)으로 이중 방어했습니다. 설계 관점에서 부족한 엣지 케이스가 있을지 리뷰 부탁드립니다.