### PR TITLE
 [Fix] 주가 데이터 페이지 개선

### DIFF
--- a/apps/web/Design_UI/src/components/common/stock/AIPredictionPanel/AIPredictionPanel.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/AIPredictionPanel/AIPredictionPanel.tsx
@@ -211,46 +211,38 @@ export const AIPredictionPanel: React.FC<AIPredictionPanelProps> = ({
   if (viewport === "mobile") {
     return (
       <div style={{
-        width: "393px",
-        height: "852px",
-        backgroundColor: "#131316",
+        width: "345px",
+        height: "657px",
+        backgroundColor: "#1C1D21",
+        borderRadius: "12px",
+        padding: "24px",
         display: "flex",
         flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center", 
+        gap: "10px",
         boxSizing: "border-box",
+        overflowY: "auto",
+        flexShrink: 0,
       }}>
-        <div style={{
-          width: "345px",
-          height: "657px",
-          backgroundColor: "#1C1D21",
-          borderRadius: "12px",
-          padding: "24px",
-          display: "flex",
-          flexDirection: "column",
-          gap: "10px",
-          boxSizing: "border-box",
-          overflowY: "auto",
-          flexShrink: 0,
-        }}>
-          {/* 헤더 */}
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexShrink: 0 }}>
-            <span style={{ fontSize: "14px", fontWeight: 400, color: "#FFFFFF" }}>AI 가격 예측 패널</span>
-            <HeaderAction status={status} onBuyClick={onBuyClick} />
-          </div>
-          {/* 본문 - flexShrink 0으로 찌그러짐 방지 */}
-          <div style={{ display: "flex", flexDirection: "column", gap: "10px", flexShrink: 0 }}>
-            {status === "error" ? <PanelError onRetry={onRetry} /> : <PanelInner {...innerProps} />}
-          </div>
+        {/* 헤더 */}
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexShrink: 0 }}>
+          <span style={{ fontSize: "14px", fontWeight: 400, color: "#FFFFFF" }}>AI 가격 예측 패널</span>
+          <HeaderAction status={status} onBuyClick={onBuyClick} />
+        </div>
+        {/* 본문 */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "10px", flexShrink: 0 }}>
+          {status === "error" ? <PanelError onRetry={onRetry} /> : <PanelInner {...innerProps} />}
         </div>
       </div>
     );
   }
 
   // ── Desktop / Tablet: 340px ──
+  const panelWidth = viewport === "tablet" ? "347px" : "340px";
+
   return (
     <div style={{
-      width: "340px",
+      width: panelWidth,
+      height: "820px",
       maxHeight: "100vh",
       overflowY: "auto",
       backgroundColor: "#1C1D21",

--- a/apps/web/Design_UI/src/components/common/stock/OrderbookTable/OrderbookTable.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/OrderbookTable/OrderbookTable.tsx
@@ -67,20 +67,107 @@ const SkeletonBox: React.FC<{
   />
 );
 
-const OrderbookSkeleton: React.FC = () => (
-  <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
-    <div style={{ display: "flex", gap: "4px" }}>
-      <div style={{ display: "flex", flexDirection: "column", gap: "4px", width: "100px" }}>
-        {Array.from({ length: 12 }).map((_, i) => <SkeletonBox key={i} width={100} height={28} borderRadius={4} />)}
-      </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: "4px", flex: 1 }}>
-        <SkeletonBox height={28} borderRadius={4} />
-        {Array.from({ length: 11 }).map((_, i) => <SkeletonBox key={i} height={28} borderRadius={4} />)}
-      </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: "4px", width: "100px" }}>
-        {Array.from({ length: 12 }).map((_, i) => <SkeletonBox key={i} width={100} height={28} borderRadius={4} />)}
-      </div>
+// 우측 시세 정보 전용 스켈레톤
+const SkeletonMarketInfo = () => {
+  const D = <div style={{ height: "1px", background: "rgba(255,255,255,0.08)", margin: "6px 0" }} />;
+  const R = ({ label }: { label: string }) => (
+    <div style={{ display: "flex", justifyContent: "space-between", gap: "6px" }}>
+      <span style={{ fontSize: "11px", fontWeight: 400, color: "#9F9F9F", whiteSpace: "nowrap" }}>{label}</span>
+      <span style={{ fontSize: "11px", fontWeight: 400, color: "#9F9F9F", whiteSpace: "nowrap" }}>-</span>
     </div>
+  );
+  return (
+    <div style={{ width: "110px", display: "flex", flexDirection: "column" }}>
+      <R label="- 주 최고" />
+      <R label="- 주 최저" />
+      {D}
+      <R label="상한가" />
+      <R label="하한가" />
+      <R label="상승VI" />
+      <R label="하강VI" />
+      {D}
+      <R label="시작" />
+      <R label="최고" />
+      <R label="최저" />
+      {D}
+      <div style={{ fontSize: "11px", color: "#9F9F9F", whiteSpace: "nowrap" }}>거래량</div>
+      <div style={{ fontSize: "11px", color: "#9F9F9F", whiteSpace: "nowrap" }}>-</div>
+      <R label="어제보다" />
+      {D}
+      <R label="중간호가" />
+    </div>
+  );
+};
+
+// 데스크톱 & 태블릿 스켈레톤
+const DesktopOrderbookSkeleton: React.FC = () => (
+  <div style={{ display: "flex", position: "relative" }}>
+    {/* 좌측: 매도 잔량 및 체결 내역 */}
+    <div style={{ display: "flex", flexDirection: "column", width: "100px" }}>
+      <div style={{ height: "32px" }} />
+      {Array.from({ length: 10 }).map((_, i) => (
+        <div key={`ask-qty-${i}`} style={{ height: "32px", display: "flex", alignItems: "center", justifyContent: "flex-end", paddingRight: "8px" }}>
+          <SkeletonBox width={76} height={20} borderRadius={6} />
+        </div>
+      ))}
+      <div style={{ height: "32px", display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0 8px" }}>
+        <span style={{ fontSize: "12px", color: "#FFFFFF", fontWeight: 400 }}>체결강도</span>
+        <SkeletonBox width={32} height={18} borderRadius={9} />
+      </div>
+      {Array.from({ length: 14 }).map((_, i) => (
+        <div key={`trade-${i}`} style={{ height: "32px", display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0 8px" }}>
+          <span style={{ fontSize: "13px", color: "#FFFFFF", fontWeight: 400 }}>-</span>
+          <span style={{ fontSize: "13px", color: "#FFFFFF", fontWeight: 400 }}>-</span>
+        </div>
+      ))}
+    </div>
+
+    {/* 중앙: 호가 가격 */}
+    <div style={{ display: "flex", flexDirection: "column", flex: 1, alignItems: "center" }}>
+      {Array.from({ length: 21 }).map((_, i) => (
+        <div key={`price-${i}`} style={{ height: "32px", display: "flex", alignItems: "center", justifyContent: "center", width: "100%" }}>
+          <SkeletonBox width={76} height={20} borderRadius={6} />
+        </div>
+      ))}
+    </div>
+
+    {/* 우측: 시세 정보 및 매수 잔량 */}
+    <div style={{ display: "flex", flexDirection: "column", width: "110px" }}>
+      <div style={{ height: "32px" }} />
+      <SkeletonMarketInfo />
+      <div style={{ height: "50px" }} />
+      {Array.from({ length: 10 }).map((_, i) => (
+        <div key={`bid-qty-${i}`} style={{ height: "32px", display: "flex", alignItems: "center", justifyContent: "flex-start", paddingLeft: "8px" }}>
+          <SkeletonBox width={76} height={20} borderRadius={6} />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+// 모바일 스켈레톤
+const MobileOrderbookSkeleton: React.FC = () => (
+  <div style={{ display: "flex", flexDirection: "column" }}>
+    <div style={{ display: "flex", alignItems: "center", height: "32px" }}>
+      <div style={{ flex: 1 }} />
+      <div style={{ width: "110px", display: "flex", justifyContent: "center" }}>
+        <SkeletonBox width={76} height={20} borderRadius={6} />
+      </div>
+      <div style={{ flex: 1 }} />
+    </div>
+    {Array.from({ length: 10 }).map((_, i) => (
+      <div key={`mob-skel-${i}`} style={{ display: "flex", alignItems: "center", height: "32px", width: "100%" }}>
+        <div style={{ flex: 1, display: "flex", justifyContent: "flex-end", paddingRight: "8px" }}>
+          <SkeletonBox width="80%" height={20} borderRadius={6} />
+        </div>
+        <div style={{ width: "110px", display: "flex", justifyContent: "center" }}>
+          <SkeletonBox width={76} height={20} borderRadius={6} />
+        </div>
+        <div style={{ flex: 1, display: "flex", justifyContent: "flex-start", paddingLeft: "8px" }}>
+          <SkeletonBox width="80%" height={20} borderRadius={6} />
+        </div>
+      </div>
+    ))}
   </div>
 );
 
@@ -323,7 +410,7 @@ export const OrderbookTable = ({
       className={cn(className)}
       style={{
         width: isMobile ? "345px" : "340px",
-        height: isMobile ? "454px" : undefined, 
+        height: isMobile ? "454px" : "820px", 
         backgroundColor: "#1C1D21",
         borderRadius: "12px",
         padding: "16px",
@@ -343,8 +430,10 @@ export const OrderbookTable = ({
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", position: "relative" }}>
         <span style={{ fontSize: "14px", fontWeight: 400, color: "#FFFFFF" }}>호가</span>
         {status === "empty" && <GlobalEmptyState variant="market-closed" display="badge" />}
-        {status === "default" && !isMobile && <QuickOrderButton onClick={onQuickOrder} />}
-        {status === "default" && isMobile && (
+        
+        {/* 스켈레톤 상태일 때도 버튼이 보이도록 변경 */}
+        {(status === "default" || status === "skeleton") && !isMobile && <QuickOrderButton onClick={onQuickOrder} />}
+        {(status === "default" || status === "skeleton") && isMobile && (
           <button
             onClick={onQuickOrder}
             style={{ display: "inline-flex", alignItems: "center", gap: "4px", padding: "4px 12px", backgroundColor: "transparent", border: "1px solid rgba(255,255,255,0.2)", borderRadius: "6px", cursor: "pointer", fontSize: "12px", fontWeight: 400, color: "#9F9F9F" }}
@@ -355,7 +444,7 @@ export const OrderbookTable = ({
       </div>
 
       {/* 상태별 본문 */}
-      {status === "skeleton" && <OrderbookSkeleton />}
+      {status === "skeleton" && (isMobile ? <MobileOrderbookSkeleton /> : <DesktopOrderbookSkeleton />)}
       {status === "error" && <OrderbookError onRetry={onRetry} />}
 
       {(status === "default" || status === "empty") && marketInfo && (

--- a/apps/web/Design_UI/src/components/common/stock/StockDataPage/StockDataPage.stories.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDataPage/StockDataPage.stories.tsx
@@ -46,16 +46,16 @@ const meta: Meta<typeof StockDataPage> = {
     docs: {
       description: {
         component:
-          "주가 데이터 페이지 통합 Story. `pageState` prop으로 7가지 상태(default·skeleton·realtime·error·empty·market-closed·extreme)를 전환하며 확인할 수 있습니다. `viewport` prop으로 desktop(1200px)·tablet(768px)·mobile(393px) 레이아웃을 전환합니다.",
+          "주가 데이터 페이지 통합 Story. `pageState` prop으로 7가지 상태(default·skeleton·realtime·error·empty·extreme)를 전환하며 확인할 수 있습니다. `viewport` prop으로 desktop(1200px)·tablet(768px)·mobile(393px) 레이아웃을 전환합니다.",
       },
     },
   },
   argTypes: {
     pageState: {
       control: "radio",
-      options: ["default", "skeleton", "realtime", "error", "empty", "market-closed", "extreme"],
+      options: ["default", "skeleton", "realtime", "error", "empty", "extreme"],
       description:
-        "default: 정상 데이터 | skeleton: 로딩 중 | realtime: 실시간 갱신 | error: API 실패 | empty: 조회 결과 없음 | market-closed: 시장 휴장 | extreme: 극단값(99:1)",
+        "default: 정상 데이터 | skeleton: 로딩 중 | realtime: 실시간 갱신 | error: API 실패 | empty: 조회 결과 없음 | extreme: 극단값(99:1)",
     },
     viewport: {
       control: "radio",
@@ -149,20 +149,6 @@ export const Empty: Story = {
     docs: {
       description: {
         story: "필터 조건에 맞는 종목이 없을 때 표시됩니다. GlobalEmptyState variant='no-data'를 사용합니다.",
-      },
-    },
-  },
-  decorators: [desktopDecorator],
-};
-
-/** 시장 휴장 */
-export const MarketClosed: Story = {
-  name: "Market Closed",
-  args: { ...DEFAULT_ARGS, pageState: "market-closed", viewport: "desktop" },
-  parameters: {
-    docs: {
-      description: {
-        story: "시장 휴장 시간에 표시됩니다. GlobalEmptyState variant='market-closed'를 사용합니다.",
       },
     },
   },

--- a/apps/web/Design_UI/src/components/common/stock/StockDataPage/StockDataPage.stories.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDataPage/StockDataPage.stories.tsx
@@ -4,9 +4,11 @@ import { StockTable } from "../StockTable/StockTable";
 import { TickerAnimation } from "../TickerAnimation/TickerAnimation";
 import { LocalError } from "../../../common/LocalError/LocalError";
 import { GlobalEmptyState } from "../../../common/GlobalEmptyState/GlobalEmptyState";
+import { Skeleton } from "../../../common/Skeleton/Skeleton";
 import { LinearGauge } from "../LinearGauge/LinearGauge";
 import { Tab } from "../../../common/Tab/Tab";
 import type { StockRow } from "../StockTable/StockTable";
+import type { Viewport } from "../StockTable/StockTable";
 
 // ─── Mock Data ────────────────────────────────────────────────
 
@@ -29,15 +31,23 @@ const EXTREME_ROWS: StockRow[] = [
   { id: "e3", rank: 3, isFavorite: false, name: "보합 (50:50)",     price: 10000, changeRate: 0,     tradeAmount: 500000, buyRatio: 50 },
 ];
 
-// ─── Page State Types ─────────────────────────────────────────
+// ─── Types ────────────────────────────────────────────────────
 
-type PageState = "data" | "realtime" | "error" | "empty" | "market-closed" | "extreme";
+type PageState =
+  | "default"       // 정상 데이터
+  | "skeleton"      // 로딩 (Skeleton 애니메이션)
+  | "realtime"      // 실시간 가격 갱신
+  | "error"         // API 실패
+  | "empty"         // 조회 결과 없음
+  | "market-closed" // 시장 휴장
+  | "extreme";      // 극단값 (99:1, 1:99)
 
 interface StockDataPageProps {
   pageState?: PageState;
+  viewport?: Viewport;
 }
 
-// ─── Page Component ───────────────────────────────────────────
+// ─── Filter Tab Items ─────────────────────────────────────────
 
 const MARKET_FILTER_ITEMS = [
   { label: "전체", value: "all" },
@@ -47,14 +57,29 @@ const MARKET_FILTER_ITEMS = [
 
 const SORT_FILTER_ITEMS = [
   { label: "증권 거래대금", value: "amount" },
-  { label: "증권 거래량", value: "volume" },
-  { label: "거래대금", value: "trade-amount" },
-  { label: "거래량", value: "trade-volume" },
+  { label: "증권 거래량",   value: "volume" },
+  { label: "거래대금",      value: "trade-amount" },
+  { label: "거래량",        value: "trade-volume" },
 ];
 
-const StockDataPage = ({ pageState = "data" }: StockDataPageProps) => {
-  const [rows, setRows] = useState<StockRow[]>(MOCK_ROWS);
+// ─── Page Container Width per Viewport ───────────────────────
 
+const VIEWPORT_WIDTH: Record<Viewport, string> = {
+  desktop: "1200px",
+  tablet:  "768px",
+  mobile:  "393px",
+};
+
+// ─── StockDataPage Component ──────────────────────────────────
+
+const StockDataPage = ({
+  pageState = "default",
+  viewport = "desktop",
+}: StockDataPageProps) => {
+  const [rows, setRows] = useState<StockRow[]>(MOCK_ROWS);
+  const containerWidth = VIEWPORT_WIDTH[viewport];
+
+  // 실시간 갱신 — realtime 상태에서만 활성화
   useEffect(() => {
     if (pageState !== "realtime") return;
     const timers = MOCK_ROWS.map((row) => {
@@ -72,46 +97,84 @@ const StockDataPage = ({ pageState = "data" }: StockDataPageProps) => {
     return () => timers.forEach(clearInterval);
   }, [pageState]);
 
-  const isContentState = pageState === "data" || pageState === "realtime" || pageState === "extreme";
+  // 콘텐츠 상태 여부 (테이블 렌더링)
+  const isTableState =
+    pageState === "default" ||
+    pageState === "realtime" ||
+    pageState === "extreme";
 
   return (
-    <div style={{ width: "1200px", backgroundColor: "#131316", minHeight: "800px", display: "flex", flexDirection: "column" }}>
-      {/* 탭 필터 영역 */}
-      <div style={{ padding: "16px", display: "flex", gap: "12px", flexWrap: "wrap" }}>
+    <div
+      style={{
+        width: containerWidth,
+        backgroundColor: "#131316",
+        minHeight: "800px",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* ── 필터 탭 영역 ── */}
+      <div
+        style={{
+          padding: "16px",
+          display: "flex",
+          gap: "12px",
+          flexWrap: "wrap",
+        }}
+      >
         <Tab items={MARKET_FILTER_ITEMS} defaultValue="all" />
-        <Tab items={SORT_FILTER_ITEMS} defaultValue="amount" />
+        {/* 태블릿/모바일에서는 정렬 필터 숨김 (공간 부족) */}
+        {viewport === "desktop" && (
+          <Tab items={SORT_FILTER_ITEMS} defaultValue="amount" />
+        )}
       </div>
 
-      {/* 콘텐츠 영역 — 에러/빈 상태일 때 수직 중앙 */}
+      {/* ── 콘텐츠 영역 ── */}
       <div
         style={{
           flex: 1,
           display: "flex",
           flexDirection: "column",
-          justifyContent: isContentState ? "flex-start" : "center",
-          alignItems: isContentState ? "flex-start" : "center",
+          justifyContent: isTableState ? "flex-start" : "center",
+          alignItems: isTableState ? "flex-start" : "center",
         }}
       >
+        {/* Skeleton — 초기 로딩 */}
+        {pageState === "skeleton" && (
+          <Skeleton variant="table-row" rows={10} />
+        )}
+
+        {/* Error — API 실패 */}
         {pageState === "error" && (
           <LocalError
             message="데이터를 불러오는 데 실패했습니다."
             onRetry={() => alert("다시 시도")}
           />
         )}
+
+        {/* Empty — 조회 결과 없음 */}
         {pageState === "empty" && (
           <GlobalEmptyState variant="no-data" display="inline" />
         )}
+
+        {/* Market Closed — 시장 휴장 */}
         {pageState === "market-closed" && (
           <GlobalEmptyState variant="market-closed" display="inline" />
         )}
+
+        {/* Extreme — 극단값 검증 */}
         {pageState === "extreme" && (
-          <StockTable rows={EXTREME_ROWS} />
+          <StockTable rows={EXTREME_ROWS} viewport={viewport} />
         )}
-        {pageState === "data" && (
-          <StockTable rows={rows} />
+
+        {/* Default — 정상 데이터 */}
+        {pageState === "default" && (
+          <StockTable rows={rows} viewport={viewport} />
         )}
+
+        {/* Realtime — 실시간 가격 갱신 */}
         {pageState === "realtime" && (
-          <div style={{ width: "1200px" }}>
+          <div style={{ width: containerWidth }}>
             {rows.map((row) => (
               <TickerAnimation key={row.id} row={row} />
             ))}
@@ -136,16 +199,22 @@ const meta: Meta<typeof StockDataPage> = {
     layout: "fullscreen",
     docs: {
       description: {
-        component: "주가 데이터 페이지의 전체 상태를 Controls로 전환하며 확인할 수 있는 통합 Story입니다.",
+        component:
+          "주가 데이터 페이지 통합 Story. `pageState` prop으로 7가지 상태(default·skeleton·realtime·error·empty·market-closed·extreme)를 전환하며 확인할 수 있습니다. `viewport` prop으로 desktop(1200px)·tablet(768px)·mobile(393px) 레이아웃을 전환합니다.",
       },
     },
   },
   argTypes: {
     pageState: {
       control: "radio",
-      options: ["data", "realtime", "error", "empty", "market-closed", "extreme"],
+      options: ["default", "skeleton", "realtime", "error", "empty", "market-closed", "extreme"],
       description:
-        "data: 정상 데이터 | realtime: 실시간 갱신 | error: API 실패 | empty: 조회 결과 없음 | market-closed: 시장 휴장 | extreme: 극단값(99:1)",
+        "default: 정상 데이터 | skeleton: 로딩 중 | realtime: 실시간 갱신 | error: API 실패 | empty: 조회 결과 없음 | market-closed: 시장 휴장 | extreme: 극단값(99:1)",
+    },
+    viewport: {
+      control: "radio",
+      options: ["desktop", "tablet", "mobile"],
+      description: "desktop: 1200px | tablet: 768px | mobile: 393px",
     },
   },
 };
@@ -153,84 +222,207 @@ const meta: Meta<typeof StockDataPage> = {
 export default meta;
 type Story = StoryObj<typeof StockDataPage>;
 
-// ─── Integrated Controls ──────────────────────────────────────
+// ─── 공통 데코레이터 ──────────────────────────────────────────
 
-export const IntegratedControls: Story = {
-  name: "Integrated — Page State Controls",
-  args: { pageState: "data" },
-  decorators: [
-    (Story) => (
-      <div style={{ minWidth: "1200px" }}>
-        <Story />
-      </div>
-    ),
-  ],
+const desktopDecorator = (Story: React.ComponentType) => (
+  <div style={{ minWidth: "1200px" }}>
+    <Story />
+  </div>
+);
+
+const tabletDecorator = (Story: React.ComponentType) => (
+  <div style={{ width: "768px" }}>
+    <Story />
+  </div>
+);
+
+const mobileDecorator = (Story: React.ComponentType) => (
+  <div style={{ width: "393px" }}>
+    <Story />
+  </div>
+);
+
+// ════════════════════════════════════════════════════════════════
+// Desktop Stories
+// ════════════════════════════════════════════════════════════════
+
+/** 정상 데이터 — 기본 상태 */
+export const Default: Story = {
+  name: "Default",
+  args: { pageState: "default", viewport: "desktop" },
+  decorators: [desktopDecorator],
 };
 
-export const ExtremeValueCheck: Story = {
-  name: "Criteria 1 — Extreme Value Rendering",
-  args: { pageState: "extreme" },
+/** 로딩 — Skeleton 애니메이션 */
+export const Loading: Story = {
+  name: "Loading (Skeleton)",
+  args: { pageState: "skeleton", viewport: "desktop" },
   parameters: {
     docs: {
       description: {
-        story: "극단적인 비율(99:1, 1:99)에서 UI 오류 없이 LinearGauge의 최소 너비 4px 규칙이 올바르게 적용되는지 확인합니다.",
+        story: "데이터 로딩 중 상태. Skeleton variant='table-row' 10행으로 표시됩니다. 400ms 딜레이 후 pulse 애니메이션이 시작됩니다.",
       },
     },
   },
-  decorators: [
-    (Story) => (
-      <div style={{ minWidth: "1200px" }}>
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [desktopDecorator],
 };
 
-export const ErrorStateCheck: Story = {
-  name: "Criteria 2 — Local Error + Retry Action",
-  args: { pageState: "error" },
+/** 실시간 갱신 — TickerAnimation */
+export const Realtime: Story = {
+  name: "Realtime — Dynamic Price Updates",
+  args: { pageState: "realtime", viewport: "desktop" },
   parameters: {
     docs: {
       description: {
-        story: "API 오류 발생 시 LocalError가 표시되는지, 그리고 onRetry 콜백이 제대로 연결되는지 확인합니다.",
+        story: "각 종목마다 1.5~4.5초 랜덤 주기로 가격이 갱신됩니다. 상승 시 붉은색, 하락 시 파란색 배경 깜빡임이 적용됩니다.",
       },
     },
   },
-  decorators: [
-    (Story) => (
-      <div style={{ minWidth: "1200px" }}>
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [desktopDecorator],
 };
 
-export const EmptyStateCheck: Story = {
-  name: "Criteria 2 — Empty State (No Results)",
-  args: { pageState: "empty" },
-  decorators: [
-    (Story) => (
-      <div style={{ minWidth: "1200px" }}>
-        <Story />
-      </div>
-    ),
-  ],
+/** API 오류 — LocalError */
+export const Error: Story = {
+  name: "Error",
+  args: { pageState: "error", viewport: "desktop" },
+  parameters: {
+    docs: {
+      description: {
+        story: "API 호출 실패 시 LocalError 컴포넌트가 페이지 중앙에 표시됩니다. '다시 시도' 버튼으로 재요청을 트리거합니다.",
+      },
+    },
+  },
+  decorators: [desktopDecorator],
 };
 
-export const MarketClosedCheck: Story = {
-  name: "Criteria 2 — Empty State (Market Closed)",
-  args: { pageState: "market-closed" },
-  decorators: [
-    (Story) => (
-      <div style={{ minWidth: "1200px" }}>
-        <Story />
-      </div>
-    ),
-  ],
+/** 빈 데이터 — 조회 결과 없음 */
+export const Empty: Story = {
+  name: "Empty",
+  args: { pageState: "empty", viewport: "desktop" },
+  parameters: {
+    docs: {
+      description: {
+        story: "필터 조건에 맞는 종목이 없을 때 표시됩니다. GlobalEmptyState variant='no-data'를 사용합니다.",
+      },
+    },
+  },
+  decorators: [desktopDecorator],
 };
 
+/** 시장 휴장 */
+export const MarketClosed: Story = {
+  name: "Market Closed",
+  args: { pageState: "market-closed", viewport: "desktop" },
+  parameters: {
+    docs: {
+      description: {
+        story: "시장 휴장 시간에 표시됩니다. GlobalEmptyState variant='market-closed'를 사용합니다.",
+      },
+    },
+  },
+  decorators: [desktopDecorator],
+};
+
+/** 극단값 검증 — LinearGauge min-width 4px */
+export const ExtremeValues: Story = {
+  name: "Extreme Values (99:1)",
+  args: { pageState: "extreme", viewport: "desktop" },
+  parameters: {
+    docs: {
+      description: {
+        story: "극단적 비율(99:1, 1:99)에서 LinearGauge의 최소 너비 4px 규칙이 올바르게 적용되는지 검증합니다.",
+      },
+    },
+  },
+  decorators: [desktopDecorator],
+};
+
+// ════════════════════════════════════════════════════════════════
+// Tablet Stories
+// ════════════════════════════════════════════════════════════════
+
+/** 태블릿 — 정상 데이터 */
+export const TabletDefault: Story = {
+  name: "Tablet / Default",
+  args: { pageState: "default", viewport: "tablet" },
+  parameters: { viewport: { defaultViewport: "tablet" } },
+  decorators: [tabletDecorator],
+};
+
+/** 태블릿 — 로딩 */
+export const TabletLoading: Story = {
+  name: "Tablet / Loading",
+  args: { pageState: "skeleton", viewport: "tablet" },
+  parameters: { viewport: { defaultViewport: "tablet" } },
+  decorators: [tabletDecorator],
+};
+
+/** 태블릿 — 오류 */
+export const TabletError: Story = {
+  name: "Tablet / Error",
+  args: { pageState: "error", viewport: "tablet" },
+  parameters: { viewport: { defaultViewport: "tablet" } },
+  decorators: [tabletDecorator],
+};
+
+/** 태블릿 — 빈 데이터 */
+export const TabletEmpty: Story = {
+  name: "Tablet / Empty",
+  args: { pageState: "empty", viewport: "tablet" },
+  parameters: { viewport: { defaultViewport: "tablet" } },
+  decorators: [tabletDecorator],
+};
+
+// ════════════════════════════════════════════════════════════════
+// Mobile Stories
+// ════════════════════════════════════════════════════════════════
+
+/** 모바일 — 정상 데이터 */
+export const MobileDefault: Story = {
+  name: "Mobile / Default",
+  args: { pageState: "default", viewport: "mobile" },
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  decorators: [mobileDecorator],
+};
+
+/** 모바일 — 로딩 */
+export const MobileLoading: Story = {
+  name: "Mobile / Loading",
+  args: { pageState: "skeleton", viewport: "mobile" },
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  decorators: [mobileDecorator],
+};
+
+/** 모바일 — 오류 */
+export const MobileError: Story = {
+  name: "Mobile / Error",
+  args: { pageState: "error", viewport: "mobile" },
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  decorators: [mobileDecorator],
+};
+
+/** 모바일 — 빈 데이터 */
+export const MobileEmpty: Story = {
+  name: "Mobile / Empty",
+  args: { pageState: "empty", viewport: "mobile" },
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  decorators: [mobileDecorator],
+};
+
+// ════════════════════════════════════════════════════════════════
+// QA / Validation Stories (기존 유지)
+// ════════════════════════════════════════════════════════════════
+
+/** Controls로 모든 상태·뷰포트 자유 조작 */
+export const Playground: Story = {
+  name: "Playground",
+  args: { pageState: "default", viewport: "desktop" },
+  decorators: [desktopDecorator],
+};
+
+/** 색상 명도 대비 검증 */
 export const ContrastCheck: Story = {
-  name: "Criteria 3 — Color Contrast Check",
+  name: "QA — Color Contrast Check",
   parameters: {
     docs: {
       description: {
@@ -241,23 +433,20 @@ WCAG AA (4.5:1) color contrast verification:
 |---|---|---|---|
 | Text (primary) | #FFFFFF | #131316 | ✅ Pass |
 | Text (secondary) | #9194A1 | #131316 | ✅ Pass |
-| Text (disabled) | #9F9F9F | #131316 | ✅ Pass |
 | Price change (rise) | #EA580C | #131316 | ✅ Pass |
 | Price change (fall) | #256AF4 | #131316 | ✅ Pass |
 | LinearGauge label (rise) | #EA580C | #131316 | ✅ Pass |
 | LinearGauge label (fall) | #256AF4 | #131316 | ✅ Pass |
-| TickerAnimation bg (rise) | #EA580C 10% | #131316 | ℹ️ Background only |
-| TickerAnimation bg (fall) | #256AF4 10% | #131316 | ℹ️ Background only |
+| TickerAnimation bg (rise) | rgba(234,88,12,0.1) | #131316 | ℹ️ Background only |
+| TickerAnimation bg (fall) | rgba(37,106,244,0.1) | #131316 | ℹ️ Background only |
 | LocalError text | #9F9F9F | #131316 | ✅ Pass |
 | GlobalEmptyState text | #9F9F9F | #131316 | ✅ Pass |
-| Badge text | #FFFFFF | #2C2C30 | ✅ Pass |
         `,
       },
     },
   },
   render: () => (
     <div style={{ backgroundColor: "#131316", padding: "32px", display: "flex", flexDirection: "column", gap: "32px", minWidth: "1200px" }}>
-      {/* 텍스트 명도 대비 */}
       <section>
         <h3 style={{ fontSize: "14px", color: "#9194A1", marginBottom: "12px" }}>Text Color Contrast</h3>
         <div style={{ display: "flex", gap: "24px", alignItems: "center" }}>
@@ -266,8 +455,6 @@ WCAG AA (4.5:1) color contrast verification:
           <span style={{ fontSize: "14px", color: "#9F9F9F" }}>Disabled #9F9F9F</span>
         </div>
       </section>
-
-      {/* 등락률 색상 대비 */}
       <section>
         <h3 style={{ fontSize: "14px", color: "#9194A1", marginBottom: "12px" }}>Price Change Color Contrast</h3>
         <div style={{ display: "flex", gap: "24px", alignItems: "center" }}>
@@ -276,8 +463,6 @@ WCAG AA (4.5:1) color contrast verification:
           <span style={{ fontSize: "15px", fontWeight: 500, color: "#9194A1" }}>0.00% (Flat #9194A1)</span>
         </div>
       </section>
-
-      {/* LinearGauge 대비 */}
       <section>
         <h3 style={{ fontSize: "14px", color: "#9194A1", marginBottom: "12px" }}>LinearGauge Color Contrast</h3>
         <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
@@ -286,8 +471,6 @@ WCAG AA (4.5:1) color contrast verification:
           <LinearGauge buyRatio={1} />
         </div>
       </section>
-
-      {/* TickerAnimation 배경 대비 */}
       <section>
         <h3 style={{ fontSize: "14px", color: "#9194A1", marginBottom: "12px" }}>TickerAnimation Background Contrast</h3>
         <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
@@ -297,14 +480,6 @@ WCAG AA (4.5:1) color contrast verification:
           <div style={{ backgroundColor: "rgba(37,106,244,0.1)", padding: "12px 16px", borderRadius: "4px" }}>
             <span style={{ fontSize: "15px", fontWeight: 500, color: "#FFFFFF" }}>Fall bg rgba(37,106,244,0.1) — Text #FFFFFF</span>
           </div>
-        </div>
-      </section>
-
-      {/* Badge 대비 */}
-      <section>
-        <h3 style={{ fontSize: "14px", color: "#9194A1", marginBottom: "12px" }}>Badge Color Contrast</h3>
-        <div style={{ display: "inline-flex", alignItems: "center", gap: "5px", padding: "5px", backgroundColor: "#2C2C30", borderRadius: "4px" }}>
-          <span style={{ fontSize: "10px", fontWeight: 500, color: "#FFFFFF" }}>휴장 시간</span>
         </div>
       </section>
     </div>

--- a/apps/web/Design_UI/src/components/common/stock/StockDataPage/StockDataPage.stories.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDataPage/StockDataPage.stories.tsx
@@ -1,14 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { useState, useEffect } from "react";
-import { StockTable } from "../StockTable/StockTable";
-import { TickerAnimation } from "../TickerAnimation/TickerAnimation";
-import { LocalError } from "../../../common/LocalError/LocalError";
-import { GlobalEmptyState } from "../../../common/GlobalEmptyState/GlobalEmptyState";
-import { Skeleton } from "../../../common/Skeleton/Skeleton";
 import { LinearGauge } from "../LinearGauge/LinearGauge";
-import { Tab } from "../../../common/Tab/Tab";
+import { StockDataPage } from "./StockDataPage";
 import type { StockRow } from "../StockTable/StockTable";
-import type { Viewport } from "../StockTable/StockTable";
 
 // ─── Mock Data ────────────────────────────────────────────────
 
@@ -31,158 +24,11 @@ const EXTREME_ROWS: StockRow[] = [
   { id: "e3", rank: 3, isFavorite: false, name: "보합 (50:50)",     price: 10000, changeRate: 0,     tradeAmount: 500000, buyRatio: 50 },
 ];
 
-// ─── Types ────────────────────────────────────────────────────
-
-type PageState =
-  | "default"       // 정상 데이터
-  | "skeleton"      // 로딩 (Skeleton 애니메이션)
-  | "realtime"      // 실시간 가격 갱신
-  | "error"         // API 실패
-  | "empty"         // 조회 결과 없음
-  | "market-closed" // 시장 휴장
-  | "extreme";      // 극단값 (99:1, 1:99)
-
-interface StockDataPageProps {
-  pageState?: PageState;
-  viewport?: Viewport;
-}
-
-// ─── Filter Tab Items ─────────────────────────────────────────
-
-const MARKET_FILTER_ITEMS = [
-  { label: "전체", value: "all" },
-  { label: "국내", value: "domestic" },
-  { label: "해외", value: "overseas" },
-];
-
-const SORT_FILTER_ITEMS = [
-  { label: "증권 거래대금", value: "amount" },
-  { label: "증권 거래량",   value: "volume" },
-  { label: "거래대금",      value: "trade-amount" },
-  { label: "거래량",        value: "trade-volume" },
-];
-
-// ─── Page Container Width per Viewport ───────────────────────
-
-const VIEWPORT_WIDTH: Record<Viewport, string> = {
-  desktop: "1200px",
-  tablet:  "768px",
-  mobile:  "393px",
-};
-
-// ─── StockDataPage Component ──────────────────────────────────
-
-const StockDataPage = ({
-  pageState = "default",
-  viewport = "desktop",
-}: StockDataPageProps) => {
-  const [rows, setRows] = useState<StockRow[]>(MOCK_ROWS);
-  const containerWidth = VIEWPORT_WIDTH[viewport];
-
-  // 실시간 갱신 — realtime 상태에서만 활성화
-  useEffect(() => {
-    if (pageState !== "realtime") return;
-    const timers = MOCK_ROWS.map((row) => {
-      const interval = 1500 + Math.random() * 3000;
-      return setInterval(() => {
-        const delta = Math.floor((Math.random() - 0.5) * 2000);
-        if (delta === 0) return;
-        setRows((prev) =>
-          prev.map((r) =>
-            r.id === row.id ? { ...r, price: Math.max(1000, r.price + delta) } : r
-          )
-        );
-      }, interval);
-    });
-    return () => timers.forEach(clearInterval);
-  }, [pageState]);
-
-  // 콘텐츠 상태 여부 (테이블 렌더링)
-  const isTableState =
-    pageState === "default" ||
-    pageState === "realtime" ||
-    pageState === "extreme";
-
-  return (
-    <div
-      style={{
-        width: containerWidth,
-        backgroundColor: "#131316",
-        minHeight: "800px",
-        display: "flex",
-        flexDirection: "column",
-      }}
-    >
-      {/* ── 필터 탭 영역 ── */}
-      <div
-        style={{
-          padding: "16px",
-          display: "flex",
-          gap: "12px",
-          flexWrap: "wrap",
-        }}
-      >
-        <Tab items={MARKET_FILTER_ITEMS} defaultValue="all" />
-        {/* 태블릿/모바일에서는 정렬 필터 숨김 (공간 부족) */}
-        {viewport === "desktop" && (
-          <Tab items={SORT_FILTER_ITEMS} defaultValue="amount" />
-        )}
-      </div>
-
-      {/* ── 콘텐츠 영역 ── */}
-      <div
-        style={{
-          flex: 1,
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: isTableState ? "flex-start" : "center",
-          alignItems: isTableState ? "flex-start" : "center",
-        }}
-      >
-        {/* Skeleton — 초기 로딩 */}
-        {pageState === "skeleton" && (
-          <Skeleton variant="table-row" rows={10} />
-        )}
-
-        {/* Error — API 실패 */}
-        {pageState === "error" && (
-          <LocalError
-            message="데이터를 불러오는 데 실패했습니다."
-            onRetry={() => alert("다시 시도")}
-          />
-        )}
-
-        {/* Empty — 조회 결과 없음 */}
-        {pageState === "empty" && (
-          <GlobalEmptyState variant="no-data" display="inline" />
-        )}
-
-        {/* Market Closed — 시장 휴장 */}
-        {pageState === "market-closed" && (
-          <GlobalEmptyState variant="market-closed" display="inline" />
-        )}
-
-        {/* Extreme — 극단값 검증 */}
-        {pageState === "extreme" && (
-          <StockTable rows={EXTREME_ROWS} viewport={viewport} />
-        )}
-
-        {/* Default — 정상 데이터 */}
-        {pageState === "default" && (
-          <StockTable rows={rows} viewport={viewport} />
-        )}
-
-        {/* Realtime — 실시간 가격 갱신 */}
-        {pageState === "realtime" && (
-          <div style={{ width: containerWidth }}>
-            {rows.map((row) => (
-              <TickerAnimation key={row.id} row={row} />
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
+// Story args에서 공통으로 사용할 데이터
+const DEFAULT_ARGS = {
+  rows: MOCK_ROWS,
+  extremeRows: EXTREME_ROWS,
+  onRetry: () => alert("다시 시도"),
 };
 
 // ─── Meta ─────────────────────────────────────────────────────
@@ -249,14 +95,14 @@ const mobileDecorator = (Story: React.ComponentType) => (
 /** 정상 데이터 — 기본 상태 */
 export const Default: Story = {
   name: "Default",
-  args: { pageState: "default", viewport: "desktop" },
+  args: { ...DEFAULT_ARGS, pageState: "default", viewport: "desktop" },
   decorators: [desktopDecorator],
 };
 
 /** 로딩 — Skeleton 애니메이션 */
 export const Loading: Story = {
   name: "Loading (Skeleton)",
-  args: { pageState: "skeleton", viewport: "desktop" },
+  args: { ...DEFAULT_ARGS, pageState: "skeleton", viewport: "desktop" },
   parameters: {
     docs: {
       description: {
@@ -270,7 +116,7 @@ export const Loading: Story = {
 /** 실시간 갱신 — TickerAnimation */
 export const Realtime: Story = {
   name: "Realtime — Dynamic Price Updates",
-  args: { pageState: "realtime", viewport: "desktop" },
+  args: { ...DEFAULT_ARGS, pageState: "realtime", viewport: "desktop" },
   parameters: {
     docs: {
       description: {
@@ -284,7 +130,7 @@ export const Realtime: Story = {
 /** API 오류 — LocalError */
 export const Error: Story = {
   name: "Error",
-  args: { pageState: "error", viewport: "desktop" },
+  args: { ...DEFAULT_ARGS, pageState: "error", viewport: "desktop" },
   parameters: {
     docs: {
       description: {
@@ -298,7 +144,7 @@ export const Error: Story = {
 /** 빈 데이터 — 조회 결과 없음 */
 export const Empty: Story = {
   name: "Empty",
-  args: { pageState: "empty", viewport: "desktop" },
+  args: { ...DEFAULT_ARGS, pageState: "empty", viewport: "desktop" },
   parameters: {
     docs: {
       description: {
@@ -312,7 +158,7 @@ export const Empty: Story = {
 /** 시장 휴장 */
 export const MarketClosed: Story = {
   name: "Market Closed",
-  args: { pageState: "market-closed", viewport: "desktop" },
+  args: { ...DEFAULT_ARGS, pageState: "market-closed", viewport: "desktop" },
   parameters: {
     docs: {
       description: {
@@ -326,7 +172,7 @@ export const MarketClosed: Story = {
 /** 극단값 검증 — LinearGauge min-width 4px */
 export const ExtremeValues: Story = {
   name: "Extreme Values (99:1)",
-  args: { pageState: "extreme", viewport: "desktop" },
+  args: { ...DEFAULT_ARGS, pageState: "extreme", viewport: "desktop" },
   parameters: {
     docs: {
       description: {
@@ -344,7 +190,7 @@ export const ExtremeValues: Story = {
 /** 태블릿 — 정상 데이터 */
 export const TabletDefault: Story = {
   name: "Tablet / Default",
-  args: { pageState: "default", viewport: "tablet" },
+  args: { ...DEFAULT_ARGS, pageState: "default", viewport: "tablet" },
   parameters: { viewport: { defaultViewport: "tablet" } },
   decorators: [tabletDecorator],
 };
@@ -352,7 +198,7 @@ export const TabletDefault: Story = {
 /** 태블릿 — 로딩 */
 export const TabletLoading: Story = {
   name: "Tablet / Loading",
-  args: { pageState: "skeleton", viewport: "tablet" },
+  args: { ...DEFAULT_ARGS, pageState: "skeleton", viewport: "tablet" },
   parameters: { viewport: { defaultViewport: "tablet" } },
   decorators: [tabletDecorator],
 };
@@ -360,7 +206,7 @@ export const TabletLoading: Story = {
 /** 태블릿 — 오류 */
 export const TabletError: Story = {
   name: "Tablet / Error",
-  args: { pageState: "error", viewport: "tablet" },
+  args: { ...DEFAULT_ARGS, pageState: "error", viewport: "tablet" },
   parameters: { viewport: { defaultViewport: "tablet" } },
   decorators: [tabletDecorator],
 };
@@ -368,7 +214,7 @@ export const TabletError: Story = {
 /** 태블릿 — 빈 데이터 */
 export const TabletEmpty: Story = {
   name: "Tablet / Empty",
-  args: { pageState: "empty", viewport: "tablet" },
+  args: { ...DEFAULT_ARGS, pageState: "empty", viewport: "tablet" },
   parameters: { viewport: { defaultViewport: "tablet" } },
   decorators: [tabletDecorator],
 };
@@ -380,7 +226,7 @@ export const TabletEmpty: Story = {
 /** 모바일 — 정상 데이터 */
 export const MobileDefault: Story = {
   name: "Mobile / Default",
-  args: { pageState: "default", viewport: "mobile" },
+  args: { ...DEFAULT_ARGS, pageState: "default", viewport: "mobile" },
   parameters: { viewport: { defaultViewport: "mobile1" } },
   decorators: [mobileDecorator],
 };
@@ -388,7 +234,7 @@ export const MobileDefault: Story = {
 /** 모바일 — 로딩 */
 export const MobileLoading: Story = {
   name: "Mobile / Loading",
-  args: { pageState: "skeleton", viewport: "mobile" },
+  args: { ...DEFAULT_ARGS, pageState: "skeleton", viewport: "mobile" },
   parameters: { viewport: { defaultViewport: "mobile1" } },
   decorators: [mobileDecorator],
 };
@@ -396,7 +242,7 @@ export const MobileLoading: Story = {
 /** 모바일 — 오류 */
 export const MobileError: Story = {
   name: "Mobile / Error",
-  args: { pageState: "error", viewport: "mobile" },
+  args: { ...DEFAULT_ARGS, pageState: "error", viewport: "mobile" },
   parameters: { viewport: { defaultViewport: "mobile1" } },
   decorators: [mobileDecorator],
 };
@@ -404,7 +250,7 @@ export const MobileError: Story = {
 /** 모바일 — 빈 데이터 */
 export const MobileEmpty: Story = {
   name: "Mobile / Empty",
-  args: { pageState: "empty", viewport: "mobile" },
+  args: { ...DEFAULT_ARGS, pageState: "empty", viewport: "mobile" },
   parameters: { viewport: { defaultViewport: "mobile1" } },
   decorators: [mobileDecorator],
 };
@@ -416,7 +262,7 @@ export const MobileEmpty: Story = {
 /** Controls로 모든 상태·뷰포트 자유 조작 */
 export const Playground: Story = {
   name: "Playground",
-  args: { pageState: "default", viewport: "desktop" },
+  args: { ...DEFAULT_ARGS, pageState: "default", viewport: "desktop" },
   decorators: [desktopDecorator],
 };
 

--- a/apps/web/Design_UI/src/components/common/stock/StockDataPage/StockDataPage.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDataPage/StockDataPage.tsx
@@ -16,7 +16,6 @@ export type PageState =
   | "realtime"      // 실시간 가격 갱신
   | "error"         // API 실패
   | "empty"         // 조회 결과 없음
-  | "market-closed" // 시장 휴장
   | "extreme";      // 극단값 (99:1, 1:99)
 
 export interface StockDataPageProps {
@@ -143,9 +142,6 @@ export const StockDataPage = ({
         )}
         {pageState === "empty" && (
           <GlobalEmptyState variant="no-data" display="inline" />
-        )}
-        {pageState === "market-closed" && (
-          <GlobalEmptyState variant="market-closed" display="inline" />
         )}
         {pageState === "extreme" && (
           <StockTable

--- a/apps/web/Design_UI/src/components/common/stock/StockDataPage/StockDataPage.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDataPage/StockDataPage.tsx
@@ -1,0 +1,178 @@
+import { useState, useEffect } from "react";
+import { StockTable } from "../StockTable/StockTable";
+import { TickerAnimation } from "../TickerAnimation/TickerAnimation";
+import { LocalError } from "../../../common/LocalError/LocalError";
+import { GlobalEmptyState } from "../../../common/GlobalEmptyState/GlobalEmptyState";
+import { Skeleton } from "../../../common/Skeleton/Skeleton";
+import { Tab } from "../../../common/Tab/Tab";
+import type { StockRow } from "../StockTable/StockTable";
+import type { Viewport } from "../StockTable/StockTable";
+
+// ─── Types ────────────────────────────────────────────────────
+
+export type PageState =
+  | "default"       // 정상 데이터
+  | "skeleton"      // 로딩 (Skeleton 애니메이션)
+  | "realtime"      // 실시간 가격 갱신
+  | "error"         // API 실패
+  | "empty"         // 조회 결과 없음
+  | "market-closed" // 시장 휴장
+  | "extreme";      // 극단값 (99:1, 1:99)
+
+export interface StockDataPageProps {
+  rows?: StockRow[];
+  extremeRows?: StockRow[];
+  pageState?: PageState;
+  viewport?: Viewport;
+  onRetry?: () => void;
+  onFavoriteToggle?: (id: string) => void;
+  onRowClick?: (id: string) => void;
+}
+
+// ─── Filter Tab Items ─────────────────────────────────────────
+
+const MARKET_FILTER_ITEMS = [
+  { label: "전체", value: "all" },
+  { label: "국내", value: "domestic" },
+  { label: "해외", value: "overseas" },
+];
+
+const SORT_FILTER_ITEMS = [
+  { label: "증권 거래대금", value: "amount" },
+  { label: "증권 거래량",   value: "volume" },
+  { label: "거래대금",      value: "trade-amount" },
+  { label: "거래량",        value: "trade-volume" },
+];
+
+// ─── Viewport Width ───────────────────────────────────────────
+
+const VIEWPORT_WIDTH: Record<Viewport, string> = {
+  desktop: "1200px",
+  tablet:  "768px",
+  mobile:  "393px",
+};
+
+// ─── StockDataPage ────────────────────────────────────────────
+
+export const StockDataPage = ({
+  rows: rowsProp,
+  extremeRows,
+  pageState = "default",
+  viewport = "desktop",
+  onRetry,
+  onFavoriteToggle,
+  onRowClick,
+}: StockDataPageProps) => {
+  const [rows, setRows] = useState<StockRow[]>(rowsProp ?? []);
+  const containerWidth = VIEWPORT_WIDTH[viewport];
+
+  // rows prop 변경 시 내부 state 동기화
+  useEffect(() => {
+    if (rowsProp) setRows(rowsProp);
+  }, [rowsProp]);
+
+  // 실시간 갱신 — realtime 상태에서만 활성화
+  useEffect(() => {
+    if (pageState !== "realtime" || !rowsProp) return;
+    const timers = rowsProp.map((row) => {
+      const interval = 1500 + Math.random() * 3000;
+      return setInterval(() => {
+        const delta = Math.floor((Math.random() - 0.5) * 2000);
+        if (delta === 0) return;
+        setRows((prev) =>
+          prev.map((r) =>
+            r.id === row.id ? { ...r, price: Math.max(1000, r.price + delta) } : r
+          )
+        );
+      }, interval);
+    });
+    return () => timers.forEach(clearInterval);
+  }, [pageState]);
+
+  const isTableState =
+    pageState === "default" ||
+    pageState === "realtime" ||
+    pageState === "extreme";
+
+  return (
+    <div
+      style={{
+        width: containerWidth,
+        backgroundColor: "#131316",
+        minHeight: "800px",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* ── 필터 탭 영역 — 넘칠 경우 가로 스크롤 ── */}
+      <div
+        style={{
+          padding: "16px",
+          display: "flex",
+          gap: "12px",
+          overflowX: "auto",
+          flexShrink: 0,
+          scrollbarWidth: "none",
+          msOverflowStyle: "none",
+        }}
+      >
+        <div style={{ display: "flex", gap: "12px", flexShrink: 0 }}>
+          <Tab items={MARKET_FILTER_ITEMS} defaultValue="all" />
+          <Tab items={SORT_FILTER_ITEMS} defaultValue="amount" />
+        </div>
+      </div>
+
+      {/* ── 콘텐츠 영역 ── */}
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: isTableState ? "flex-start" : "center",
+          alignItems: isTableState ? "flex-start" : "center",
+        }}
+      >
+        {pageState === "skeleton" && (
+          <Skeleton variant="table-row" rows={10} />
+        )}
+        {pageState === "error" && (
+          <LocalError
+            message="데이터를 불러오는 데 실패했습니다."
+            onRetry={onRetry}
+          />
+        )}
+        {pageState === "empty" && (
+          <GlobalEmptyState variant="no-data" display="inline" />
+        )}
+        {pageState === "market-closed" && (
+          <GlobalEmptyState variant="market-closed" display="inline" />
+        )}
+        {pageState === "extreme" && (
+          <StockTable
+            rows={extremeRows ?? []}
+            viewport={viewport}
+            onFavoriteToggle={onFavoriteToggle}
+            onRowClick={onRowClick}
+          />
+        )}
+        {pageState === "default" && (
+          <StockTable
+            rows={rows}
+            viewport={viewport}
+            onFavoriteToggle={onFavoriteToggle}
+            onRowClick={onRowClick}
+          />
+        )}
+        {pageState === "realtime" && (
+          <div style={{ width: containerWidth }}>
+            {rows.map((row) => (
+              <TickerAnimation key={row.id} row={row} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default StockDataPage;

--- a/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.stories.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.stories.tsx
@@ -1,0 +1,475 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { StockDetailPage } from "./StockDetailPage";
+import type { CandlestickData } from "../TradingViewWrapper/TradingViewWrapper";
+import type { OrderbookRow, MarketInfo } from "../OrderbookTable/OrderbookTable";
+import type { TradeTickRow } from "../TradeTickerList/TradeTickerList";
+import type { SparklineDataPoint } from "../AIPredictionPanel/SparklineChart";
+import type { AnalysisData } from "../AIPredictionPanel/PredictionAnalysisWidget";
+type AnalysisDataWithTabs = AnalysisData & {
+  tabs: string[];
+  activeTab: string;
+  items: {
+    type: "warning" | "neutral" | "positive";
+    text: string;
+  }[];
+};
+
+// ════════════════════════════════════════════════════════════════
+// Mock Data
+// ════════════════════════════════════════════════════════════════
+
+// ─── 종목 메타 ────────────────────────────────────────────────
+
+const MOCK_STOCK = {
+  ticker: "005930",
+  name: "삼성전자",
+  price: 75000,
+  changeFromYesterday: 1720,
+  changeRate: 2.35,
+};
+
+const MOCK_STOCK_DOWN = {
+  ticker: "000660",
+  name: "SK하이닉스",
+  price: 182000,
+  changeFromYesterday: -2200,
+  changeRate: -1.20,
+};
+
+// ─── 차트 데이터 ──────────────────────────────────────────────
+
+const generateChartData = (days: number): CandlestickData[] => {
+  const data: CandlestickData[] = [];
+  let price = 75000;
+  const startDate = new Date("2025-10-01");
+  for (let i = 0; i < days; i++) {
+    const date = new Date(startDate);
+    date.setDate(startDate.getDate() + i);
+    if (date.getDay() === 0 || date.getDay() === 6) continue;
+    const open = price;
+    const change = (Math.random() - 0.48) * 3000;
+    const close = Math.max(50000, open + change);
+    const high = Math.max(open, close) + Math.random() * 1500;
+    const low = Math.min(open, close) - Math.random() * 1500;
+    const volume = Math.floor(Math.random() * 200000000 + 50000000);
+    data.push({
+      time: date.toISOString().split("T")[0],
+      open: Math.round(open),
+      high: Math.round(high),
+      low: Math.round(low),
+      close: Math.round(close),
+      volume,
+    });
+    price = close;
+  }
+  return data;
+};
+
+const MOCK_CHART_DATA = generateChartData(180);
+
+// ─── 호가 데이터 ──────────────────────────────────────────────
+
+const MOCK_ASKS: OrderbookRow[] = [
+  { price: 76000, changeRate: -9.52,  quantity: 1200 },
+  { price: 75500, changeRate: -9.52,  quantity: 800  },
+  { price: 75000, changeRate: -10.71, quantity: 2100 },
+  { price: 74500, changeRate: -11.31, quantity: 500  },
+  { price: 74000, changeRate: -11.90, quantity: 1800 },
+  { price: 73500, changeRate: -12.50, quantity: 900  },
+  { price: 73000, changeRate: -13.10, quantity: 3200 },
+  { price: 72500, changeRate: -13.69, quantity: 700  },
+  { price: 72000, changeRate: -14.29, quantity: 1500 },
+  { price: 71500, changeRate: -14.88, quantity: 600  },
+];
+
+const MOCK_BIDS: OrderbookRow[] = [
+  { price: 74800, changeRate: -11.55, quantity: 2500 },
+  { price: 74300, changeRate: -12.14, quantity: 1300 },
+  { price: 73800, changeRate: -12.74, quantity: 800  },
+  { price: 73300, changeRate: -13.33, quantity: 3500 },
+  { price: 72800, changeRate: -13.93, quantity: 600  },
+  { price: 72300, changeRate: -14.52, quantity: 1900 },
+  { price: 71800, changeRate: -15.12, quantity: 700  },
+  { price: 71300, changeRate: -15.71, quantity: 2200 },
+  { price: 70800, changeRate: -16.31, quantity: 400  },
+  { price: 70300, changeRate: -16.90, quantity: 1600 },
+];
+
+const MOCK_TRADES: TradeTickRow[] = Array.from({ length: 14 }, (_, i) => ({
+  id: `t${i + 1}`,
+  price: 75000 + Math.floor((Math.random() - 0.5) * 500),
+  quantity: Math.floor(Math.random() * 10) + 1,
+  isBuy: Math.random() > 0.5,
+}));
+
+const MOCK_MARKET_INFO: MarketInfo = {
+  weekHigh: 98000,
+  weekLow: 62000,
+  upperLimit: 97500,
+  lowerLimit: 52500,
+  riseVI: undefined,
+  fallVI: undefined,
+  open: 74000,
+  high: 76500,
+  low: 73200,
+  volume: 15234567,
+  volumeUnit: "1,523만",
+  changeFromYesterday: 2.35,
+  midPrice: 75200,
+};
+
+// ─── AI 예측 패널 Mock 데이터 ─────────────────────────────────
+
+const MOCK_AI_HISTORICAL: SparklineDataPoint[] = [
+  { time: "2025-10-01", value: 63000 },
+  { time: "2025-11-01", value: 58000 },
+  { time: "2025-12-01", value: 61000 },
+  { time: "2026-01-01", value: 55000 },
+  { time: "2026-02-01", value: 59000 },
+  { time: "2026-03-01", value: 57000 },
+  { time: "2026-03-15", value: 63000 },
+];
+
+const MOCK_AI_FORECAST: SparklineDataPoint[] = [
+  { time: "2026-03-15", value: 63000 },
+  { time: "2026-03-22", value: 70000 },
+  { time: "2026-03-29", value: 80000 },
+];
+
+const MOCK_AI_ANALYSIS: AnalysisDataWithTabs = {
+  "기술적 지표": [
+    { type: "warning", text: "경고 또는 위험 신호가 있는 내용" },
+    { type: "neutral", text: "중립이거나 추가 확인이 필요한 내용" },
+    { type: "positive", text: "긍정적 신호가 있는 내용" },
+    { type: "neutral", text: "중립이거나 추가 확인이 필요한 내용" },
+    { type: "neutral", text: "중립이거나 추가 확인이 필요한 내용" },
+  ],
+  "시장 심리": [],
+  "수급 동향": [],
+  tabs: ["기술적 지표", "시장 심리", "수급 동향"],
+  activeTab: "기술적 지표",
+  items: [
+    { type: "warning", text: "경고 또는 위험 신호가 있는 내용" },
+    { type: "neutral", text: "중립이거나 추가 확인이 필요한 내용" },
+    { type: "positive", text: "긍정적 신호가 있는 내용" },
+    { type: "neutral", text: "중립이거나 추가 확인이 필요한 내용" },
+    { type: "neutral", text: "중립이거나 추가 확인이 필요한 내용" },
+  ],
+};
+
+// ─── 공통 args ────────────────────────────────────────────────
+
+const COMMON_ARGS = {
+  stock: MOCK_STOCK,
+  chartData: MOCK_CHART_DATA,
+  chartPeriod: "1d" as const,
+  currentPrice: 75000,
+  currentChangeRate: 2.35,
+  asks: MOCK_ASKS,
+  bids: MOCK_BIDS,
+  trades: MOCK_TRADES,
+  tradeStrength: 72,
+  marketInfo: MOCK_MARKET_INFO,
+  onQuickOrder: () => alert("빠른 주문"),
+  onRetry: () => alert("Retry"),
+  onBuyClick: () => alert("매수하기"),
+
+  // 패널 상태
+  chartState: "default" as const,
+  orderbookState: "default" as const,
+  aiState: "default" as const,
+
+  // AI 패널 데이터
+  aiHistoricalData: MOCK_AI_HISTORICAL,
+  aiForecastData: MOCK_AI_FORECAST,
+  aiPredictedPrice: 80000,
+  aiPriceDiff: 17000,
+  aiChangeRate: 26.98,
+  aiBaseDate: "2025년 03월 26일",
+  aiUpProbability: 72,
+  aiDownProbability: 28,
+  aiAnalysisData: MOCK_AI_ANALYSIS,
+};
+
+// ════════════════════════════════════════════════════════════════
+// Meta
+// ════════════════════════════════════════════════════════════════
+
+const meta: Meta<typeof StockDetailPage> = {
+  title: "Components/Stock/StockDetailPage",
+  component: StockDetailPage,
+  tags: ["autodocs"],
+  parameters: {
+    backgrounds: {
+      default: "dark",
+      values: [{ name: "dark", value: "#131316" }],
+    },
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: `
+종목 세부 페이지 통합 Story.
+
+**레이아웃**
+- Desktop (1440px): 좌(차트 680×400 + 빈패널 680×400) / 중(호가 340) / 우(AI 340) 고정 3열
+- Tablet (768px): 차트 710×400 상단 / AI 347px + 호가 340px 하단 2열, 페이지 전체 스크롤
+- Mobile (393px): 차트 탭에서 차트 345×407 + 호가창 345×454 수직 나열, AI는 AI탭에서만 표시
+
+**패널별 독립 상태**
+\`chartState\`, \`orderbookState\`, \`aiState\` prop으로 각 패널 상태 개별 지정.
+\`isMarketClosed=true\`이면 호가창은 항상 empty 상태.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    activeTab: {
+      control: "radio",
+      options: ["chart", "orderbook", "trade", "ai"],
+    },
+    chartState: {
+      control: "radio",
+      options: ["default", "skeleton", "error", "empty"],
+      description: "차트 패널 상태",
+    },
+    orderbookState: {
+      control: "radio",
+      options: ["default", "skeleton", "error", "empty"],
+      description: "호가창 패널 상태 (isMarketClosed=true 이면 empty 강제)",
+    },
+    aiState: {
+      control: "radio",
+      options: ["default", "skeleton", "error", "empty"],
+      description: "AI 예측 패널 상태",
+    },
+    viewport: {
+      control: "radio",
+      options: ["desktop", "tablet", "mobile"],
+    },
+    isMarketClosed: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StockDetailPage>;
+
+// ─── 데코레이터 ───────────────────────────────────────────────
+
+const desktopDec = (Story: React.ComponentType) => (
+  <div style={{ minWidth: "1440px" }}><Story /></div>
+);
+const tabletDec = (Story: React.ComponentType) => (
+  <div style={{ width: "768px" }}><Story /></div>
+);
+const mobileDec = (Story: React.ComponentType) => (
+  <div style={{ width: "393px" }}><Story /></div>
+);
+
+// ════════════════════════════════════════════════════════════════
+// Desktop Stories
+// ════════════════════════════════════════════════════════════════
+
+export const DesktopChart: Story = {
+  name: "Desktop / Chart Tab — Default",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "desktop" },
+  decorators: [desktopDec],
+};
+
+export const DesktopDownTrend: Story = {
+  name: "Desktop / Down Trend",
+  args: { ...COMMON_ARGS, stock: MOCK_STOCK_DOWN, activeTab: "chart", viewport: "desktop" },
+  decorators: [desktopDec],
+};
+
+export const DesktopTabSwitching: Story = {
+  name: "Desktop / Tab Switching Demo",
+  render: () => {
+    const [tab, setTab] = useState<"chart" | "orderbook" | "trade" | "ai">("chart");
+    return (
+      <div style={{ minWidth: "1440px" }}>
+        <StockDetailPage
+          {...COMMON_ARGS}
+          activeTab={tab}
+          onTabChange={(t) => setTab(t as any)}
+          viewport="desktop"
+        />
+      </div>
+    );
+  },
+};
+
+export const DesktopMarketClosed: Story = {
+  name: "Desktop / Market Closed",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "desktop", isMarketClosed: true },
+  decorators: [desktopDec],
+};
+
+// ── 패널별 상태 ───────────────────────────────────────────────
+
+export const DesktopChartSkeleton: Story = {
+  name: "Desktop / Chart Panel — Skeleton",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "desktop", chartState: "skeleton" },
+  decorators: [desktopDec],
+};
+
+export const DesktopChartError: Story = {
+  name: "Desktop / Chart Panel — Error",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "desktop", chartState: "error" },
+  decorators: [desktopDec],
+};
+
+export const DesktopOrderbookSkeleton: Story = {
+  name: "Desktop / Orderbook Panel — Skeleton",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "desktop", orderbookState: "skeleton" },
+  decorators: [desktopDec],
+};
+
+export const DesktopOrderbookError: Story = {
+  name: "Desktop / Orderbook Panel — Error",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "desktop", orderbookState: "error" },
+  decorators: [desktopDec],
+};
+
+export const DesktopAISkeleton: Story = {
+  name: "Desktop / AI Panel — Skeleton",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "desktop", aiState: "skeleton" },
+  decorators: [desktopDec],
+};
+
+export const DesktopAIError: Story = {
+  name: "Desktop / AI Panel — Error",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "desktop", aiState: "error" },
+  decorators: [desktopDec],
+};
+
+export const DesktopAllSkeleton: Story = {
+  name: "Desktop / All Panels — Skeleton (Initial Load)",
+  args: {
+    ...COMMON_ARGS,
+    activeTab: "chart",
+    viewport: "desktop",
+    chartState: "skeleton",
+    orderbookState: "skeleton",
+    aiState: "skeleton",
+  },
+  decorators: [desktopDec],
+};
+
+export const DesktopAllError: Story = {
+  name: "Desktop / All Panels — Error",
+  args: {
+    ...COMMON_ARGS,
+    activeTab: "chart",
+    viewport: "desktop",
+    chartState: "error",
+    orderbookState: "error",
+    aiState: "error",
+  },
+  decorators: [desktopDec],
+};
+
+export const DesktopStockInfo: Story = {
+  name: "Desktop / Stock Info Tab — Placeholder",
+  args: { ...COMMON_ARGS, activeTab: "orderbook", viewport: "desktop" },
+  decorators: [desktopDec],
+};
+
+// ════════════════════════════════════════════════════════════════
+// Tablet Stories
+// ════════════════════════════════════════════════════════════════
+
+export const TabletChart: Story = {
+  name: "Tablet / Chart Tab — Default",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "tablet" },
+  parameters: { viewport: { defaultViewport: "tablet" } },
+  decorators: [tabletDec],
+};
+
+export const TabletOrderbookSkeleton: Story = {
+  name: "Tablet / Orderbook Panel — Skeleton",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "tablet", orderbookState: "skeleton" },
+  parameters: { viewport: { defaultViewport: "tablet" } },
+  decorators: [tabletDec],
+};
+
+export const TabletOrderbookError: Story = {
+  name: "Tablet / Orderbook Panel — Error",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "tablet", orderbookState: "error" },
+  parameters: { viewport: { defaultViewport: "tablet" } },
+  decorators: [tabletDec],
+};
+
+export const TabletMarketClosed: Story = {
+  name: "Tablet / Market Closed",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "tablet", isMarketClosed: true },
+  parameters: { viewport: { defaultViewport: "tablet" } },
+  decorators: [tabletDec],
+};
+
+// ════════════════════════════════════════════════════════════════
+// Mobile Stories
+// ════════════════════════════════════════════════════════════════
+
+export const MobileChart: Story = {
+  name: "Mobile / Chart Tab",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "mobile" },
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  decorators: [mobileDec],
+};
+
+export const MobileOrderbookSkeleton: Story = {
+  name: "Mobile / Orderbook Panel — Skeleton",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "mobile", orderbookState: "skeleton" },
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  decorators: [mobileDec],
+};
+
+export const MobileOrderbookError: Story = {
+  name: "Mobile / Orderbook Panel — Error",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "mobile", orderbookState: "error" },
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  decorators: [mobileDec],
+};
+
+export const MobileMarketClosed: Story = {
+  name: "Mobile / Market Closed",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "mobile", isMarketClosed: true },
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  decorators: [mobileDec],
+};
+
+export const MobileAITab: Story = {
+  name: "Mobile / AI Tab",
+  args: { ...COMMON_ARGS, activeTab: "ai", viewport: "mobile" },
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  decorators: [mobileDec],
+};
+
+export const MobileTabSwitching: Story = {
+  name: "Mobile / Tab Switching Demo",
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  render: () => {
+    const [tab, setTab] = useState<"chart" | "orderbook" | "trade" | "ai">("chart");
+    return (
+      <div style={{ width: "393px" }}>
+        <StockDetailPage
+          {...COMMON_ARGS}
+          activeTab={tab}
+          onTabChange={(t) => setTab(t as any)}
+          viewport="mobile"
+        />
+      </div>
+    );
+  },
+};
+
+// ════════════════════════════════════════════════════════════════
+// Playground
+// ════════════════════════════════════════════════════════════════
+
+export const Playground: Story = {
+  name: "Playground",
+  args: { ...COMMON_ARGS, activeTab: "chart", viewport: "desktop" },
+  decorators: [desktopDec],
+};

--- a/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.tsx
@@ -1,0 +1,457 @@
+import { useState } from "react";
+import { Tab } from "../../../common/Tab/Tab";
+import { MobileTabSwitcher } from "../../../common/MobileTabSwitcher/MobileTabSwitcher";
+import { TradingViewWrapper } from "../TradingViewWrapper/TradingViewWrapper";
+import { OrderbookTable } from "../OrderbookTable/OrderbookTable";
+import { AIPredictionPanel } from "../AIPredictionPanel/AIPredictionPanel";
+import { ChartIcon } from "../../../icons/ChartIcon";
+import { StockInfoIcon } from "../../../icons/StockInfoIcon";
+import { TradeStatusIcon } from "../../../icons/TradeStatusIcon";
+import { AIPredictionIcon } from "../../../icons/AIPredictionIcon";
+import type { CandlestickData, ChartPeriod } from "../TradingViewWrapper/TradingViewWrapper";
+import type { OrderbookRow, MarketInfo } from "../OrderbookTable/OrderbookTable";
+import type { TradeTickRow } from "../TradeTickerList/TradeTickerList";
+import type { Viewport } from "../StockTable/StockTable";
+import type { SparklineDataPoint } from "../AIPredictionPanel/SparklineChart";
+import type { AnalysisData } from "../AIPredictionPanel/PredictionAnalysisWidget";
+
+// ─── Types ────────────────────────────────────────────────────
+
+export type DetailTab = "chart" | "orderbook" | "trade" | "ai";
+export type PanelState = "default" | "skeleton" | "error" | "empty";
+
+export interface StockMeta {
+  ticker: string;
+  name: string;
+  price: number;
+  changeFromYesterday: number;
+  changeRate: number;
+  logoUrl?: string;
+}
+
+export interface StockDetailPageProps {
+  stock?: StockMeta;
+  activeTab?: DetailTab;
+  onTabChange?: (tab: DetailTab) => void;
+  viewport?: Viewport;
+  onRetry?: () => void;
+  isMarketClosed?: boolean;
+
+  // ── 패널별 독립 상태 ──────────────────────────────────────
+  chartState?: PanelState;
+  orderbookState?: PanelState;
+  aiState?: PanelState;
+
+  // ── 차트 ─────────────────────────────────────────────────
+  chartData?: CandlestickData[];
+  chartPeriod?: ChartPeriod;
+  onChartPeriodChange?: (period: ChartPeriod) => void;
+
+  // ── 호가창 ───────────────────────────────────────────────
+  currentPrice?: number;
+  currentChangeRate?: number;
+  asks?: OrderbookRow[];
+  bids?: OrderbookRow[];
+  trades?: TradeTickRow[];
+  tradeStrength?: number;
+  marketInfo?: MarketInfo;
+  onQuickOrder?: () => void;
+
+  // ── AI 예측 패널 ──────────────────────────────────────────
+  aiPeriod?: "1주" | "1개월" | "3개월";
+  onAIPeriodChange?: (period: "1주" | "1개월" | "3개월") => void;
+  onBuyClick?: () => void;
+  aiHistoricalData?: SparklineDataPoint[];
+  aiForecastData?: SparklineDataPoint[];
+  aiPredictedPrice?: number;
+  aiPriceDiff?: number;
+  aiChangeRate?: number;
+  aiBaseDate?: string;
+  aiUpProbability?: number;
+  aiDownProbability?: number;
+  aiAnalysisData?: AnalysisData;
+}
+
+// ─── 탭 정의 ──────────────────────────────────────────────────
+
+const DESKTOP_TAB_ITEMS = [
+  { label: "차트·호가", value: "chart" },
+  { label: "종목정보",  value: "orderbook" },
+  { label: "거래현황",  value: "trade" },
+];
+
+const MOBILE_TAB_ITEMS = [
+  { label: "차트",     value: "chart",     icon: <ChartIcon /> },
+  { label: "종목 정보", value: "orderbook", icon: <StockInfoIcon /> },
+  { label: "거래 현황", value: "trade",     icon: <TradeStatusIcon /> },
+  { label: "AI 예측",  value: "ai",        icon: <AIPredictionIcon /> },
+];
+
+// ─── Viewport 전체 너비 ───────────────────────────────────────
+
+const VIEWPORT_WIDTH: Record<Viewport, string> = {
+  desktop: "1440px",
+  tablet:  "768px",
+  mobile:  "393px",
+};
+
+// ─── 헤더 ─────────────────────────────────────────────────────
+
+const StockHeader = ({
+  stock,
+  viewport,
+}: {
+  stock: StockMeta;
+  viewport: Viewport;
+}) => {
+  const isMobile = viewport === "mobile";
+  const isRise = stock.changeRate >= 0;
+  const changeColor = isRise ? "#EA580C" : "#256AF4";
+  const sign = isRise ? "+" : "";
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: isMobile ? "12px" : "16px",
+        padding: isMobile ? "16px" : "20px 24px",
+      }}
+    >
+      <div
+        style={{
+          width: isMobile ? "48px" : "56px",
+          height: isMobile ? "48px" : "56px",
+          borderRadius: "12px",
+          backgroundColor: "#21242C",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+          overflow: "hidden",
+        }}
+      >
+        {stock.logoUrl ? (
+          <img
+            src={stock.logoUrl}
+            alt={stock.name}
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+          />
+        ) : (
+          <span style={{ fontSize: isMobile ? "16px" : "18px", fontWeight: 500, color: "#9194A1" }}>
+            {stock.name[0]}
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: "8px" }}>
+          <span style={{ fontSize: isMobile ? "16px" : "18px", fontWeight: 700, color: "#FFFFFF" }}>
+            {stock.name}
+          </span>
+          <span style={{ fontSize: "13px", fontWeight: 400, color: "#9194A1" }}>
+            {stock.ticker}
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "baseline", gap: "8px" }}>
+          <span
+            style={{
+              fontSize: isMobile ? "22px" : "26px",
+              fontWeight: 700,
+              color: "#FFFFFF",
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {stock.price.toLocaleString("ko-KR")}원
+          </span>
+          <span
+            style={{
+              fontSize: "14px",
+              fontWeight: 500,
+              color: changeColor,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            어제보다 {sign}{stock.changeFromYesterday.toLocaleString("ko-KR")}원 ({sign}{stock.changeRate.toFixed(2)}%)
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── StockDetailPage ──────────────────────────────────────────
+
+export const StockDetailPage = ({
+  stock = {
+    ticker: "005930",
+    name: "삼성전자",
+    price: 75000,
+    changeFromYesterday: 1720,
+    changeRate: 2.35,
+  },
+  activeTab: activeTabProp,
+  onTabChange,
+  viewport = "desktop",
+  onRetry,
+  isMarketClosed = false,
+
+  chartState = "default",
+  orderbookState = "default",
+  aiState = "default",
+
+  chartData = [],
+  chartPeriod = "1d",
+  onChartPeriodChange,
+
+  currentPrice = 0,
+  currentChangeRate = 0,
+  asks = [],
+  bids = [],
+  trades = [],
+  tradeStrength = 0,
+  marketInfo,
+  onQuickOrder,
+
+  aiPeriod,
+  onAIPeriodChange,
+  onBuyClick,
+  aiHistoricalData = [],
+  aiForecastData = [],
+  aiPredictedPrice = 0,
+  aiPriceDiff = 0,
+  aiChangeRate = 0,
+  aiBaseDate = "",
+  aiUpProbability = 0,
+  aiDownProbability = 0,
+  aiAnalysisData,
+}: StockDetailPageProps) => {
+  const [internalTab, setInternalTab] = useState<DetailTab>("chart");
+  const activeTab = activeTabProp ?? internalTab;
+  const isMobile = viewport === "mobile";
+  const isTablet = viewport === "tablet";
+  const containerWidth = VIEWPORT_WIDTH[viewport];
+
+  const handleTabChange = (tab: string) => {
+    setInternalTab(tab as DetailTab);
+    onTabChange?.(tab as DetailTab);
+  };
+
+  const resolvedOrderbookStatus: "default" | "skeleton" | "error" | "empty" =
+    isMarketClosed ? "empty" : orderbookState;
+
+  // ── 차트 패널 ─────────────────────────────────────────────
+  const renderChart = (width: number, height: number) => (
+    <div
+      style={{
+        width: `${width}px`,
+        height: `${height}px`,
+        backgroundColor: "#1C1D21",
+        borderRadius: "12px",
+        overflow: "hidden",
+        padding: "12px",
+        boxSizing: "border-box",
+        flexShrink: 0,
+      }}
+    >
+      <TradingViewWrapper
+        data={chartData}
+        period={chartPeriod}
+        onPeriodChange={onChartPeriodChange}
+        isMarketClosed={isMarketClosed}
+      />
+    </div>
+  );
+
+  // ── 호가창 ────────────────────────────────────────────────
+  const renderOrderbook = (vp: Viewport) => (
+    <OrderbookTable
+      status={resolvedOrderbookStatus}
+      viewport={vp}
+      onRetry={onRetry}
+      currentPrice={currentPrice}
+      currentChangeRate={currentChangeRate}
+      asks={asks}
+      bids={bids}
+      trades={trades}
+      tradeStrength={tradeStrength}
+      marketInfo={marketInfo}
+      onQuickOrder={onQuickOrder}
+    />
+  );
+
+  // ── AI 예측 패널 ──────────────────────────────────────────
+  const renderAI = () => (
+    <AIPredictionPanel
+      status={aiState}
+      viewport={viewport}
+      onRetry={onRetry}
+      period={aiPeriod}
+      onPeriodChange={onAIPeriodChange}
+      onBuyClick={onBuyClick}
+      historicalData={aiHistoricalData}
+      forecastData={aiForecastData}
+      predictedPrice={aiPredictedPrice}
+      priceDiff={aiPriceDiff}
+      changeRate={aiChangeRate}
+      baseDate={aiBaseDate}
+      upProbability={aiUpProbability}
+      downProbability={aiDownProbability}
+      analysisData={aiAnalysisData}
+    />
+  );
+
+  return (
+    <div
+      style={{
+        width: containerWidth,
+        backgroundColor: "#131316",
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        boxSizing: "border-box",
+      }}
+    >
+      {/* ── 헤더 ── */}
+      <StockHeader stock={stock} viewport={viewport} />
+
+      {/* ── 탭 (구분선 없음) ── */}
+      {!isMobile && (
+        <div style={{ padding: "0 24px" }}>
+          <Tab
+            items={DESKTOP_TAB_ITEMS}
+            value={activeTab}
+            onChange={handleTabChange}
+          />
+        </div>
+      )}
+
+      <div style={{ flex: 1 }}>
+
+        {/* ══ 차트·호가 탭 — 데스크톱 ══════════════════════════
+            좌: [차트 680×400] + [빈패널 680×400]
+            중: 호가창 340
+            우: AI 340
+        ═════════════════════════════════════════════════ */}
+        {activeTab === "chart" && !isMobile && !isTablet && (
+          <div
+            style={{
+              padding: "16px 24px",
+              display: "flex",
+              gap: "12px",
+              alignItems: "flex-start",
+              boxSizing: "border-box",
+            }}
+          >
+            <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+              {renderChart(680, 400)}
+              <div
+                style={{
+                  width: "680px",
+                  height: "400px",
+                  backgroundColor: "#1C1D21",
+                  borderRadius: "12px",
+                  flexShrink: 0,
+                }}
+              />
+            </div>
+            {renderOrderbook("desktop")}
+            {renderAI()}
+          </div>
+        )}
+
+        {/* ══ 차트·호가 탭 — 태블릿 ═══════════════════════════
+            상단: 차트 710×400
+            하단: AI 347px + 호가 340px
+            페이지 전체 스크롤
+        ═════════════════════════════════════════════════ */}
+        {activeTab === "chart" && isTablet && (
+          <div
+            style={{
+              padding: "16px 24px",
+              display: "flex",
+              flexDirection: "column",
+              gap: "12px",
+              boxSizing: "border-box",
+            }}
+          >
+            {renderChart(710, 400)}
+            <div style={{ display: "flex", gap: "12px", alignItems: "flex-start" }}>
+              <div style={{ width: "347px", flexShrink: 0 }}>
+                {renderAI()}
+              </div>
+              {renderOrderbook("desktop")}
+            </div>
+          </div>
+        )}
+
+        {/* ══ 차트·호가 탭 — 모바일 ════════════════════*/}
+        {activeTab === "chart" && isMobile && (
+          <div
+            style={{
+              padding: "12px",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "12px",
+              boxSizing: "border-box",
+            }}
+          >
+            {renderChart(345, 407)}
+            {renderOrderbook("mobile")}
+          </div>
+        )}
+
+        {/* ══ 종목정보 탭 ══════════════════════════════════════ */}
+        {activeTab === "orderbook" && (
+          <div
+            style={{
+              padding: "40px 24px",
+              color: "#9194A1",
+              fontSize: "14px",
+              textAlign: "center",
+            }}
+          >
+            종목정보 탭 — 추후 구현 예정
+          </div>
+        )}
+
+        {/* ══ 거래현황 탭 ══════════════════════════════════════ */}
+        {activeTab === "trade" && (
+          <div
+            style={{
+              padding: "40px 24px",
+              color: "#9194A1",
+              fontSize: "14px",
+              textAlign: "center",
+            }}
+          >
+            거래현황 탭 — InvestorTable 구현 예정 (이슈 6+)
+          </div>
+        )}
+
+        {/* ══ AI 예측 탭 — 모바일 전용 ════════════════════════ */}
+        {activeTab === "ai" && isMobile && (
+          <div style={{
+            padding: "12px",
+            display: "flex",
+            justifyContent: "center"
+          }}>
+            {renderAI()}
+          </div>
+        )}
+      </div>
+
+      {/* ── 모바일 하단 탭 ── */}
+      {isMobile && (
+        <MobileTabSwitcher
+          items={MOBILE_TAB_ITEMS}
+          value={activeTab}
+          onChange={handleTabChange}
+        />
+      )}
+    </div>
+  );
+};
+
+export default StockDetailPage;


### PR DESCRIPTION
# [Fix] 주가 데이터 페이지 개선

## 📌 1. PR 요약
주가 데이터 페이지 컴포넌트 통합 과정에서 발견된 여백 및 정렬 이슈를 수정하고, 데스크톱·태블릿·모바일 해상도에 완벽하게 대응할 수 있도록 반응형 레이아웃 개선 및 검증용 Story를 추가했습니다.

## 🛠 2. 작업 내용
### 레이아웃 및 정렬 개선
- 페이지 내 단위 컴포넌트(StockTable, TickerAnimation 등) 조합 시 발생하던 컴포넌트 간 여백(Spacing) 및 정렬 틀어짐 문제를 수정했습니다.

### 반응형(Responsive) 레이아웃 대응
- 데스크톱, 태블릿, 모바일 등 다양한 기기 환경에서 레이아웃 깨짐 현상이 발생하지 않도록 CSS 및 컨테이너 구조를 개선하여 가독성을 확보했습니다.

### 반응형 Page Story 추가
- 모바일 및 태블릿 뷰포트에서의 레이아웃을 독립적으로 검증할 수 있도록 `StockDataPage`의 반응형 Story variant를 추가했습니다.

## 📸 3. 스크린샷
| `Tablet Layout View` | `Mobile Layout View` |
|:---:|:---:|
| <img width="924" height="862" alt="image" src="https://github.com/user-attachments/assets/1a18d4b5-8c86-4e60-828f-d4993d52c0bc" /> | <img width="361" height="624" alt="image" src="https://github.com/user-attachments/assets/e642ee94-3d04-4e6a-b597-305b2d7d95f6" /> |

## 📋 4. 파일 변경 목록
- `StockDataPage.tsx`: 컴포넌트 간 여백 및 정렬 이슈 수정, 기기별 해상도 대응을 위한 반응형 컨테이너 CSS 보완
- `StockDataPage.stories.tsx`: 태블릿 및 모바일 환경 레이아웃 검증을 위한 반응형 Story variant 추가

## 💬 5. 리뷰 포인트
- **반응형 레이아웃 해상도 대응**: 스크린샷을 통해 태블릿 및 모바일 뷰포트에서 테이블의 가로 폭이나 상단 탭이 화면 밖으로 넘치거나 깨지는 현상 없이 자연스럽게 렌더링되는지 확인해 주시기 바랍니다.
- **컴포넌트 간격 및 정렬**: 수정된 코드 렌더링 화면에서 페이지 내 각 단위 컴포넌트 사이의 여백이 디자인 시스템 가이드에 맞게 개선되었는지 시각적으로 검토 부탁드립니다.