### PR TITLE
[Feat] 부하 테스트 베이스라인 측정을 위한 Prometheus & Grafana 모니터링 환경 구축

### DIFF
--- a/apps/docker-compose.yml
+++ b/apps/docker-compose.yml
@@ -23,3 +23,27 @@ services:
     ports:
       - "6379:6379"
     restart: always
+
+  # Prometheus 컨테이너 (모니터링 지표 수집기)
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: assetmind-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    restart: unless-stopped
+
+  # Grafana 컨테이너 (모니터링 대시보드)
+  grafana:
+    image: grafana/grafana:latest
+    container_name: assetmind-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus
+    restart: unless-stopped

--- a/apps/prometheus.yml
+++ b/apps/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 10m
+
+scrape_configs:
+  # Auth 서버 수집 설정
+  - job_name: 'assetmind-auth-server'
+    metrics_path: '/manage/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8081']
+
+  # Stock 서버 수집 설정
+  - job_name: 'assetmind-stock-server'
+    metrics_path: '/manage/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:9091']

--- a/apps/server-stock/src/main/resources/application.yml
+++ b/apps/server-stock/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 9090
+
 spring:
   application:
     name: stock-service
@@ -18,6 +21,8 @@ spring:
     url: jdbc:postgresql://${DB_HOST:localhost}:5432/${POSTGRES_DB:assetmind}
     username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
+    hikari:
+      pool-name: AssetMind-Stock-HikariCP # HikariCP 매트릭 name
 
   flyway:
     enabled: true
@@ -45,6 +50,22 @@ spring:
 logging:
   file:
     name: ./logs/error-tracking.log
+
+management:
+  server:
+    port: 9091
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus, health, info"
+      base-path: "/manage" # 기본 경로 (/actuator)를 변경하여 스캐닝 공격 방어
+  endpoint:
+    prometheus:
+      access: read_only
+  metrics:
+    tags:
+      application: "AssetMind-Stock"
+
 
 
 kis:

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,13 @@ subprojects {
             // Spring REST Docs 의존성
             testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
             asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+
+            // 모니터링
+            // Actuator: 애플리케이션 상태 모니터링 앤드포인트 제공
+            implementation 'org.springframework.boot:spring-boot-starter-actuator'
+            // Micrometer Prometheus Registry: Prometheus 형식으로 메트릭 변환
+            implementation 'io.micrometer:micrometer-registry-prometheus'
+
         }
 
         jacoco {


### PR DESCRIPTION
## 📌 작업 내용
- **Spring Boot 모니터링 기반 마련:** 애플리케이션의 핵심 지표(JVM, HTTP Latency, DB 커넥션 풀 등)를 노출하기 위해 Spring Boot 3 버전 환경에 맞춘 Actuator 및 Micrometer 설정 적용.
- **모니터링 인프라 통합 구축:** Docker Compose를 활용하여 루트 레벨에 Prometheus(지표 수집)와 Grafana(시각화) 컨테이너를 구성하고, 멀티 모듈(Auth, Stock) 서버와의 네트워크 연동 완료.
- **부하 테스트 대시보드 세팅:** 시스템 병목 지점을 직관적으로 파악하기 위해 JVM 메모리/GC, HikariCP 활성 커넥션, HTTP TPS 관련 핵심 그라파나 대시보드 템플릿 연동 및 쿼리 수정.

---

## 🏗 기술적 의사결정 및 설계 (Core Design)

### 1. Actuator 포트 분리 및 최소 권한 부여 (Security)
> **목적:** 모니터링 엔드포인트 외부 노출로 인한 보안 위협(환경변수 유출, 스레드 덤프 등) 원천 차단

- **문제:** 비즈니스 로직을 서빙하는 포트(`server.port`)와 Actuator 포트를 동일하게 사용하거나 엔드포인트를 전체 개방(`*`)할 경우 심각한 보안 취약점이 발생할 수 있음.
- **해결 & 설계:** - `management.server.port`를 별도로 분리(Auth: 8081, Stock: 9091)하여 모니터링 통로는 내부망(Docker)에서만 접근 가능하도록 격리.
  - 보안상 안전하고 필수적인 엔드포인트(`prometheus, health, info`)만 노출.
  - Spring Boot 3.4+ 최신 보안 정책에 맞춰 프로메테우스 엔드포인트 접근 권한을 `access: read_only`로 제한하여 안전성 극대화.

### 2. 수집 주기(Scrape Interval) 및 타겟 최적화
> **목적:** 모니터링 행위 자체가 서버에 가하는 부하(Observer Effect) 최소화 및 정확한 트렌드 분석

- **문제:** 지표 수집 주기가 너무 짧으면 서버 스레드/네트워크 I/O 부하 및 Prometheus TSDB 용량 폭발이 발생하고, 너무 길면 부하 테스트 중 발생하는 순간적인 병목(Spike)을 놓칠 우려가 있음.
- **해결 & 설계:** - 부하 테스트의 베이스라인 측정에 가장 적합한 스위트 스팟인 `10s`로 수집 주기를 설정하여 노이즈 없는 부드러운 트렌드 그래프 확보.
  - `prometheus.yml`에서 `job_name`을 모듈별(Auth, Stock)로 분리하여, 추후 그라파나에서 도메인별 필터링이 용이하도록 설계.
  - HikariCP 풀 네임(`AssetMind-Stock-HikariCP`)과 메트릭 태그(`application: AssetMind-Stock`)를 명시하여 멀티 모듈 환경에서의 지표 식별성 강화.

---

## ✅ 주요 변경점
- **Build & Config:**
  - `build.gradle`: `spring-boot-starter-actuator`, `micrometer-registry-prometheus` 의존성 추가.
  - `application.yml`: HikariCP 풀 네임 지정, Actuator 포트 분리 및 노출 범위 설정.
- **Infrastructure (Docker & Prometheus):**
  - `docker-compose.yml`: 루트 인프라 파일에 `prometheus`, `grafana` 서비스 추가 (DB/Redis와 동일 네트워크 구성).
  - `prometheus.yml`: 주기(`10s`) 및 멀티 모듈 각각의 타겟(`host.docker.internal:8081, 9091`) 수집 설정 추가.

---

## 🖥️ 결과물
> 환경 세팅이 완료된 Grafana 대시보드 화면
<img width="1903" height="950" alt="image" src="https://github.com/user-attachments/assets/5cd8c740-39c5-4d72-a8f1-96b8f6d93c4f" />


## 📝 리뷰 포인트
- **보안 및 포트 설정:** `application.yml`에 설정된 Actuator 포트 분리 및 `read_only` 노출 설정이 운영 보안 원칙에 부합하는지 확인 부탁드립니다.
- **추가 지표 수집:** 현재 다가올 부하 테스트를 대비해 **JVM(메모리/GC), HTTP(응답속도/TPS), Database(HikariCP 대기 커넥션)** 3가지를 핵심 관찰 지표로 세팅해두었습니다. KIS API 호출 통계 등 추가로 커스텀(Custom) 수집이 필요한 비즈니스 지표가 있다면 의견 부탁드립니다.