### PR TITLE
[Story] 종목 세부 페이지 — AI 예측 패널 반응형 및 보완

### DIFF
--- a/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.stories.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.stories.tsx
@@ -256,7 +256,7 @@ const tabletDec = (Story: React.ComponentType) => (
   <div style={{ width: "768px" }}><Story /></div>
 );
 const mobileDec = (Story: React.ComponentType) => (
-  <div style={{ width: "393px" }}><Story /></div>
+  <div style={{ width: "393px", height: "852px", overflow: "hidden" }}><Story /></div>
 );
 
 // ════════════════════════════════════════════════════════════════

--- a/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.tsx
@@ -310,7 +310,7 @@ export const StockDetailPage = ({
       style={{
         width: containerWidth,
         backgroundColor: "#131316",
-        minHeight: "100vh",
+        minHeight: isMobile ? "852px" : "100vh",
         display: "flex",
         flexDirection: "column",
         boxSizing: "border-box",

--- a/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.tsx
@@ -310,10 +310,12 @@ export const StockDetailPage = ({
       style={{
         width: containerWidth,
         backgroundColor: "#131316",
-        minHeight: isMobile ? "852px" : "100vh",
+        height: isMobile ? "852px" : isTablet ? "1024px" : "auto",
+        minHeight: isMobile || isTablet ? undefined : "100vh",
         display: "flex",
         flexDirection: "column",
         boxSizing: "border-box",
+        overflow: isMobile || isTablet ? "hidden" : undefined,
       }}
     >
       {/* ── 헤더 ── */}

--- a/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.tsx
@@ -237,8 +237,12 @@ export const StockDetailPage = ({
     onTabChange?.(tab as DetailTab);
   };
 
-  const resolvedOrderbookStatus: "default" | "skeleton" | "error" | "empty" =
+  // isMarketClosed → 호가창·AI 패널 모두 empty 강제
+  const resolvedOrderbookStatus: PanelState =
     isMarketClosed ? "empty" : orderbookState;
+
+  const resolvedAIStatus: PanelState =
+    isMarketClosed ? "empty" : aiState;
 
   // ── 차트 패널 ─────────────────────────────────────────────
   const renderChart = (width: number, height: number) => (
@@ -280,10 +284,10 @@ export const StockDetailPage = ({
     />
   );
 
-  // ── AI 예측 패널 ──────────────────────────────────────────
+  // ── AI 예측 패널 — isMarketClosed 시 status="empty" 전달 ──
   const renderAI = () => (
     <AIPredictionPanel
-      status={aiState}
+      status={resolvedAIStatus}
       viewport={viewport}
       onRetry={onRetry}
       period={aiPeriod}
@@ -328,7 +332,7 @@ export const StockDetailPage = ({
 
       <div style={{ flex: 1 }}>
 
-        {/* ══ 차트·호가 탭 — 데스크톱 ════════════════════ */}
+        {/* ══ 차트·호가 탭 — 데스크톱 ══════════════════════════ */}
         {activeTab === "chart" && !isMobile && !isTablet && (
           <div
             style={{
@@ -356,7 +360,7 @@ export const StockDetailPage = ({
           </div>
         )}
 
-        {/* ══ 차트·호가 탭 — 태블릿 ══════════════════ */}
+        {/* ══ 차트·호가 탭 — 태블릿 ══════════════════════════ */}
         {activeTab === "chart" && isTablet && (
           <div
             style={{
@@ -377,7 +381,7 @@ export const StockDetailPage = ({
           </div>
         )}
 
-        {/* ══ 차트·호가 탭 — 모바일 ════════════════════*/}
+        {/* ══ 차트·호가 탭 — 모바일 ══════════════════════════ */}
         {activeTab === "chart" && isMobile && (
           <div
             style={{
@@ -427,7 +431,7 @@ export const StockDetailPage = ({
           <div style={{
             padding: "12px",
             display: "flex",
-            justifyContent: "center"
+            justifyContent: "center",
           }}>
             {renderAI()}
           </div>


### PR DESCRIPTION
# [Story] 종목 세부 페이지 — AI 예측 패널 반응형 및 보완

## 📌 1. PR 요약
AI 예측 패널의 모바일 및 태블릿 반응형 레이아웃을 최적화하여 가독성을 개선하고, 시장 휴장 시 패널 상태를 자동으로 제어하는 로직을 보완하여 사용자 경험을 강화했습니다.

## 🛠 2. 작업 내용
### 반응형 레이아웃 최적화 및 버그 수정
- 모바일 뷰에서 AI 분석 위젯의 텍스트와 차트가 겹치지 않도록 레이아웃을 재배치하여 가독성을 확보했습니다.
- 반응형 해상도 전환 시 차트가 비정상적으로 렌더링되던 리사이징 이슈를 해결했습니다.

### 시장 휴장 상태 대응 로직 개선
- `isMarketClosed` 상태에 따라 AI 패널의 상태를 강제로 오버라이드하는 `resolvedAIStatus` 로직을 추가했습니다.
- 휴장 시 AI 패널 상단에 ' 휴장 시간' 뱃지가 정상적으로 노출되도록 렌더링 파라미터를 수정했습니다.

### Storybook 검증 시나리오 추가
- 태블릿 및 모바일 전용 Page Story variant를 추가하여 좁은 뷰포트에서의 시각적 정합성을 확인했습니다.

## 📸 3. 스크린샷
| Mobile Responsive View | Market Closed (Empty) State |
|:---:|:---:|
| <img width="390" height="848" alt="image" src="https://github.com/user-attachments/assets/7768239e-8ff4-437d-94ab-a17a4864c501" /> | <img width="970" height="412" alt="image" src="https://github.com/user-attachments/assets/891c612c-8761-4743-85c2-92d1d9f82629" /> |

## 📋 4. 파일 변경 목록
- `StockDetailPage.tsx`: 
    - `resolvedAIStatus` 로직 도입 (`isMarketClosed ? "empty" : aiState`)
    - `renderAI()` 함수 내 `status` 전달 값을 `aiState`에서 `resolvedAIStatus`로 변경
- `StockDetailPage.stories.tsx`: 태블릿/모바일 variant 검증을 위한 신규 Page Story 추가

## 💬 5. 리뷰 포인트
- **반응형 가독성**: 모바일 해상도에서 AI 분석 위젯의 텍스트 크기와 차트 비율이 정보 과부하 없이 적절하게 노출되는지 확인해 주세요.
- **휴장 상태 동기화**: `isMarketClosed=true`일 때 호가창과 AI 패널 모두 'empty' 상태로 전환되어 휴장 안내 뱃지가 일관되게 표시되는지 시각적으로 검토 부탁드립니다.