### PR TITLE
[FEAT] 차트 데이터 서빙 API 개발

### DIFF
--- a/apps/server-stock/build.gradle
+++ b/apps/server-stock/build.gradle
@@ -22,4 +22,6 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	// Flyway PostgreSQL 전용 모듈
 	implementation 'org.flywaydb:flyway-database-postgresql'
+
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }

--- a/apps/server-stock/src/docs/asciidoc/index.adoc
+++ b/apps/server-stock/src/docs/asciidoc/index.adoc
@@ -45,3 +45,18 @@ include::{snippets}/stock-history/get-history-success/query-parameters.adoc[]
 ==== 응답 (Response)
 include::{snippets}/stock-history/get-history-success/http-response.adoc[]
 include::{snippets}/stock-history/get-history-success/response-fields.adoc[]
+
+== 3. 주식 차트 (Chart)
+
+=== 3-1. 특정 종목 차트 캔들 조회
+특정 종목의 과거 N분봉, N일봉 등의 캔들 데이터(시가, 고가, 저가, 종가, 거래량)를 조회합니다.
+차트의 초기 렌더링 및 과거 데이터 무한 스크롤(Paging) 목적으로 사용됩니다.
+
+==== 요청 (Request)
+include::{snippets}/chart-get-candles/http-request.adoc[]
+include::{snippets}/chart-get-candles/path-parameters.adoc[]
+include::{snippets}/chart-get-candles/query-parameters.adoc[]
+
+==== 응답 (Response)
+include::{snippets}/chart-get-candles/http-response.adoc[]
+include::{snippets}/chart-get-candles/response-fields.adoc[]

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/global/error/ErrorCode.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/global/error/ErrorCode.java
@@ -10,7 +10,10 @@ public enum ErrorCode {
 
     // Stock 에러
     INVALID_STOCK_PARAMETER(HttpStatus.BAD_REQUEST, "S001", "유효하지 않은 입력값 입니다."),
-    NOT_FOUND_STOCK(HttpStatus.NOT_FOUND, "S002", "주식 데이터를 찾을 수 없습니다.");
+    NOT_FOUND_STOCK(HttpStatus.NOT_FOUND, "S002", "주식 데이터를 찾을 수 없습니다."),
+
+    // Chart 에러
+    INVALID_CHART_PARAMETER(HttpStatus.BAD_REQUEST, "S003", "유효하지 않은 입력값 입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/config/JacksonConfig.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/config/JacksonConfig.java
@@ -3,6 +3,7 @@ package com.assetmind.server_stock.market_access.infrastructure.kis.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -21,6 +22,7 @@ public class JacksonConfig {
     @Bean
     public ObjectMapper objectMapper() {
         return JsonMapper.builder()
+                .addModule(new JavaTimeModule())
                 // JSON의 실수형(Float) 데이터를 무조건 BigDecimal로 역직렬화한다.
                 // (이유: 0.1 + 0.2 != 0.3 부동소수점 이슈 방지)
                 .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
@@ -1,11 +1,11 @@
 package com.assetmind.server_stock.stock.application;
 
 import com.assetmind.server_stock.global.error.ErrorCode;
-import com.assetmind.server_stock.stock.application.dto.ChartResponseDto;
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1dRepository;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1mRepository;
 import com.assetmind.server_stock.stock.exception.InvalidChartParameterException;
+import com.assetmind.server_stock.stock.presentation.dto.ChartResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
@@ -1,0 +1,91 @@
+package com.assetmind.server_stock.stock.application;
+
+import com.assetmind.server_stock.global.error.ErrorCode;
+import com.assetmind.server_stock.stock.application.dto.ChartResponseDto;
+import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
+import com.assetmind.server_stock.stock.domain.repository.Ohlcv1dRepository;
+import com.assetmind.server_stock.stock.domain.repository.Ohlcv1mRepository;
+import com.assetmind.server_stock.stock.exception.InvalidChartParameterException;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 프론트엔드 차트 렌더링을 위한 N분봉, N일/주/월/년봉 동적 서빙 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChartService {
+    private final Ohlcv1mRepository ohlcv1mRepository;
+    private final Ohlcv1dRepository ohlcv1dRepository;
+
+    public ChartResponseDto getCandles(String stockCode, String timeframe, LocalDateTime endTime, int limit) {
+        if (endTime == null) {
+            endTime = LocalDateTime.now();
+        }
+
+        log.info("[ChartService] 차트 조회 - 종목: {}, 타임프레임: {}, 기준시간: {}, 조회 요청 개수: {}", stockCode, timeframe, endTime, limit);
+
+        List<OhlcvDto> dtoList;
+
+        // 요청 받은 timeframe이 분봉(1m) 테이블로 갈지, 일봉(1d) 테이블로 갈지 결정
+        if (isMinuteTimeframe(timeframe)) {
+            String intervalString = getMinuteInterval(timeframe);
+            dtoList = ohlcv1mRepository.findDynamicMinuteCandles(stockCode, intervalString, endTime, limit);
+        } else {
+            dtoList = getOhlcvDtoBasedDailyCandles(stockCode, timeframe, endTime, limit);
+        }
+
+        List<ChartResponseDto.CandleDto> candleDtos = dtoList.stream()
+                .map(dto -> ChartResponseDto.CandleDto.builder()
+                        .timestamp(dto.candleTimestamp())
+                        .open(String.valueOf(dto.openPrice()))
+                        .high(String.valueOf(dto.highPrice()))
+                        .low(String.valueOf(dto.lowPrice()))
+                        .close(String.valueOf(dto.lowPrice()))
+                        .volume(String.valueOf(dto.volume()))
+                        .build()
+                ).toList();
+
+        return ChartResponseDto.builder()
+                .stockCode(stockCode)
+                .timeframe(timeframe)
+                .candles(candleDtos)
+                .build();
+    }
+
+    private boolean isMinuteTimeframe(String timeframe) {
+        return timeframe.endsWith("m") && !timeframe.endsWith("mo");
+    }
+
+    private String getMinuteInterval(String timeframe) {
+        return switch (timeframe.toLowerCase()) {
+            case "1m" -> "1 minute";
+            case "3m" -> "3 minute";
+            case "5m" -> "5 minute";
+            case "15m" -> "15 minute";
+            default -> throw new InvalidChartParameterException(ErrorCode.INVALID_CHART_PARAMETER, "지원하지 않는 분봉 타임프레임입니다.");
+        };
+    }
+
+    private List<OhlcvDto> getOhlcvDtoBasedDailyCandles(String stockCode, String timeframe, LocalDateTime endTime, int limit) {
+        return switch (timeframe.toLowerCase()) {
+            // 고정 길이 (date_bin 사용)
+            case "1d" -> ohlcv1dRepository.findDynamicDailyCandles(stockCode, "1 day", endTime, limit);
+            case "3d" -> ohlcv1dRepository.findDynamicDailyCandles(stockCode, "3 days", endTime, limit);
+            case "5d" -> ohlcv1dRepository.findDynamicDailyCandles(stockCode, "5 days", endTime, limit);
+            case "1w" -> ohlcv1dRepository.findDynamicDailyCandles(stockCode, "1 week", endTime, limit);
+
+            // 가변 길이 (date_trunc 사용)
+            case "1mo" -> ohlcv1dRepository.findMonthlyCandles(stockCode, endTime, limit);
+            case "1y" -> ohlcv1dRepository.findYearlyCandles(stockCode, endTime, limit);
+
+            default -> throw new InvalidChartParameterException(ErrorCode.INVALID_CHART_PARAMETER, "지원하지 않는 일/주/월/년봉 타임프레임입니다: ");
+        };
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
@@ -47,7 +47,7 @@ public class ChartService {
                         .open(String.valueOf(dto.openPrice()))
                         .high(String.valueOf(dto.highPrice()))
                         .low(String.valueOf(dto.lowPrice()))
-                        .close(String.valueOf(dto.lowPrice()))
+                        .close(String.valueOf(dto.closePrice()))
                         .volume(String.valueOf(dto.volume()))
                         .build()
                 ).toList();
@@ -66,9 +66,9 @@ public class ChartService {
     private String getMinuteInterval(String timeframe) {
         return switch (timeframe.toLowerCase()) {
             case "1m" -> "1 minute";
-            case "3m" -> "3 minute";
-            case "5m" -> "5 minute";
-            case "15m" -> "15 minute";
+            case "3m" -> "3 minutes";
+            case "5m" -> "5 minutes";
+            case "15m" -> "15 minutes";
             default -> throw new InvalidChartParameterException(ErrorCode.INVALID_CHART_PARAMETER, "지원하지 않는 분봉 타임프레임입니다.");
         };
     }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/dto/ChartResponseDto.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/dto/ChartResponseDto.java
@@ -1,0 +1,27 @@
+package com.assetmind.server_stock.stock.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * 프론트엔드 차트 렌더링을 위한 최종 API 응답 객체
+ */
+@Builder
+public record ChartResponseDto(
+        String stockCode,
+        String timeframe,
+        List<CandleDto> candles
+) {
+
+    @Builder
+    public record CandleDto(
+            LocalDateTime timestamp,
+            String open,
+            String high,
+            String low,
+            String close,
+            String volume
+    ) {
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/listener/StockTradeEventListener.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/listener/StockTradeEventListener.java
@@ -32,7 +32,7 @@ public class StockTradeEventListener {
         try {
             printEventLog(event);
 
-            // TODO: 비즈니스 로직 수행 (서비스 연동 하여 DB 저장)
+            // 실시간 데이터를 DB 저장
             stockService.processRealTimeTrade(event);
         } catch (Exception e) {
             // @Async가 적용된 비동기 메서드 이므로 메인 스레드로 예외가 전파되지 않음

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/Ohlcv1dRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/Ohlcv1dRepository.java
@@ -2,6 +2,7 @@ package com.assetmind.server_stock.stock.domain.repository;
 
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,10 +24,38 @@ public interface Ohlcv1dRepository {
     void save(OhlcvDto ohlcvDto);
 
     /**
-     * DB에 저장되어있는 1일봉 캔들 데이터를 조회한다.
+     * DB에 저장되어있는 1일봉 캔들(한개) 데이터를 조회한다.
      * 3일봉, 5일봉, 주봉, 월봉, 년봉 등등 롤업 계산에도 사용
      * @param stockCode 종목 코드
      * @param date 조회 날짜
      */
     Optional<OhlcvDto> findCandleByDay(String stockCode, LocalDate date);
+
+    /**
+     * DB에 저장되어있는 2000년 01월 01일 부터 EndTime 까지의 N일봉 데이터를 조회한다.
+     * @param stockCode 종목 코드
+     * @param intervalString 날짜의 간격(예: 3일봉 - 3 days, 1주봉 - 7 days)
+     * @param endTime N일봉을 조회하려는 기간의 마지막 날짜
+     * @param limit 조회하려는 데이터의 개수
+     * @return 캔들 데이터 DTO 리스트
+     */
+    List<OhlcvDto> findDynamicDailyCandles(String stockCode, String intervalString, LocalDateTime endTime, int limit);
+
+    /**
+     * DB에 저장되어있는 2000년 01월 01일 부터 현재까지의 N월봉 데이터를 조회한다.
+     * @param stockCode 종목 코드
+     * @param endTime N월봉을 조회하려는 기간의 마지막 날짜
+     * @param limit 조회하려는 데이터의 개수
+     * @return 캔들 데이터 DTO 리스트
+     */
+    List<OhlcvDto> findMonthlyCandles(String stockCode, LocalDateTime endTime, int limit);
+
+    /**
+     * DB에 저장되어있는 2000년 01월 01일 부터 현재까지의 N년봉 데이터를 조회한다.
+     * @param stockCode 종목 코드
+     * @param endTime N년봉을 조회하려는 기간의 마지막 날짜
+     * @param limit 조회하려는 데이터의 개수
+     * @return 캔들 데이터 DTO 리스트
+     */
+    List<OhlcvDto> findYearlyCandles(String stockCode, LocalDateTime endTime, int limit);
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/Ohlcv1mRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/Ohlcv1mRepository.java
@@ -2,6 +2,7 @@ package com.assetmind.server_stock.stock.domain.repository;
 
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -22,4 +23,14 @@ public interface Ohlcv1mRepository {
      * @return 해당 날짜의 1분봉 OHLCV DTO 리스트
      */
     List<OhlcvDto> findCandlesByDate(String stockCode, LocalDate date);
+
+    /**
+     * DB에서 2000년 01월 01일부터 EndTime 까지의 N분봉 데이터를 조회
+     * @param stockCode 종목 코드
+     * @param intervalString 시간 간격(3 minute, 5 minute ...)
+     * @param endTime 조회의 마지막 시점 시간
+     * @param limit 조회 요청 개수
+     * @return N분봉 OHLCV DTO 리스트
+     */
+    List<OhlcvDto> findDynamicMinuteCandles(String stockCode, String intervalString, LocalDateTime endTime, int limit);
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/exception/InvalidChartParameterException.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/exception/InvalidChartParameterException.java
@@ -1,0 +1,10 @@
+package com.assetmind.server_stock.stock.exception;
+
+import com.assetmind.server_stock.global.error.BusinessException;
+import com.assetmind.server_stock.global.error.ErrorCode;
+
+public class InvalidChartParameterException extends BusinessException {
+    public InvalidChartParameterException(ErrorCode errorCode, String message) {
+        super(message, errorCode);
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/RawTickJpaEntity.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/RawTickJpaEntity.java
@@ -1,10 +1,10 @@
 package com.assetmind.server_stock.stock.infrastructure.persistence.entity;
 
-import com.assetmind.server_stock.stock.infrastructure.persistence.entity.keys.TickId;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -15,14 +15,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "raw_tick")
-@IdClass(TickId.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RawTickJpaEntity {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     @Column(name = "stock_code", nullable = false, length = 20)
     private String stockCode;
 
-    @Id
     @Column(name = "trade_timestamp", nullable = false)
     private LocalDateTime tradeTimestamp;
 

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/projection/ChartCandleProjection.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/entity/projection/ChartCandleProjection.java
@@ -1,0 +1,18 @@
+package com.assetmind.server_stock.stock.infrastructure.persistence.entity.projection;
+
+import java.time.LocalDateTime;
+
+/**
+ * JPA Native 동적 쿼리에 대한 집계 결과 값을 객체로 받기 위한 인터페이스
+ *
+ * Spring Data Jpa가 해당 인터페이스를 동적 프록시 방법으로 내부적으로 가짜 객체를 생성해낸다.
+ */
+public interface ChartCandleProjection {
+    LocalDateTime getCandleTimestamp();
+    Double getOpen();
+    Double getHigh();
+    Double getLow();
+    Double getClose();
+    Long getVolume();
+
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaAdapter.java
@@ -3,6 +3,7 @@ package com.assetmind.server_stock.stock.infrastructure.persistence.jpa;
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1dRepository;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1dJpaEntity;
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.projection.ChartCandleProjection;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -47,6 +48,31 @@ public class Ohlcv1dJpaAdapter implements Ohlcv1dRepository {
                 .map(this::toDto);
     }
 
+    @Override
+    public List<OhlcvDto> findDynamicDailyCandles(String stockCode, String intervalString,
+            LocalDateTime endTime, int limit) {
+        return ohlcv1dJpaRepository.findDynamicDailyCandles(stockCode, intervalString, endTime, limit)
+                .stream()
+                .map(projection -> toDto(stockCode, projection))
+                .toList();
+    }
+
+    @Override
+    public List<OhlcvDto> findMonthlyCandles(String stockCode, LocalDateTime endTime, int limit) {
+        return ohlcv1dJpaRepository.findMonthlyCandles(stockCode, endTime, limit)
+                .stream()
+                .map(projection -> toDto(stockCode, projection))
+                .toList();
+    }
+
+    @Override
+    public List<OhlcvDto> findYearlyCandles(String stockCode, LocalDateTime endTime, int limit) {
+        return ohlcv1dJpaRepository.findYearlyCandles(stockCode, endTime, limit)
+                .stream()
+                .map(projection -> toDto(stockCode, projection))
+                .toList();
+    }
+
     private Ohlcv1dJpaEntity toEntity(OhlcvDto dto) {
         return Ohlcv1dJpaEntity.builder()
                 .stockCode(dto.stockCode())
@@ -68,6 +94,18 @@ public class Ohlcv1dJpaAdapter implements Ohlcv1dRepository {
                 entity.getLowPrice(),
                 entity.getClosePrice(),
                 entity.getVolume()
+        );
+    }
+
+    private OhlcvDto toDto(String stockCode, ChartCandleProjection projection) {
+        return new OhlcvDto(
+                stockCode,
+                projection.getCandleTimestamp(),
+                projection.getOpen(),
+                projection.getHigh(),
+                projection.getLow(),
+                projection.getClose(),
+                projection.getVolume()
         );
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaRepository.java
@@ -2,7 +2,9 @@ package com.assetmind.server_stock.stock.infrastructure.persistence.jpa;
 
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1dJpaEntity;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.keys.OhlcvId;
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.projection.ChartCandleProjection;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,6 +12,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface Ohlcv1dJpaRepository extends JpaRepository<Ohlcv1dJpaEntity, OhlcvId> {
 
+    /**
+     * 특정 주식의 지정된 날짜 범위(예: 하루 전체)에 해당하는 1일봉 단건을 조회한다.
+     */
     @Query("SELECT o FROM Ohlcv1dJpaEntity o"
             + " WHERE o.stockCode = :stockCode"
             + " AND o.candleTimestamp >= :startDay"
@@ -19,4 +24,81 @@ public interface Ohlcv1dJpaRepository extends JpaRepository<Ohlcv1dJpaEntity, Oh
             @Param("startDay") LocalDateTime startDay,
             @Param("endDay") LocalDateTime endDay
     );
+
+    /**
+     * 고정 길이 롤업 - N일봉, N주봉 캔들을 동적으로 집계한다.
+     * date_bin() 함수를 사용하여 3일, 1주 등 고정된 절대 시간을 기준으로 그룹을 나누고,
+     * 해당 그룹 안에서 첫 번째 값을 시가(Open), 마지막 값을 종가(Close)로 추출한다.
+     */
+    @Query(value = """
+        SELECT
+            date_bin(CAST(:intervalString AS interval), candle_timestamp, TIMESTAMP '2000-01-01') AS candleTimestamp,
+            (array_agg(open_price ORDER BY candle_timestamp ASC))[1] AS open,
+            MAX(high_price) AS high,
+            MIN(low_price) AS low,
+            (array_agg(close_price ORDER BY candle_timestamp DESC))[1] AS close,
+            SUM(volume) AS volume
+        FROM ohlcv_1d
+        WHERE stock_code = :stockCode AND candle_timestamp <= :endTime
+        GROUP BY candleTimestamp
+        ORDER BY candleTimestamp DESC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<ChartCandleProjection> findDynamicDailyCandles(
+            @Param("stockCode") String stockCode,
+            @Param("intervalString") String intervalString,
+            @Param("endTime") LocalDateTime endTime,
+            @Param("limit") int limit
+    );
+
+    /**
+     * 가변 길이 롤업 - 1월봉 캔들을 동적으로 집계한다.
+     * 월마다 일수(28~31일)가 다르기 때문에 date_bin 대신 date_trunc('month')를 사용하여
+     * 일수를 모두 잘라내고 해당 월의 1일 기준으로 바구니를 묶어 OHLCV를 추출한다.
+     */
+    @Query(value = """
+        SELECT
+            date_trunc('month', candle_timestamp) AS candleTimestamp,
+            (array_agg(open_price ORDER BY candle_timestamp ASC))[1] AS open,
+            MAX(high_price) AS high,
+            MIN(low_price) AS low,
+            (array_agg(close_price ORDER BY candle_timestamp DESC))[1] AS close,
+            SUM(volume) AS volume
+        FROM ohlcv_1d
+        WHERE stock_code = :stockCode AND candle_timestamp <= :endTime
+        GROUP BY candleTimestamp
+        ORDER BY candleTimestamp DESC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<ChartCandleProjection> findMonthlyCandles(
+            @Param("stockCode") String stockCode,
+            @Param("endTime") LocalDateTime endTime,
+            @Param("limit") int limit
+    );
+
+    /**
+     * 가변 길이 롤업 - 1년봉 캔들을 동적으로 집계한다.
+     * 윤년(366일)과 평년(365일)의 차이를 무시하기 위해 date_trunc('year')를 사용하여
+     * 월과 일을 모두 잘라내고 해당 연도의 1월 1일 기준으로 바구니를 묶어 OHLCV를 추출한다.
+     */
+    @Query(value = """
+        SELECT
+            date_trunc('year', candle_timestamp) AS candleTimestamp,
+            (array_agg(open_price ORDER BY candle_timestamp ASC))[1] AS open,
+            MAX(high_price) AS high,
+            MIN(low_price) AS low,
+            (array_agg(close_price ORDER BY candle_timestamp DESC))[1] AS close,
+            SUM(volume) AS volume
+        FROM ohlcv_1d
+        WHERE stock_code = :stockCode AND candle_timestamp <= :endTime
+        GROUP BY candleTimestamp
+        ORDER BY candleTimestamp DESC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<ChartCandleProjection> findYearlyCandles(
+            @Param("stockCode") String stockCode,
+            @Param("endTime") LocalDateTime endTime,
+            @Param("limit") int limit
+    );
+
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
@@ -6,7 +6,10 @@ import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1mJpaEntity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -38,7 +41,18 @@ public class Ohlcv1mJpaAdapter implements Ohlcv1mRepository {
                         .build()
                 ).toList();
 
-        ohlcv1mJpaRepository.saveAll(entities);
+        // 리스트 내부에 식별자가 같은 데이터가 있다면 최산 값으로 덮어씀
+        Map<String, Ohlcv1mJpaEntity> deduplicatedMap = entities.stream()
+                .collect(Collectors.toMap(
+                        entity -> entity.getStockCode() + "_" + entity.getCandleTimestamp()
+                                .toString(),
+                        entity -> entity,
+                        (existing, replacement) -> replacement
+                ));
+
+        Collection<Ohlcv1mJpaEntity> uniqueEntities = deduplicatedMap.values();
+
+        ohlcv1mJpaRepository.saveAll(uniqueEntities);
     }
 
     @Override

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
@@ -4,6 +4,7 @@ import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1mRepository;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1dJpaEntity;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1mJpaEntity;
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.projection.ChartCandleProjection;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -68,6 +69,16 @@ public class Ohlcv1mJpaAdapter implements Ohlcv1mRepository {
                 .toList();
     }
 
+    @Override
+    public List<OhlcvDto> findDynamicMinuteCandles(String stockCode, String intervalString,
+            LocalDateTime endTime, int limit) {
+        return ohlcv1mJpaRepository.findDynamicMinuteCandles(stockCode, intervalString, endTime, limit)
+                .stream()
+                .map(projection -> toDto(stockCode, projection))
+                .toList();
+
+    }
+
     private OhlcvDto toDto(Ohlcv1mJpaEntity entity) {
         return new OhlcvDto(
                 entity.getStockCode(),
@@ -77,6 +88,18 @@ public class Ohlcv1mJpaAdapter implements Ohlcv1mRepository {
                 entity.getLowPrice(),
                 entity.getClosePrice(),
                 entity.getVolume()
+        );
+    }
+
+    private OhlcvDto toDto(String stockCode, ChartCandleProjection projection) {
+        return new OhlcvDto(
+                stockCode,
+                projection.getCandleTimestamp(),
+                projection.getOpen(),
+                projection.getHigh(),
+                projection.getLow(),
+                projection.getClose(),
+                projection.getVolume()
         );
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaRepository.java
@@ -2,6 +2,7 @@ package com.assetmind.server_stock.stock.infrastructure.persistence.jpa;
 
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1mJpaEntity;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.keys.OhlcvId;
+import com.assetmind.server_stock.stock.infrastructure.persistence.entity.projection.ChartCandleProjection;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,5 +23,26 @@ public interface Ohlcv1mJpaRepository extends JpaRepository<Ohlcv1mJpaEntity, Oh
             @Param("stockCode") String stockCode,
             @Param("startTime") LocalDateTime startTime,
             @Param("endTime") LocalDateTime endTime
+    );
+
+    @Query(value = """
+          SELECT 
+              date_bin(CAST(:intervalString AS INTERVAL), candle_timestamp, TIMESTAMP '2000-01-01') AS candleTimestamp,
+              (array_agg(open_price ORDER BY candle_timestamp ASC))[1] AS open,
+              MAX(high_price) AS high,
+              MIN(low_price) AS low,
+              (array_agg(close_price ORDER BY candle_timestamp DESC ))[1] AS close,
+              SUM(volume) AS volume
+          FROM ohlcv_1m
+          WHERE stock_code = :stockCode AND candle_timestamp <= :endTime
+          GROUP BY candleTimestamp
+          ORDER BY candleTimestamp DESC
+          LIMIT :limit
+        """, nativeQuery = true)
+    List<ChartCandleProjection> findDynamicMinuteCandles(
+            @Param("stockCode") String stockCode,
+            @Param("intervalString") String intervalString,
+            @Param("endTime") LocalDateTime endTime,
+            @Param("limit") int limit
     );
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/ChartController.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/ChartController.java
@@ -1,0 +1,44 @@
+package com.assetmind.server_stock.stock.presentation;
+
+import com.assetmind.server_stock.global.common.ApiResponse;
+import com.assetmind.server_stock.stock.application.ChartService;
+import com.assetmind.server_stock.stock.presentation.dto.ChartRequestDto;
+import com.assetmind.server_stock.stock.presentation.dto.ChartResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 프론트엔드 차트 렌더링을 위한 REST API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stocks")
+public class ChartController {
+
+    private final ChartService chartService;
+
+    /**
+     * 특정 종목의 차트 캔들 데이터를 조회
+     * @param stockCode 조회할 종목 코드
+     * @param dto       특정 종목 차트 캔들 조회 요청 DTO
+     */
+    @GetMapping("/{stockCode}/charts/candles")
+    public ApiResponse<ChartResponseDto> getCandles(
+            @PathVariable String stockCode,
+            @Valid @ModelAttribute ChartRequestDto dto
+    ) {
+        log.info("[ChartController] 캔들 조회 요청 - 종목: {}, 타임프레임: {}, Limit: {}, 기준시간: {}",
+                stockCode, dto.timeframe(), dto.limit(), dto.endTime());
+
+        ChartResponseDto response = chartService.getCandles(stockCode, dto.timeframe(), dto.endTime(), dto.limit());
+
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/ChartRequestDto.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/ChartRequestDto.java
@@ -1,0 +1,29 @@
+package com.assetmind.server_stock.stock.presentation.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+
+/**
+ * 특정 종목 차트 캔들 조회 요청 DTO
+ * @param timeframe 타임프레임 (예: 1m, 5m, 1d, 1w, 1mo)
+ * @param limit     조회할 캔들 개수 (기본값: 200)
+ * @param endTime   조회 기준 시간 (과거 스크롤 시 전달, 미전달 시 현재 시간 기준)
+ */
+public record ChartRequestDto(
+        @NotBlank(message = "타임프레임(timeframe)은 필수입니다. (예: 1m, 1d)")
+        String timeframe,
+
+        @Min(value = 1, message = "조회 개수는 최소 1개 이상이어야 합니다.")
+        Integer limit,
+
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        LocalDateTime endTime
+) {
+    public ChartRequestDto {
+        if (limit == null) {
+            limit = 200;
+        }
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/ChartResponseDto.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/ChartResponseDto.java
@@ -1,4 +1,4 @@
-package com.assetmind.server_stock.stock.application.dto;
+package com.assetmind.server_stock.stock.presentation.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/ChartResponseDto.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/ChartResponseDto.java
@@ -1,5 +1,6 @@
 package com.assetmind.server_stock.stock.presentation.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
@@ -16,6 +17,7 @@ public record ChartResponseDto(
 
     @Builder
     public record CandleDto(
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
             LocalDateTime timestamp,
             String open,
             String high,

--- a/apps/server-stock/src/main/resources/db/migration/V2__init_trading_tables.sql
+++ b/apps/server-stock/src/main/resources/db/migration/V2__init_trading_tables.sql
@@ -10,11 +10,14 @@ CREATE TABLE IF NOT EXISTS stock_meta_data (
 
 -- 실시간 체결 데이터 파티셔닝 테이블(부모 테이블) 생성
 CREATE TABLE raw_tick (
+    id BIGSERIAL,
     stock_code VARCHAR(20) NOT NULL,
-    current_price INTEGER NOT NULL,
-    price_change INTEGER NOT NULL,
-    volume INTEGER NOT NULL,
-    trade_timestamp TIMESTAMPTZ NOT NULL
+    current_price DOUBLE PRECISION NOT NULL,
+    price_change DOUBLE PRECISION NOT NULL,
+    volume BIGINT NOT NULL,
+    trade_timestamp TIMESTAMP NOT NULL,
+
+    PRIMARY KEY (id, trade_timestamp)
 ) PARTITION BY RANGE (trade_timestamp);
 
 CREATE INDEX idx_raw_tick_stock_time ON raw_tick (stock_code, trade_timestamp DESC);

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/ChartServiceTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/ChartServiceTest.java
@@ -8,11 +8,11 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.assetmind.server_stock.stock.application.dto.ChartResponseDto;
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1dRepository;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1mRepository;
 import com.assetmind.server_stock.stock.exception.InvalidChartParameterException;
+import com.assetmind.server_stock.stock.presentation.dto.ChartResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/ChartServiceTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/ChartServiceTest.java
@@ -1,0 +1,165 @@
+package com.assetmind.server_stock.stock.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.assetmind.server_stock.stock.application.dto.ChartResponseDto;
+import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
+import com.assetmind.server_stock.stock.domain.repository.Ohlcv1dRepository;
+import com.assetmind.server_stock.stock.domain.repository.Ohlcv1mRepository;
+import com.assetmind.server_stock.stock.exception.InvalidChartParameterException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChartServiceTest {
+
+    @Mock
+    private Ohlcv1mRepository ohlcv1mRepository;
+
+    @Mock
+    private Ohlcv1dRepository ohlcv1dRepository;
+
+    @InjectMocks
+    private ChartService chartService;
+
+    private final String STOCK_CODE = "005930";
+    private final int LIMIT = 10;
+    private final LocalDateTime END_TIME = LocalDateTime.of(2026, 4, 1, 12, 0);
+
+    @Test
+    @DisplayName("endTime이 null일 경우 현재 시간(now)을 기준으로 조회한다.")
+    void givenEndTimeIsNull_whenGetCandles_thenQueryEndTimeNow() {
+        // given
+        when(ohlcv1mRepository.findDynamicMinuteCandles(any(), any(), any(), anyInt()))
+                .thenReturn(List.of());
+
+        // when
+        chartService.getCandles(STOCK_CODE, "1m", null, LIMIT);
+
+        // then
+        // findDynamicMinuteCandles의 3번째 인자로 LocalDateTime이 전달되었는지 확인
+        verify(ohlcv1mRepository).findDynamicMinuteCandles(eq(STOCK_CODE), any(), any(LocalDateTime.class), eq(LIMIT));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1m, 1 minute",
+            "3m, 3 minutes",
+            "5m, 5 minutes",
+            "15m, 15 minutes",
+    })
+    @DisplayName("다양한 분봉 타임프레임 요청 시 1분봉 레포지토리의 정확한 interval로 라우팅된다.")
+    void givenNMinutes_whenGetCandles_thenRoutingCollectInterval(String timeframe, String expectedInterval) {
+        // given
+        when(ohlcv1mRepository.findDynamicMinuteCandles(any(), any(), any(), anyInt()))
+                .thenReturn(List.of());
+
+        // when
+        chartService.getCandles(STOCK_CODE, timeframe, END_TIME, LIMIT);
+
+        // then
+        verify(ohlcv1mRepository).findDynamicMinuteCandles(STOCK_CODE, expectedInterval, END_TIME, LIMIT);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1d, 1 day",
+            "3d, 3 days",
+            "5d, 5 days",
+            "1w, 1 week"
+    })
+    @DisplayName("일/주봉 타임프레임 요청 시 1일봉 레포지토리의 고정 간격 메서드로 라우팅된다.")
+    void givenNDays_whenGetCandles_thenRoutingCollectInterval(String timeframe, String expectedInterval) {
+        // given
+        when(ohlcv1dRepository.findDynamicDailyCandles(any(), any(), any(), anyInt()))
+                .thenReturn(List.of());
+
+        // when
+        chartService.getCandles(STOCK_CODE, timeframe, END_TIME, LIMIT);
+
+        // then
+        verify(ohlcv1dRepository).findDynamicDailyCandles(STOCK_CODE, expectedInterval, END_TIME, LIMIT);
+    }
+
+    @Test
+    @DisplayName("1mo(월봉) 요청 시 1일봉 레포지토리의 findMonthlyCandles 메서드로 라우팅된다.")
+    void given1MonthTimeframe_whenGetCandles_thenRoutingCollectInterval() {
+        // given
+        when(ohlcv1dRepository.findMonthlyCandles(any(), any(), anyInt()))
+                .thenReturn(List.of());
+
+        // when
+        chartService.getCandles(STOCK_CODE, "1mo", END_TIME, LIMIT);
+
+        // then
+        verify(ohlcv1dRepository).findMonthlyCandles(STOCK_CODE, END_TIME, LIMIT);
+    }
+
+    @Test
+    @DisplayName("1y(년봉) 요청 시 1일봉 레포지토리의 findYearlyCandles 메서드로 라우팅된다.")
+    void given1YearTimeframe_whenGetCandles_thenRoutingCollectInterval() {
+        // given
+        when(ohlcv1dRepository.findYearlyCandles(any(), any(), anyInt()))
+                .thenReturn(List.of());
+
+        // when
+        chartService.getCandles(STOCK_CODE, "1y", END_TIME, LIMIT);
+
+        // then
+        verify(ohlcv1dRepository).findYearlyCandles(STOCK_CODE, END_TIME, LIMIT);
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 잘못된 타임프레임(분봉) 요청 시 InvalidChartParameterException 발생한다.")
+    void givenInvalidMinutesTimeframe_whenGetCandles_thenThrowException() {
+        // then & when
+        assertThatThrownBy(() -> chartService.getCandles(STOCK_CODE, "23m", END_TIME, LIMIT))
+                .isInstanceOf(InvalidChartParameterException.class)
+                .hasMessageContaining("지원하지 않는 분봉");
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 잘못된 타임프레임(일/주/월/년봉) 요청 시 InvalidChartParameterException 발생한다.")
+    void givenInvalidTimeframe_whenGetCandles_thenThrowException() {
+        // then & when
+        assertThatThrownBy(() -> chartService.getCandles(STOCK_CODE, "99h", END_TIME, LIMIT))
+                .isInstanceOf(InvalidChartParameterException.class)
+                .hasMessageContaining("지원하지 않는 일/주/월/년봉");
+    }
+
+    @Test
+    @DisplayName("조회된 OhlcvDto가 ChartResponseDto.CandleDto로 누락 없이 매핑된다.")
+    void givenValidParameters_whenGetCandles_thenReturnResponse() {
+        // given
+        OhlcvDto mockDto = new OhlcvDto(STOCK_CODE, END_TIME, 100.0, 150.0, 90.0, 120.0, 1000L);
+        when(ohlcv1mRepository.findDynamicMinuteCandles(any(), any(), any(), anyInt()))
+                .thenReturn(List.of(mockDto));
+
+        // when
+        ChartResponseDto response = chartService.getCandles(STOCK_CODE, "1m", END_TIME, LIMIT);
+
+        // then
+        assertThat(response.candles()).hasSize(1);
+        ChartResponseDto.CandleDto candle = response.candles().get(0);
+        assertThat(candle.timestamp()).isEqualTo(END_TIME);
+        assertThat(candle.open()).isEqualTo("100.0");
+        assertThat(candle.high()).isEqualTo("150.0");
+        assertThat(candle.low()).isEqualTo("90.0");
+        assertThat(candle.close()).isEqualTo("120.0");
+        assertThat(candle.volume()).isEqualTo("1000");
+    }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/StockServiceTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/StockServiceTest.java
@@ -14,6 +14,8 @@ import com.assetmind.server_stock.stock.application.event.StockRankingUpdatedEve
 import com.assetmind.server_stock.stock.application.listener.dto.RealTimeStockTradeEvent;
 import com.assetmind.server_stock.stock.application.mapper.StockMapper;
 import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
+import com.assetmind.server_stock.stock.domain.enums.CandleType;
+import com.assetmind.server_stock.stock.domain.repository.CandleRepository;
 import com.assetmind.server_stock.stock.domain.repository.RawTickRepository;
 import com.assetmind.server_stock.stock.domain.repository.StockSnapshotRepository;
 import com.assetmind.server_stock.stock.exception.StockNotFoundException;
@@ -34,6 +36,9 @@ import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class StockServiceTest {
+
+    @Mock
+    private CandleRepository candleRepository;
 
     @Mock
     private StockSnapshotRepository stockSnapshotRepository;
@@ -104,6 +109,10 @@ class StockServiceTest {
             // 2개의 이벤트(History, Ranking) 발행 확인
             verify(eventPublisher, times(1)).publishEvent(any(StockHistorySavedEvent.class));
             verify(eventPublisher, times(1)).publishEvent(any(StockRankingUpdatedEvent.class));
+
+            // 1분봉 캐싱 호출 확인
+            verify(candleRepository, times(1)).save(any(RealTimeStockTradeEvent.class), any(
+                    CandleType.class));
         }
 
         @Test

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaAdapterTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1dJpaAdapterTest.java
@@ -101,4 +101,97 @@ class Ohlcv1dJpaAdapterTest {
         // Then
         assertThat(result).isEmpty();
     }
+
+    @Test
+    @DisplayName("N일봉 동적 집계: 기간 내의 1일봉들이 정확한 OHLCV(시/고/저/종/거래량)로 롤업된다.")
+    void givenDailyCandles_whenFindDynamicDailyCandles_thenAggregatedCorrectly() {
+        // Given: 2000년 1월 1일 ~ 1월 3일 (3일간의 데이터)
+        String stockCode = "005930";
+        ohlcv1dJpaAdapter.saveAll(List.of(
+                // 1일차: 시가 100, 고가 120, 저가 90, 종가 110, 거래량 10
+                new OhlcvDto(stockCode, LocalDateTime.of(2000, 1, 1, 0, 0), 100.0, 120.0, 90.0, 110.0, 10L),
+                // 2일차: 시가 110, 고가 150, 저가 100, 종가 140, 거래량 20 (최고가 150 갱신)
+                new OhlcvDto(stockCode, LocalDateTime.of(2000, 1, 2, 0, 0), 110.0, 150.0, 100.0, 140.0, 20L),
+                // 3일차: 시가 140, 고가 160, 저가 80, 종가 155, 거래량 30 (최저가 80 갱신, 최종 종가 155)
+                new OhlcvDto(stockCode, LocalDateTime.of(2000, 1, 3, 0, 0), 140.0, 160.0, 80.0, 155.0, 30L)
+        ));
+
+        // When: 3 days 간격으로 집계 요청 (Limit 10)
+        LocalDateTime endTime = LocalDateTime.of(2026, 4, 4, 0, 0);
+        List<OhlcvDto> result = ohlcv1dJpaAdapter.findDynamicDailyCandles(stockCode, "3 days", endTime, 10);
+
+        // Then
+        assertThat(result).isNotEmpty();
+        OhlcvDto aggregatedDto = result.getFirst(); // 3일 치가 하나의 캔들로 묶임
+
+        // OHLCV 연산 검증
+        assertThat(aggregatedDto.openPrice()).isEqualTo(100.0);   // 첫 날의 시가
+        assertThat(aggregatedDto.highPrice()).isEqualTo(160.0);   // 3일 중 최고가
+        assertThat(aggregatedDto.lowPrice()).isEqualTo(80.0);     // 3일 중 최저가
+        assertThat(aggregatedDto.closePrice()).isEqualTo(155.0);  // 마지막 날의 종가
+        assertThat(aggregatedDto.volume()).isEqualTo(60L);        // 거래량 총합 (10 + 20 + 30)
+    }
+
+    @Test
+    @DisplayName("월봉 집계(date_trunc): 여러 달에 걸친 데이터가 각 월별 1일 기준으로 분리되어 집계된다.")
+    void givenCandlesAcrossMonths_whenFindMonthlyCandles_thenGroupedByMonth() {
+        // Given: 3월 데이터 2개, 4월 데이터 1개
+        String stockCode = "005930";
+        ohlcv1dJpaAdapter.saveAll(List.of(
+                // 3월 데이터 (3월 15일, 3월 25일)
+                new OhlcvDto(stockCode, LocalDateTime.of(2026, 3, 15, 0, 0), 100.0, 150.0, 90.0, 140.0, 10L),
+                new OhlcvDto(stockCode, LocalDateTime.of(2026, 3, 25, 0, 0), 140.0, 180.0, 130.0, 170.0, 20L),
+                // 4월 데이터 (4월 5일)
+                new OhlcvDto(stockCode, LocalDateTime.of(2026, 4, 5, 0, 0), 170.0, 200.0, 160.0, 190.0, 30L)
+        ));
+
+        LocalDateTime endTime = LocalDateTime.of(2026, 4, 30, 0, 0);
+
+        // When: 월봉 조회
+        List<OhlcvDto> result = ohlcv1dJpaAdapter.findMonthlyCandles(stockCode, endTime, 10);
+
+        // Then: 4월(최신) 1개, 3월(과거) 1개 -> 총 2개의 월봉이 나와야 함 (DESC 정렬)
+        assertThat(result).hasSize(2);
+
+        // 첫 번째 결과 (최신인 4월봉)
+        assertThat(result.get(0).candleTimestamp()).isEqualTo(LocalDateTime.of(2026, 4, 1, 0, 0)); // 4월 1일로 버림(trunc)됨
+        assertThat(result.get(0).closePrice()).isEqualTo(190.0);
+        assertThat(result.get(0).volume()).isEqualTo(30L);
+
+        // 두 번째 결과 (과거인 3월봉) - 3월 데이터 2개가 하나로 합쳐짐
+        assertThat(result.get(1).candleTimestamp()).isEqualTo(LocalDateTime.of(2026, 3, 1, 0, 0)); // 3월 1일로 버림(trunc)됨
+        assertThat(result.get(1).openPrice()).isEqualTo(100.0); // 3/15의 시가
+        assertThat(result.get(1).closePrice()).isEqualTo(170.0); // 3/25의 종가
+        assertThat(result.get(1).highPrice()).isEqualTo(180.0); // 3월 중 최고가
+        assertThat(result.get(1).volume()).isEqualTo(30L); // 10 + 20
+    }
+
+    @Test
+    @DisplayName("년봉 집계(date_trunc): 해가 바뀌는 데이터가 연도별 1월 1일 기준으로 정확히 분리된다.")
+    void givenCandlesAcrossYears_whenFindYearlyCandles_thenGroupedByYear() {
+        // Given: 2025년 데이터 1개, 2026년 데이터 1개
+        String stockCode = "005930";
+        ohlcv1dJpaAdapter.saveAll(List.of(
+                // 2025년 연말
+                new OhlcvDto(stockCode, LocalDateTime.of(2025, 12, 31, 0, 0), 50000.0, 55000.0, 49000.0, 54000.0, 100L),
+                // 2026년 연초
+                new OhlcvDto(stockCode, LocalDateTime.of(2026, 1, 2, 0, 0), 54000.0, 60000.0, 53000.0, 59000.0, 200L)
+        ));
+
+        LocalDateTime endTime = LocalDateTime.of(2026, 12, 31, 0, 0);
+
+        // When: 년봉 조회
+        List<OhlcvDto> result = ohlcv1dJpaAdapter.findYearlyCandles(stockCode, endTime, 10);
+
+        // Then: 2026년 봉, 2025년 봉 총 2개가 DESC 순서로 반환되어야 함
+        assertThat(result).hasSize(2);
+
+        // 첫 번째 (최신 2026년봉)
+        assertThat(result.get(0).candleTimestamp()).isEqualTo(LocalDateTime.of(2026, 1, 1, 0, 0)); // 2026-01-01로 묶임
+        assertThat(result.get(0).closePrice()).isEqualTo(59000.0);
+
+        // 두 번째 (과거 2025년봉)
+        assertThat(result.get(1).candleTimestamp()).isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0)); // 2025-01-01로 묶임
+        assertThat(result.get(1).closePrice()).isEqualTo(54000.0);
+    }
 }

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapterTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapterTest.java
@@ -94,4 +94,47 @@ class Ohlcv1mJpaAdapterTest {
                         LocalDateTime.of(2026, 3, 30, 15, 30)
                 );
     }
+
+    @Test
+    @DisplayName("N분봉 동적 집계: 1분봉들이 지정된 N분 간격으로 정확한 OHLCV(시/고/저/종/거래량)로 롤업된다.")
+    void givenMinuteCandles_whenFindDynamicMinuteCandles_thenAggregatedCorrectly() {
+        // Given: date_bin의 기준점(2000-01-01 00:00:00)에 3분 치 1분봉 데이터를 넣는다
+        String stockCode = "005930";
+        ohlcv1mJpaAdapter.saveAll(List.of(
+                // 1분차 (00:00): 시가 100, 고가 120, 저가 90, 종가 110, 거래량 10
+                new OhlcvDto(stockCode, LocalDateTime.of(2000, 1, 1, 0, 0), 100.0, 120.0, 90.0, 110.0, 10L),
+                // 2분차 (00:01): 시가 110, 고가 150, 저가 100, 종가 140, 거래량 20
+                new OhlcvDto(stockCode, LocalDateTime.of(2000, 1, 1, 0, 1), 110.0, 150.0, 100.0, 140.0, 20L),
+                // 3분차 (00:02): 시가 140, 고가 160, 저가 80, 종가 155, 거래량 30
+                new OhlcvDto(stockCode, LocalDateTime.of(2000, 1, 1, 0, 2), 140.0, 160.0, 80.0, 155.0, 30L),
+
+                // 다음 바구니(Bin) 데이터 (00:03 ~ 00:05 구간) - 집계가 따로 묶이는지 확인용 데이터
+                new OhlcvDto(stockCode, LocalDateTime.of(2000, 1, 1, 0, 3), 155.0, 170.0, 150.0, 165.0, 40L)
+        ));
+
+        // When: '3 minutes' 간격으로 집계 요청 (Limit 10)
+        // endTime을 00:04로 주어서 첫 번째 바구니(00:00~00:02)와 두 번째 바구니 일부(00:03)가 조회되도록 함
+        LocalDateTime endTime = LocalDateTime.of(2000, 1, 1, 0, 4);
+        List<OhlcvDto> result = ohlcv1mJpaAdapter.findDynamicMinuteCandles(stockCode, "3 minutes", endTime, 10);
+
+        // Then: 2개의 바구니(3분봉 2개)가 최신순(DESC)으로 조회되어야 함
+        assertThat(result).hasSize(2);
+
+        // 첫 번째 결과 (최신 바구니: 00:03 ~ 00:05 구간) -> 00:03 데이터 1개만 있음
+        OhlcvDto latestAggregatedDto = result.get(0);
+        assertThat(latestAggregatedDto.candleTimestamp()).isEqualTo(LocalDateTime.of(2000, 1, 1, 0, 3));
+        assertThat(latestAggregatedDto.closePrice()).isEqualTo(165.0);
+        assertThat(latestAggregatedDto.volume()).isEqualTo(40L);
+
+        // 두 번째 결과 (과거 바구니: 00:00 ~ 00:02 구간) -> 3개의 1분봉이 완벽하게 롤업되어야 함
+        OhlcvDto pastAggregatedDto = result.get(1);
+        assertThat(pastAggregatedDto.candleTimestamp()).isEqualTo(LocalDateTime.of(2000, 1, 1, 0, 0));
+
+        // OHLCV 롤업 로직 상세 검증
+        assertThat(pastAggregatedDto.openPrice()).isEqualTo(100.0);   // 첫 분(00:00)의 시가
+        assertThat(pastAggregatedDto.highPrice()).isEqualTo(160.0);   // 3분 중 최고가
+        assertThat(pastAggregatedDto.lowPrice()).isEqualTo(80.0);     // 3분 중 최저가
+        assertThat(pastAggregatedDto.closePrice()).isEqualTo(155.0);  // 마지막 분(00:02)의 종가
+        assertThat(pastAggregatedDto.volume()).isEqualTo(60L);        // 거래량 총합 (10 + 20 + 30)
+    }
 }

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/ChartControllerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/ChartControllerTest.java
@@ -1,0 +1,140 @@
+package com.assetmind.server_stock.stock.presentation;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.assetmind.server_stock.stock.application.ChartService;
+import com.assetmind.server_stock.stock.presentation.dto.ChartResponseDto;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ChartController.class)
+@AutoConfigureRestDocs
+class ChartControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ChartService chartService;
+
+    @Test
+    @DisplayName("[성공] 차트 캔들 조회 성공 및 REST Docs 생성")
+    void givenInvalidData_whenGetCandles_thenSuccess200() throws Exception {
+        // given
+        String stockCode = "005930";
+        String timeframe = "5m";
+        int limit = 10;
+        LocalDateTime endTime = LocalDateTime.of(2026, 4, 1, 10, 0);
+
+        ChartResponseDto.CandleDto candle = ChartResponseDto.CandleDto.builder()
+                .timestamp(endTime)
+                .open("80000.0")
+                .high("81000.0")
+                .low("79000.0")
+                .close("80500.0")
+                .volume("1000")
+                .build();
+
+        ChartResponseDto responseDto = ChartResponseDto.builder()
+                .stockCode(stockCode)
+                .timeframe(timeframe)
+                .candles(List.of(candle))
+                .build();
+
+        given(chartService.getCandles(eq(stockCode), eq(timeframe), eq(endTime), eq(limit)))
+                .willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/stocks/{stockCode}/charts/candles", stockCode)
+                        .param("timeframe", timeframe)
+                        .param("limit", String.valueOf(limit))
+                        .param("endTime", endTime.toString())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                // 💡 ApiResponse 필드 검증
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").isEmpty())
+                // 💡 ApiResponse 내부 data(ChartResponseDto) 필드 검증
+                .andExpect(jsonPath("$.data.stockCode").value(stockCode))
+                .andExpect(jsonPath("$.data.candles[0].close").value(80500.0))
+
+                .andDo(document("chart-get-candles",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("stockCode").description("주식 종목 코드 (6자리 숫자)")
+                        ),
+                        queryParameters(
+                                parameterWithName("timeframe").description("차트 타임프레임 (예: 1m, 5m, 1d, 1mo)"),
+                                parameterWithName("limit").description("조회할 캔들 개수 (기본값 200, 최대 1000)").optional(),
+                                parameterWithName("endTime").description("조회 기준 시간 (ISO-8601 포맷, 예: 2026-04-01T10:00:00)").optional()
+                        ),
+                        responseFields(
+                                // ApiResponse 공통 필드 명세
+                                fieldWithPath("success").description("성공 여부 (true/false)"),
+                                fieldWithPath("message").description("응답 메시지 (성공 시 null 또는 안내 메시지)"),
+
+                                // ChartResponseDto 필드 명세 (data 영역)
+                                fieldWithPath("data.stockCode").description("종목 코드"),
+                                fieldWithPath("data.timeframe").description("타임프레임"),
+                                fieldWithPath("data.candles").description("캔들 리스트"),
+                                fieldWithPath("data.candles[].timestamp").description("캔들 기준 시간"),
+                                fieldWithPath("data.candles[].open").description("시가"),
+                                fieldWithPath("data.candles[].high").description("고가"),
+                                fieldWithPath("data.candles[].low").description("저가"),
+                                fieldWithPath("data.candles[].close").description("종가"),
+                                fieldWithPath("data.candles[].volume").description("거래량")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 필수 파라미터(timeframe) 누락 시 400 Bad Request")
+    void givenTimeframeIsNull_whenGetCandles_thenResponse400Error() throws Exception {
+        String stockCode = "005930";
+
+        mockMvc.perform(get("/api/stocks/{stockCode}/charts/candles", stockCode)
+                        .param("limit", "100"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("[실패] 조회 개수(limit) 범위 미달 시 400 Bad Request")
+    void given1LessThanLimit_whenGetCandles_thenResponse400Error() throws Exception {
+        String stockCode = "005930";
+
+        mockMvc.perform(get("/api/stocks/{stockCode}/charts/candles", stockCode)
+                        .param("timeframe", "1d")
+                        .param("limit", "0")) //
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
- **주식 차트 동적 조회 API 파이프라인 구축:** 프론트엔드 차트 라이브러리(TradingView 등) 연동을 위해 특정 종목의 차트 캔들(OHLCV) 데이터를 서빙하는 REST API 완성
- **N분봉, N일/주/월/년봉 동적 집계 서빙:** 기초 데이터인 1분봉과 1일봉 데이터를 기반으로, 프론트엔드가 요청하는 다양한 타임프레임(3m, 5m, 1w, 1mo 등)을 런타임에 동적으로 조합하여 반환
- **무한 스크롤 및 초기 렌더링 지원:** 첫 진입 시 최신 데이터 200개 반환, 스크롤 시 `endTime`을 기준점으로 과거 데이터를 페이징 조회할 수 있도록 편의성 제공
- **Spring REST Docs 기반 API 명세서 자동화:** 컨트롤러 단위 테스트와 연동하여, 테스트 통과 시 항상 최신 상태의 API 공식 문서(`index.html`)가 생성되도록 CI/CD 친화적 문서화 파이프라인 구축

---

## 🏗 기술적 의사결정 및 설계 (Core Design)

### 1. 동적 바구니 집계(Dynamic Aggregation)를 위한 DB 네이티브 함수 활용
- **문제:** 애플리케이션 메모리에 수만 건의 1분봉/1일봉 데이터를 올려서 N분봉/N일봉으로 묶는(Roll-up) 로직은 OOM(Out of Memory) 및 심각한 성능 저하를 유발.
- **해결:** PostgreSQL의 네이티브 집계 함수 활용. 고정 길이(분, 일, 주)는 `date_bin` 함수로, 가변 길이(월, 년)는 `date_trunc` 함수로 기준점(바구니)을 그룹핑. 시가(Open)와 종가(Close)는 `array_agg`의 정렬 기능(`ORDER BY ASC/DESC`)을 통해 DB 엔진 레벨에서 즉시 추출하여 쿼리 한 번에 해결.

### 2. 프론트엔드 연동 편의성 및 데이터 무결성 보장
- **문제:** 파라미터가 유실되거나 Java 8의 `LocalDateTime` 형식이 JSON 변환 시 깨지는 문제 방지 필요.
- **해결:** `ChartRequestDto`에 `@Valid`를 적용해 악의적이거나 누락된 파라미터 요청 시 즉각 `400 Bad Request` 방어 로직 구축. 또한, Jackson의 `JavaTimeModule`을 수동 등록하고 글로벌 `ApiResponse` 객체로 데이터를 감싸 프론트엔드가 일관된 포맷(`success`, `message`, `data`)으로 통신할 수 있도록 설계.

### 3. 영속성 계층 완벽 격리 (Port & Adapter)
- **문제:** Native Query(`@Query`)의 복잡도가 높아 향후 DB 기술(시계열 DB 등)로 교체 시 비즈니스 서비스 클래스에 파급 효과 발생 우려.
- **해결:** 도메인 계층에 `Ohlcv1mRepository`, `Ohlcv1dRepository` 인터페이스(Port)를 정의하고, `ChartService`는 오직 이 Port에만 의존하게 설계. JPA 및 Native Query의 세부 구현은 인프라 계층의 `Ohlcv1mJpaAdapter`, `Ohlcv1dJpaAdapter`로 격리.

---

## 🧪 테스트 및 검증 전략 (Testing Strategy)
- **Testcontainers 기반 DB 통합 테스트 (Adapter 레벨):**
  - 가상의 `2000-01-01` 기준점에 맞춘 테스트 데이터를 삽입하여 `date_bin` 바구니가 정확하게 분할되는지 검증.
  - `array_agg`의 순서 보장 기능이 제대로 작동하여 기간 내 정확한 시가(Open), 종가(Close), 최고점(High), 최저점(Low)이 롤업되는지 비즈니스 정밀성 검증 완수.
- **Service 계층 100% 분기 커버리지:**
  - `ParameterizedTest`와 `@CsvSource`를 활용해 "1m", "5m", "1d", "1w" 등 모든 타임프레임 문자열 입력에 대해 올바른 Repository Port로 라우팅되는지 완벽히 검증.
- **WebMvcTest & REST Docs 기반 Controller 검증:**
  - `@WebMvcTest`를 활용해 예외 상황(Limit 초과, 파라미터 누락)에 대한 400 에러 동작 확인 및 `ApiResponse` 포맷 내에 정확히 맵핑되는지 검증. 동시에 해당 결과물로 API 문서 스니펫 추출.

---

## ✅ 주요 변경점
- **Presentation (API & Docs):**
  - `ChartController.java`: 차트 데이터 조회 엔드포인트 (`/api/stocks/{stockCode}/charts/candles`)
  - `ChartRequestDto.java`: 요청 파라미터 유효성 검사 및 기본값 세팅 객체
  - `ChartResponseDto.java`: 프론트엔드 맞춤형 차트 응답 객체
  - `index.adoc`: 차트 조회 API 명세서 문서화 추가
- **Application & Domain (Service & Port):**
  - `ChartService.java`: N분/N일/월/년봉 트래픽 라우팅 및 동적 집계 파라미터 파싱 핵심 로직
  - `Ohlcv1mRepository.java`, `Ohlcv1dRepository.java`: 도메인 Port (인터페이스)
- **Infrastructure (Adapters):**
  - `Ohlcv1mJpaAdapter.java`, `Ohlcv1dJpaAdapter.java`: PostgreSQL 네이티브 집계 쿼리를 포함한 어댑터 및 DTO 변환 로직 적용
- **Config:**
  - `JacksonConfig.java`: 날짜 데이터 ISO-8601 포맷 출력을 위한 `JavaTimeModule` 적용
- **Test:**
  - `ChartControllerTest`, `ChartServiceTest`, `Ohlcv1dJpaAdapterTest`, `Ohlcv1mJpaAdapterTest` 등 단위 및 통합 테스트 작성

---

## 📝 리뷰 포인트
- **Native Query 성능 최적화:** `date_bin`과 `array_agg`를 활용한 집계 방식이 현재 데이터 규모에서 가장 빠른 속도를 보장합니다. 향후 파티셔닝된 테이블 환경에서도 해당 쿼리의 인덱스 스캔이 효율적으로 이루어질지 의견 남겨주시면 감사하겠습니다.
- **API 응답 구조 및 DTO 분리:** `ApiResponse`로 데이터를 감싸고, 내부 도메인(`OhlcvDto`) 대신 `CandleDto`를 별도로 두어 프론트엔드 라이브러리가 선호하는 작명(timestamp, open, close 등)으로 맞췄습니다. 이 매핑 구조의 깔끔함이나 추가 개선점에 대해 리뷰 부탁드립니다.