### PR TITLE
 [Feat] 거래현황 탭 컴포넌트 개발 및 Storybook 등록

### DIFF
--- a/apps/web/Design_UI/src/components/common/stock/InvestorTradePanel/InvestorTradePanel.stories.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/InvestorTradePanel/InvestorTradePanel.stories.tsx
@@ -1,0 +1,183 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { InvestorTradePanel } from "./InvestorTradePanel";
+import type {
+  TrendDataPoint, TrendTableRow,
+  ProgramTradeRow, CreditTradeRow, LendingTradeRow,
+  ShortTradeRow, CfdTradeRow,
+} from "./InvestorTradePanel";
+
+// ─── Mock Data ────────────────────────────────────────────────
+
+const MOCK_BUY_LIST = [
+  { rank: 1, name: "미래에셋증권", quantity: 1240000 },
+  { rank: 2, name: "키움증권",     quantity: 980000  },
+  { rank: 3, name: "삼성증권",     quantity: 750000  },
+  { rank: 4, name: "NH투자증권",   quantity: 620000  },
+  { rank: 5, name: "한국투자증권", quantity: 430000  },
+];
+
+const MOCK_SELL_LIST = [
+  { rank: 1, name: "외국계A",      quantity: 1100000 },
+  { rank: 2, name: "외국계B",      quantity: 870000  },
+  { rank: 3, name: "KB증권",       quantity: 650000  },
+  { rank: 4, name: "신한투자증권", quantity: 490000  },
+  { rank: 5, name: "메리츠증권",   quantity: 310000  },
+];
+
+const MOCK_TREND_DATA: TrendDataPoint[] = [
+  { time: "2026-03-19", individual: -5200000,  foreign:  8100000,  institution:  2300000 },
+  { time: "2026-03-20", individual:  3100000,  foreign: -4200000,  institution:  1800000 },
+  { time: "2026-03-23", individual: -1800000,  foreign:  6500000,  institution: -3200000 },
+  { time: "2026-03-24", individual:  7400000,  foreign: -9800000,  institution:  4100000 },
+  { time: "2026-03-25", individual: -6300000,  foreign: 12000000,  institution: -2700000 },
+  { time: "2026-03-26", individual:  2900000,  foreign: -5600000,  institution:  3500000 },
+  { time: "2026-03-27", individual: -4100000,  foreign:  7300000,  institution: -1900000 },
+  { time: "2026-03-30", individual:  8200000,  foreign: -11000000, institution:  5600000 },
+  { time: "2026-03-31", individual: -3700000,  foreign:  9400000,  institution: -4300000 },
+  { time: "2026-04-01", individual:  5100000,  foreign: -6800000,  institution:  2100000 },
+  { time: "2026-04-02", individual: -2400000,  foreign:  4700000,  institution: -1500000 },
+  { time: "2026-04-03", individual:  6800000,  foreign: -8200000,  institution:  3800000 },
+  { time: "2026-04-06", individual: -7100000,  foreign: 10500000,  institution: -5200000 },
+  { time: "2026-04-07", individual:  4300000,  foreign: -7400000,  institution:  2900000 },
+  { time: "2026-04-08", individual: -1900000,  foreign:  3600000,  institution: -1200000 },
+  { time: "2026-04-09", individual:  9100000,  foreign: -13000000, institution:  6700000 },
+  { time: "2026-04-10", individual: -5600000,  foreign:  8900000,  institution: -3900000 },
+  { time: "2026-04-13", individual:  3800000,  foreign: -5100000,  institution:  2400000 },
+  { time: "2026-04-14", individual: -2100000,  foreign:  4400000,  institution: -1800000 },
+  { time: "2026-04-15", individual:  7500000,  foreign: -10200000, institution:  5100000 },
+];
+
+const MOCK_TABLE_DATA: TrendTableRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  closePrice: 75000 + Math.floor((Math.random() - 0.5) * 3000),
+  changeRate: parseFloat(((Math.random() - 0.5) * 4).toFixed(2)),
+  changeAmount: Math.floor((Math.random() - 0.5) * 2000),
+  individualNet: Math.floor((Math.random() - 0.5) * 10000000),
+  foreignNet: Math.floor((Math.random() - 0.5) * 15000000),
+  foreignRatio: parseFloat((52 + (Math.random() - 0.5) * 2).toFixed(2)),
+  institutionNet: Math.floor((Math.random() - 0.5) * 8000000),
+}));
+
+const MOCK_PROGRAM_DATA: ProgramTradeRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  netBuyChange: Math.floor((Math.random() - 0.5) * 5000000),
+  netBuy: Math.floor((Math.random() - 0.5) * 20000000),
+  buy: Math.floor(Math.random() * 50000000 + 10000000),
+  sell: Math.floor(Math.random() * 50000000 + 10000000),
+  nonArbitrageNet: Math.floor((Math.random() - 0.5) * 15000000),
+}));
+
+const MOCK_CREDIT_DATA: CreditTradeRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  type: i % 2 === 0 ? "융자" : "대주",
+  changeQty: Math.floor((Math.random() - 0.5) * 100000),
+  newQty: Math.floor(Math.random() * 200000 + 50000),
+  repayQty: Math.floor(Math.random() * 150000 + 30000),
+  balanceQty: Math.floor(Math.random() * 5000000 + 1000000),
+  balanceRate: parseFloat((Math.random() * 5).toFixed(2)),
+}));
+
+const MOCK_LENDING_DATA: LendingTradeRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  changeQty: Math.floor((Math.random() - 0.5) * 50000),
+  newQty: Math.floor(Math.random() * 100000 + 20000),
+  repayQty: Math.floor(Math.random() * 80000 + 15000),
+  balanceQty: Math.floor(Math.random() * 2000000 + 500000),
+}));
+
+const MOCK_SHORT_DATA: ShortTradeRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  tradeAmountRatio: parseFloat((Math.random() * 8 + 1).toFixed(2)),
+  shortQty: Math.floor(Math.random() * 500000 + 100000),
+  shortAmount: Math.floor(Math.random() * 30000000000 + 5000000000),
+  shortAvgPrice: Math.floor(74000 + (Math.random() - 0.5) * 2000),
+  tradeAmount: Math.floor(Math.random() * 400000000000 + 50000000000),
+}));
+
+const MOCK_CFD_DATA: CfdTradeRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  newBuyQty: Math.floor(Math.random() * 50000),
+  repayBuyQty: Math.floor(Math.random() * 40000),
+  balanceBuyQty: Math.floor(Math.random() * 200000 + 50000),
+  buyBalanceRate: parseFloat((Math.random() * 3).toFixed(2)),
+  newSellQty: Math.floor(Math.random() * 45000),
+  repaySellQty: Math.floor(Math.random() * 35000),
+  balanceSellQty: Math.floor(Math.random() * 180000 + 40000),
+  sellBalanceRate: parseFloat((Math.random() * 3).toFixed(2)),
+}));
+
+const ALL_ARGS = {
+  buyList: MOCK_BUY_LIST,
+  sellList: MOCK_SELL_LIST,
+  rankBaseDateTime: "2026.04.19 15:30",
+  trendData: MOCK_TREND_DATA,
+  trendBaseDateTime: "2026.04.19 15:30",
+  tableData: MOCK_TABLE_DATA,
+  programData: MOCK_PROGRAM_DATA,
+  creditData: MOCK_CREDIT_DATA,
+  lendingData: MOCK_LENDING_DATA,
+  shortData: MOCK_SHORT_DATA,
+  cfdData: MOCK_CFD_DATA,
+  onViewNetBuy: () => alert("투자자별 순매수 보기"),
+  onRetry: () => alert("Retry"),
+};
+
+// ─── Meta ─────────────────────────────────────────────────────
+
+const meta: Meta<typeof InvestorTradePanel> = {
+  title: "Components/Stock/InvestorTradePanel",
+  component: InvestorTradePanel,
+  tags: ["autodocs"],
+  parameters: {
+    backgrounds: {
+      default: "dark",
+      values: [{ name: "dark", value: "#131316" }],
+    },
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "거래현황 탭 통합 패널. 거래원 매매 상위(매수/매도 상위 5) + 투자자별 매매 동향(라인 차트 + 데이터 테이블 + 투자 유형별 현황)으로 구성됩니다. `status` prop으로 default·skeleton·error 상태 전환 가능.",
+      },
+    },
+  },
+  argTypes: {
+    status: {
+      control: "radio",
+      options: ["default", "skeleton", "error"],
+      description: "default: 정상 | skeleton: 로딩 중 | error: API 실패",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof InvestorTradePanel>;
+
+// ─── Stories ──────────────────────────────────────────────────
+
+export const Default: Story = {
+  name: "Default",
+  args: { ...ALL_ARGS, status: "default" },
+  decorators: [(Story) => <div style={{ backgroundColor: "#131316", padding: "24px", display: "inline-block" }}><Story /></div>],
+};
+
+export const Skeleton: Story = {
+  name: "Skeleton",
+  args: { status: "skeleton" },
+  parameters: {
+    docs: { description: { story: "API 호출 중 Skeleton 애니메이션 표시 상태입니다." } },
+  },
+  decorators: [(Story) => <div style={{ backgroundColor: "#131316", padding: "24px", display: "inline-block" }}><Story /></div>],
+};
+
+export const Error: Story = {
+  name: "Error",
+  args: { status: "error", onRetry: () => alert("Retry") },
+  decorators: [(Story) => <div style={{ backgroundColor: "#131316", padding: "24px", display: "inline-block" }}><Story /></div>],
+};
+
+export const Playground: Story = {
+  name: "Playground",
+  args: { ...ALL_ARGS, status: "default" },
+  decorators: [(Story) => <div style={{ backgroundColor: "#131316", padding: "24px", display: "inline-block" }}><Story /></div>],
+};

--- a/apps/web/Design_UI/src/components/common/stock/InvestorTradePanel/InvestorTradePanel.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/InvestorTradePanel/InvestorTradePanel.tsx
@@ -1,0 +1,735 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  createChart,
+  ColorType,
+  LineSeries,
+  type IChartApi,
+  type LineData,
+} from "lightweight-charts";
+
+// ─── Types ────────────────────────────────────────────────────
+
+export type TradePanelStatus = "default" | "skeleton" | "error";
+export type TrendPeriod = "daily" | "weekly";
+export type InvestorType = "program" | "credit" | "lending" | "short" | "cfd";
+
+export interface TraderRankItem {
+  rank: number;
+  name: string;
+  quantity: number;
+}
+
+export interface TrendDataPoint {
+  time: string;
+  individual: number;
+  foreign: number;
+  institution: number;
+}
+
+export interface TrendTableRow {
+  date: string;
+  closePrice: number;
+  changeRate: number;
+  changeAmount: number;
+  individualNet: number;
+  foreignNet: number;
+  foreignRatio: number;
+  institutionNet: number;
+}
+
+export interface ProgramTradeRow {
+  date: string;
+  netBuyChange: number;
+  netBuy: number;
+  buy: number;
+  sell: number;
+  nonArbitrageNet: number;
+}
+
+export interface CreditTradeRow {
+  date: string;
+  type: "융자" | "대주";
+  changeQty: number;
+  newQty: number;
+  repayQty: number;
+  balanceQty: number;
+  balanceRate: number;
+}
+
+export interface LendingTradeRow {
+  date: string;
+  changeQty: number;
+  newQty: number;
+  repayQty: number;
+  balanceQty: number;
+}
+
+export interface ShortTradeRow {
+  date: string;
+  tradeAmountRatio: number;
+  shortQty: number;
+  shortAmount: number;
+  shortAvgPrice: number;
+  tradeAmount: number;
+}
+
+export interface CfdTradeRow {
+  date: string;
+  newBuyQty: number;
+  repayBuyQty: number;
+  balanceBuyQty: number;
+  buyBalanceRate: number;
+  newSellQty: number;
+  repaySellQty: number;
+  balanceSellQty: number;
+  sellBalanceRate: number;
+}
+
+export interface InvestorTradePanelProps {
+  status?: TradePanelStatus;
+  // 거래원 매매 상위
+  buyList?: TraderRankItem[];
+  sellList?: TraderRankItem[];
+  rankBaseDateTime?: string;
+  // 투자자별 매매 동향
+  trendData?: TrendDataPoint[];
+  trendBaseDateTime?: string;
+  tableData?: TrendTableRow[];
+  programData?: ProgramTradeRow[];
+  creditData?: CreditTradeRow[];
+  lendingData?: LendingTradeRow[];
+  shortData?: ShortTradeRow[];
+  cfdData?: CfdTradeRow[];
+  onRetry?: () => void;
+  onViewNetBuy?: () => void;
+}
+
+// ─── 색상 ─────────────────────────────────────────────────────
+
+const RISE = "#EA580C";
+const FALL = "#256AF4";
+const IND_COLOR = "#C9A24D";
+const FOR_COLOR = "#4FA3B8";
+const INST_COLOR = "#8A6BBE";
+const TABLE_BG1 = "#21242C";
+const TABLE_BG2 = "transparent";
+
+// ─── Helpers ──────────────────────────────────────────────────
+
+const fmt = (v: number) => v.toLocaleString("ko-KR");
+const fmtRate = (v: number) => `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
+const fmtSigned = (v: number) => `${v >= 0 ? "+" : ""}${fmt(v)}`;
+const signColor = (v: number) => v > 0 ? RISE : v < 0 ? FALL : "#9194A1";
+
+// ─── Skeleton ─────────────────────────────────────────────────
+
+const SkeletonBox = ({ w, h = 14 }: { w: number | string; h?: number }) => (
+  <div
+    className="animate-[skeleton-pulse_700ms_ease-out_400ms_infinite]"
+    style={{ width: w, height: `${h}px`, borderRadius: "4px", backgroundColor: "#21242C", flexShrink: 0 }}
+  />
+);
+
+const PanelSkeleton = () => (
+  <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+    {Array.from({ length: 5 }).map((_, i) => (
+      <div key={i} style={{ display: "flex", gap: "12px", alignItems: "center" }}>
+        <SkeletonBox w={12} />
+        <SkeletonBox w={80} />
+        <SkeletonBox w="100%" h={22} />
+      </div>
+    ))}
+  </div>
+);
+
+const ChartSkeleton = () => (
+  <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+    <SkeletonBox w="100%" h={243} />
+    {Array.from({ length: 5 }).map((_, i) => <SkeletonBox key={i} w="100%" h={28} />)}
+  </div>
+);
+
+// ─── Error ────────────────────────────────────────────────────
+
+const ErrorBlock = ({ onRetry }: { onRetry?: () => void }) => (
+  <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", minHeight: "200px", gap: "16px" }}>
+    <svg width="30" height="28" viewBox="0 0 30 28" fill="none">
+      <path d="M16.3261 0.724424C15.8071 -0.241475 14.1932 -0.241475 13.6742 0.724424L0.174404 25.8319C0.0533393 26.057 -0.0065451 26.3091 0.00056714 26.5637C0.00767938 26.8183 0.0815466 27.0668 0.214994 27.285C0.348442 27.5032 0.536934 27.6837 0.762161 27.809C0.987389 27.9343 1.2417 28.0001 1.50038 28H28.4999C28.7586 28.0005 29.013 27.935 29.2383 27.8099C29.4636 27.6848 29.6522 27.5044 29.7856 27.2862C29.919 27.0679 29.9927 26.8194 29.9995 26.5648C30.0063 26.3102 29.946 26.0582 29.8244 25.8334L16.3261 0.724424ZM16.5001 23.5693H13.5002V20.6154H16.5001V23.5693ZM13.5002 17.6616V10.2771H16.5001L16.5016 17.6616H13.5002Z" fill="#6B7280" />
+    </svg>
+    <p style={{ fontSize: "14px", color: "#9F9F9F", textAlign: "center", margin: 0 }}>
+      데이터를 불러오지 못했습니다.<br />잠시 후 다시 시도해 주세요.
+    </p>
+    <button
+      onClick={onRetry}
+      style={{ width: "100px", height: "38px", backgroundColor: "#6D4AE6", border: "none", borderRadius: "8px", cursor: "pointer", fontSize: "14px", fontWeight: 500, color: "#FFFFFF" }}
+    >
+      다시 시도
+    </button>
+  </div>
+);
+
+// ─── 드롭다운 ─────────────────────────────────────────────────
+
+const Dropdown = ({
+  value,
+  options,
+  onChange,
+}: {
+  value: string;
+  options: { label: string; value: string }[];
+  onChange: (v: string) => void;
+}) => {
+  const [open, setOpen] = useState(false);
+  const label = options.find((o) => o.value === value)?.label ?? value;
+  return (
+    <div style={{ position: "relative" }}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          display: "inline-flex", alignItems: "center", gap: "4px",
+          padding: "4px 10px", backgroundColor: "#2C2C30",
+          border: "none", borderRadius: "6px", cursor: "pointer",
+          fontSize: "12px", fontWeight: 400, color: "#FFFFFF",
+        }}
+      >
+        {label}
+        <span style={{ fontSize: "10px", color: "#9194A1" }}>▾</span>
+      </button>
+      {open && (
+        <div style={{
+          position: "absolute", top: "calc(100% + 4px)", left: 0, zIndex: 10,
+          backgroundColor: "#21242C", border: "1px solid #2F3037",
+          borderRadius: "8px", overflow: "hidden", minWidth: "130px",
+        }}>
+          {options.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => { onChange(opt.value); setOpen(false); }}
+              style={{
+                display: "block", width: "100%", padding: "8px 14px",
+                backgroundColor: opt.value === value ? "#2C2C30" : "transparent",
+                border: "none", cursor: "pointer",
+                fontSize: "12px", fontWeight: 400, color: "#FFFFFF", textAlign: "left",
+              }}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── 거래원 매매 상위 ─────────────────────────────────────────
+// 매수: 왼쪽 정렬 (순위 | 이름 | 바+수량)
+// 매도: 오른쪽 정렬 (바+수량 | 이름 | 순위) — 시안 기준
+
+const RankRow = ({
+  item,
+  maxQty,
+  side,
+}: {
+  item: TraderRankItem;
+  maxQty: number;
+  side: "buy" | "sell";
+}) => {
+  const barPct = maxQty > 0 ? Math.round((item.quantity / maxQty) * 100) : 0;
+  const color = side === "buy" ? RISE : FALL;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "10px",
+      }}
+    >
+      {/* 순위 */}
+      <span style={{
+        fontSize: "14px", fontWeight: 400, color: "#9194A1",
+        width: "16px", flexShrink: 0, textAlign: "center",
+      }}>
+        {item.rank}
+      </span>
+
+      {/* 거래원명 */}
+      <span style={{
+        fontSize: "14px", fontWeight: 400, color: "#FFFFFF",
+        width: "68px", flexShrink: 0, whiteSpace: "nowrap",
+        overflow: "hidden", textOverflow: "ellipsis",
+        textAlign: "left",
+      }}>
+        {item.name}
+      </span>
+
+      {/* 바 + 수량 */}
+      <div style={{
+        flex: 1, position: "relative", height: "20px",
+        display: "flex", alignItems: "center",
+        borderRadius: "3px", overflow: "hidden",
+      }}>
+        {/* 바 채움 — 불투명도 20% */}
+        <div style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: `${barPct}%`,
+          height: "100%",
+          backgroundColor: color,
+          opacity: 0.2,
+          borderRadius: "3px",
+          transition: "width 0.3s ease",
+        }} />
+        {/* 수량 텍스트 — 색상 100% */}
+        <span style={{
+          position: "relative", zIndex: 1,
+          width: "100%",
+          fontSize: "12px", fontWeight: 400, color: color,
+          textAlign: "left",
+          paddingLeft: "8px",
+          fontVariantNumeric: "tabular-nums",
+          whiteSpace: "nowrap",
+          boxSizing: "border-box",
+        }}>
+          {fmt(item.quantity)} 주
+        </span>
+      </div>
+    </div>
+  );
+};
+
+// ─── 라인 차트 ────────────────────────────────────────────────
+
+const TrendLineChart: React.FC<{ data: TrendDataPoint[] }> = ({ data }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current || data.length === 0) return;
+    const chart = createChart(containerRef.current, {
+      layout: { background: { type: ColorType.Solid, color: "#1C1D21" }, textColor: "#9194A1" },
+      grid: { vertLines: { color: "#2F3037" }, horzLines: { color: "#2F3037" } },
+      rightPriceScale: { borderColor: "#2F3037" },
+      timeScale: { borderColor: "#2F3037", timeVisible: true },
+      crosshair: { vertLine: { color: "#9194A1", width: 1, style: 3 }, horzLine: { color: "#9194A1", width: 1, style: 3 } },
+      width: containerRef.current.clientWidth,
+      height: 243,
+    });
+
+    const toLineData = (key: keyof Omit<TrendDataPoint, "time">): LineData[] =>
+      data.map((d) => ({ time: d.time as any, value: d[key] }));
+
+    chart.addSeries(LineSeries, { color: IND_COLOR, lineWidth: 2 }).setData(toLineData("individual"));
+    chart.addSeries(LineSeries, { color: FOR_COLOR, lineWidth: 2 }).setData(toLineData("foreign"));
+    chart.addSeries(LineSeries, { color: INST_COLOR, lineWidth: 2 }).setData(toLineData("institution"));
+    chart.timeScale().fitContent();
+
+    const ro = new ResizeObserver(() => {
+      if (containerRef.current) chart.applyOptions({ width: containerRef.current.clientWidth });
+    });
+    ro.observe(containerRef.current);
+
+    return () => { ro.disconnect(); chart.remove(); };
+  }, [data]);
+
+  return <div ref={containerRef} style={{ width: "100%", height: "243px" }} />;
+};
+
+// ─── 데이터 테이블 공통 ───────────────────────────────────────
+
+const MoreButton = ({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) => (
+  <div style={{ display: "flex", justifyContent: "center", padding: "10px 0" }}>
+    <button
+      onClick={onToggle}
+      style={{ backgroundColor: "transparent", border: "none", cursor: "pointer", fontSize: "12px", color: "#9194A1" }}
+    >
+      {expanded ? "접기 ▴" : "더 보기 ▾"}
+    </button>
+  </div>
+);
+
+const thStyle: React.CSSProperties = {
+  padding: "8px 12px", textAlign: "right", color: "#9194A1",
+  fontWeight: 400, fontSize: "12px",
+  borderBottom: "1px solid #2F3037", whiteSpace: "nowrap",
+};
+const tdBase: React.CSSProperties = { padding: "8px 12px", textAlign: "right", fontSize: "12px", fontWeight: 400 };
+
+// 추세 데이터 테이블
+const TrendDataTable: React.FC<{ rows: TrendTableRow[] }> = ({ rows }) => {
+  const [expanded, setExpanded] = useState(false);
+  const displayed = expanded ? rows : rows.slice(0, 8);
+  const HEADERS = ["일자", "종가", "등락률", "등락금액", "개인 순매수", "외국인 순매수", "외국인 지분율", "기관 순매수"];
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead><tr>{HEADERS.map((h) => <th key={h} style={thStyle}>{h}</th>)}</tr></thead>
+        <tbody>
+          {displayed.map((row, i) => (
+            <tr key={i} style={{ backgroundColor: i % 2 === 0 ? TABLE_BG1 : TABLE_BG2 }}>
+              <td style={{ ...tdBase, color: "#9194A1" }}>{row.date}</td>
+              <td style={{ ...tdBase, color: "#FFFFFF", fontVariantNumeric: "tabular-nums" }}>{fmt(row.closePrice)}원</td>
+              <td style={{ ...tdBase, color: signColor(row.changeRate) }}>{fmtRate(row.changeRate)}</td>
+              <td style={{ ...tdBase, color: signColor(row.changeAmount) }}>{fmtSigned(row.changeAmount)}원</td>
+              <td style={{ ...tdBase, color: signColor(row.individualNet) }}>{fmtSigned(row.individualNet)}주</td>
+              <td style={{ ...tdBase, color: signColor(row.foreignNet) }}>{fmtSigned(row.foreignNet)}주</td>
+              <td style={{ ...tdBase, color: "#9194A1" }}>{row.foreignRatio.toFixed(2)}%</td>
+              <td style={{ ...tdBase, color: signColor(row.institutionNet) }}>{fmtSigned(row.institutionNet)}주</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length > 8 && <MoreButton expanded={expanded} onToggle={() => setExpanded((v) => !v)} />}
+    </div>
+  );
+};
+
+// 프로그램 매매 테이블
+const ProgramTable: React.FC<{ rows: ProgramTradeRow[] }> = ({ rows }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [subFilter, setSubFilter] = useState("all");
+  const displayed = expanded ? rows : rows.slice(0, 8);
+  const HEADERS = ["일자", "순매수 증감", "순매수", "매수", "매도", "비차익 순매수"];
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      <Dropdown value={subFilter} options={[{ label: "전체", value: "all" }, { label: "비차익·차익 거래", value: "nonarbitrage" }]} onChange={setSubFilter} />
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead><tr>{HEADERS.map((h) => <th key={h} style={thStyle}>{h}</th>)}</tr></thead>
+          <tbody>
+            {displayed.map((row, i) => (
+              <tr key={i} style={{ backgroundColor: i % 2 === 0 ? TABLE_BG1 : TABLE_BG2 }}>
+                <td style={{ ...tdBase, color: "#9194A1" }}>{row.date}</td>
+                <td style={{ ...tdBase, color: signColor(row.netBuyChange) }}>{fmtSigned(row.netBuyChange)}</td>
+                <td style={{ ...tdBase, color: signColor(row.netBuy) }}>{fmtSigned(row.netBuy)}</td>
+                <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.buy)}</td>
+                <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.sell)}</td>
+                <td style={{ ...tdBase, color: signColor(row.nonArbitrageNet) }}>{fmtSigned(row.nonArbitrageNet)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {rows.length > 8 && <MoreButton expanded={expanded} onToggle={() => setExpanded((v) => !v)} />}
+    </div>
+  );
+};
+
+// 신용거래 테이블
+const CreditTable: React.FC<{ rows: CreditTradeRow[] }> = ({ rows }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [creditFilter, setCreditFilter] = useState("융자");
+  const filtered = rows.filter((r) => r.type === creditFilter);
+  const displayed = expanded ? filtered : filtered.slice(0, 8);
+  const HEADERS = ["일자", "증감수량", "신규수량", "상환수량", "잔고수량", "잔고율"];
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      <Dropdown value={creditFilter} options={[{ label: "신용융자", value: "융자" }, { label: "신용대주", value: "대주" }]} onChange={setCreditFilter} />
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead><tr>{HEADERS.map((h) => <th key={h} style={thStyle}>{h}</th>)}</tr></thead>
+          <tbody>
+            {displayed.map((row, i) => (
+              <tr key={i} style={{ backgroundColor: i % 2 === 0 ? TABLE_BG1 : TABLE_BG2 }}>
+                <td style={{ ...tdBase, color: "#9194A1" }}>{row.date}</td>
+                <td style={{ ...tdBase, color: signColor(row.changeQty) }}>{fmtSigned(row.changeQty)}</td>
+                <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.newQty)}</td>
+                <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.repayQty)}</td>
+                <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.balanceQty)}</td>
+                <td style={{ ...tdBase, color: "#9194A1" }}>{row.balanceRate.toFixed(2)}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {filtered.length > 8 && <MoreButton expanded={expanded} onToggle={() => setExpanded((v) => !v)} />}
+    </div>
+  );
+};
+
+// 대차거래 테이블
+const LendingTable: React.FC<{ rows: LendingTradeRow[] }> = ({ rows }) => {
+  const [expanded, setExpanded] = useState(false);
+  const displayed = expanded ? rows : rows.slice(0, 8);
+  const HEADERS = ["일자", "증감수량", "신규수량", "상환수량", "잔고수량"];
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead><tr>{HEADERS.map((h) => <th key={h} style={thStyle}>{h}</th>)}</tr></thead>
+        <tbody>
+          {displayed.map((row, i) => (
+            <tr key={i} style={{ backgroundColor: i % 2 === 0 ? TABLE_BG1 : TABLE_BG2 }}>
+              <td style={{ ...tdBase, color: "#9194A1" }}>{row.date}</td>
+              <td style={{ ...tdBase, color: signColor(row.changeQty) }}>{fmtSigned(row.changeQty)}</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.newQty)}</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.repayQty)}</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.balanceQty)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length > 8 && <MoreButton expanded={expanded} onToggle={() => setExpanded((v) => !v)} />}
+    </div>
+  );
+};
+
+// 공매도 테이블
+const ShortTable: React.FC<{ rows: ShortTradeRow[] }> = ({ rows }) => {
+  const [expanded, setExpanded] = useState(false);
+  const displayed = expanded ? rows : rows.slice(0, 8);
+  const HEADERS = ["일자", "거래대금대비 비율", "공매도 수량", "공매도 금액", "공매도 평균가", "거래대금"];
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead><tr>{HEADERS.map((h) => <th key={h} style={thStyle}>{h}</th>)}</tr></thead>
+        <tbody>
+          {displayed.map((row, i) => (
+            <tr key={i} style={{ backgroundColor: i % 2 === 0 ? TABLE_BG1 : TABLE_BG2 }}>
+              <td style={{ ...tdBase, color: "#9194A1" }}>{row.date}</td>
+              <td style={{ ...tdBase, color: "#9194A1" }}>{row.tradeAmountRatio.toFixed(2)}%</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.shortQty)}</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.shortAmount)}원</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.shortAvgPrice)}원</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.tradeAmount)}원</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length > 8 && <MoreButton expanded={expanded} onToggle={() => setExpanded((v) => !v)} />}
+    </div>
+  );
+};
+
+// CFD 테이블
+const CfdTable: React.FC<{ rows: CfdTradeRow[] }> = ({ rows }) => {
+  const [expanded, setExpanded] = useState(false);
+  const displayed = expanded ? rows : rows.slice(0, 8);
+  const HEADERS = ["일자", "신규 매수 수량", "상환 매수 수량", "잔고 매수 수량", "매수 잔고율", "신규 매도 수량", "상환 매도 수량", "잔고 매도 수량", "매도 잔고율"];
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead><tr>{HEADERS.map((h) => <th key={h} style={thStyle}>{h}</th>)}</tr></thead>
+        <tbody>
+          {displayed.map((row, i) => (
+            <tr key={i} style={{ backgroundColor: i % 2 === 0 ? TABLE_BG1 : TABLE_BG2 }}>
+              <td style={{ ...tdBase, color: "#9194A1" }}>{row.date}</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.newBuyQty)}</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.repayBuyQty)}</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.balanceBuyQty)}</td>
+              <td style={{ ...tdBase, color: "#9194A1" }}>{row.buyBalanceRate.toFixed(2)}%</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.newSellQty)}</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.repaySellQty)}</td>
+              <td style={{ ...tdBase, color: "#FFFFFF" }}>{fmt(row.balanceSellQty)}</td>
+              <td style={{ ...tdBase, color: "#9194A1" }}>{row.sellBalanceRate.toFixed(2)}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length > 8 && <MoreButton expanded={expanded} onToggle={() => setExpanded((v) => !v)} />}
+    </div>
+  );
+};
+
+// ─── InvestorTradePanel (통합 패널) ───────────────────────────
+
+export const InvestorTradePanel: React.FC<InvestorTradePanelProps> = ({
+  status = "default",
+  buyList = [],
+  sellList = [],
+  rankBaseDateTime = "",
+  trendData = [],
+  trendBaseDateTime = "",
+  tableData = [],
+  programData = [],
+  creditData = [],
+  lendingData = [],
+  shortData = [],
+  cfdData = [],
+  onRetry,
+  onViewNetBuy,
+}) => {
+  const [period, setPeriod] = useState<TrendPeriod>("daily");
+  const [activeTab, setActiveTab] = useState<InvestorType>("program");
+
+  const maxBuyQty = Math.max(...buyList.map((i) => i.quantity), 1);
+  const maxSellQty = Math.max(...sellList.map((i) => i.quantity), 1);
+
+  const INVESTOR_TABS: { label: string; value: InvestorType }[] = [
+    { label: "프로그램 매매", value: "program" },
+    { label: "신용거래",     value: "credit"  },
+    { label: "대차거래",     value: "lending" },
+    { label: "공매도",       value: "short"   },
+    { label: "CFD",          value: "cfd"     },
+  ];
+
+  // 공통 섹션 카드 스타일
+  const cardStyle: React.CSSProperties = {
+    backgroundColor: "#1C1D21",
+    borderRadius: "12px",
+    padding: "24px",
+    boxSizing: "border-box",
+    width: "100%",
+  };
+
+  return (
+    // 외부 프레임: 1036x820, 좌우 패딩 30px, 내부 스크롤
+    <div
+      style={{
+        width: "1036px",
+        height: "820px",
+        backgroundColor: "#1C1D21",
+        borderRadius: "12px",
+        padding: "24px 30px",
+        boxSizing: "border-box",
+        overflowY: "auto",
+        overflowX: "hidden",
+        scrollbarWidth: "none",
+        display: "flex",
+        flexDirection: "column",
+        gap: "32px",
+      }}
+    >
+      {/* ── 거래원 매매 상위 ── */}
+      <div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "16px" }}>
+          <span style={{ fontSize: "18px", fontWeight: 700, color: "#FFFFFF" }}>거래원 매매 상위</span>
+          <span style={{ fontSize: "14px", fontWeight: 400, color: "#9194A1" }}>
+            거래소에서 제공하는 주요 거래원의 실시간 데이터입니다.
+          </span>
+        </div>
+
+        {rankBaseDateTime && (
+          <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "12px" }}>
+            <span style={{ fontSize: "14px", fontWeight: 400, color: "#9194A1" }}>
+              기준 : {rankBaseDateTime}
+            </span>
+          </div>
+        )}
+
+        {status === "skeleton" && (
+          <div style={{ display: "flex", gap: "40px" }}>
+            <div style={{ flex: 1 }}><PanelSkeleton /></div>
+            <div style={{ flex: 1 }}><PanelSkeleton /></div>
+          </div>
+        )}
+        {status === "error" && <ErrorBlock onRetry={onRetry} />}
+        {status === "default" && (
+          <div style={{ display: "flex", gap: "40px" }}>
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "10px" }}>
+              <span style={{ fontSize: "14px", fontWeight: 700, color: "#FFFFFF" }}>매수 상위 5</span>
+              {buyList.map((item) => (
+                <RankRow key={item.rank} item={item} maxQty={maxBuyQty} side="buy" />
+              ))}
+            </div>
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "10px" }}>
+              <span style={{ fontSize: "14px", fontWeight: 700, color: "#FFFFFF" }}>매도 상위 5</span>
+              {sellList.map((item) => (
+                <RankRow key={item.rank} item={item} maxQty={maxSellQty} side="sell" />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ── 구분선 ── */}
+      <div style={{ height: "1px", backgroundColor: "#2F3037", flexShrink: 0 }} />
+
+      {/* ── 투자자별 매매 동향 ── */}
+      <div>
+        <div style={{ display: "flex", flexDirection: "column", gap: "4px", marginBottom: "16px" }}>
+          <span style={{ fontSize: "18px", fontWeight: 700, color: "#FFFFFF" }}>투자자별 매매 동향</span>
+          <span style={{ fontSize: "14px", fontWeight: 400, color: "#9194A1" }}>
+            외국인 순매수량은 장외거래를 포함한 매매수량입니다.
+          </span>
+        </div>
+
+        {status === "skeleton" && <ChartSkeleton />}
+        {status === "error" && <ErrorBlock onRetry={onRetry} />}
+        {status === "default" && (
+          <>
+            {trendBaseDateTime && (
+              <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "12px" }}>
+                <span style={{ fontSize: "14px", fontWeight: 400, color: "#9194A1" }}>
+                  기준 : {trendBaseDateTime}
+                </span>
+              </div>
+            )}
+
+            {/* 기간 드롭다운 + 순매수 보기 버튼 */}
+            <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" }}>
+              <Dropdown
+                value={period}
+                options={[{ label: "일별", value: "daily" }, { label: "1주일", value: "weekly" }]}
+                onChange={(v) => setPeriod(v as TrendPeriod)}
+              />
+              <div style={{ flex: 1 }} />
+              <button
+                onClick={onViewNetBuy}
+                style={{
+                  width: "152px", height: "32px",
+                  backgroundColor: "#2C2C30", border: "none", borderRadius: "5px",
+                  cursor: "pointer", fontSize: "12px", fontWeight: 400, color: "#FFFFFF",
+                }}
+              >
+                투자자별 순매수 보기
+              </button>
+            </div>
+
+            {/* 범례 */}
+            <div style={{ display: "flex", gap: "16px", alignItems: "center", marginBottom: "12px" }}>
+              {[
+                { color: IND_COLOR, label: "개인" },
+                { color: FOR_COLOR, label: "외국인" },
+                { color: INST_COLOR, label: "기관" },
+              ].map((item) => (
+                <div key={item.label} style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                  <div style={{ width: "8px", height: "8px", borderRadius: "50%", backgroundColor: item.color, flexShrink: 0 }} />
+                  <span style={{ fontSize: "12px", fontWeight: 700, color: "#FFFFFF" }}>{item.label}</span>
+                </div>
+              ))}
+            </div>
+
+            {/* 라인 차트 */}
+            <TrendLineChart data={trendData} />
+
+            {/* 데이터 테이블 */}
+            <div style={{ marginTop: "16px" }}>
+              <TrendDataTable rows={tableData} />
+            </div>
+
+            {/* 투자 유형별 현황 */}
+            <div style={{ marginTop: "24px", display: "flex", flexDirection: "column", gap: "16px" }}>
+              <span style={{ fontSize: "18px", fontWeight: 700, color: "#FFFFFF" }}>투자 유형별 현황</span>
+              <div style={{ display: "flex", borderBottom: "1px solid #2F3037" }}>
+                {INVESTOR_TABS.map((tab) => (
+                  <button
+                    key={tab.value}
+                    onClick={() => setActiveTab(tab.value)}
+                    style={{
+                      padding: "8px 16px",
+                      backgroundColor: "transparent", border: "none",
+                      borderBottom: activeTab === tab.value ? "2px solid #FFFFFF" : "2px solid transparent",
+                      cursor: "pointer", fontSize: "14px",
+                      fontWeight: activeTab === tab.value ? 700 : 400,
+                      color: activeTab === tab.value ? "#FFFFFF" : "#9194A1",
+                      marginBottom: "-1px", whiteSpace: "nowrap",
+                    }}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+              {activeTab === "program" && <ProgramTable rows={programData} />}
+              {activeTab === "credit"  && <CreditTable rows={creditData} />}
+              {activeTab === "lending" && <LendingTable rows={lendingData} />}
+              {activeTab === "short"   && <ShortTable rows={shortData} />}
+              {activeTab === "cfd"     && <CfdTable rows={cfdData} />}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default InvestorTradePanel;


### PR DESCRIPTION
# [Feat] 거래현황 탭 컴포넌트 개발 및 Storybook 등록

## 📌 1. PR 요약
거래현황 탭의 투자자별 매매 동향 라인 차트 및 상위 거래원 리스트 컴포넌트를 개발하고, 이를 Storybook에 4가지 상태(Default, Skeleton, Error, Playground)로 등록하여 독립적인 테스트 환경을 구축했습니다.

## 🛠 2. 작업 내용
### 투자자별 시계열 Mock 데이터 정의
- 개인, 기관, 외국인 투자자의 매매 동향을 검증하기 위한 시계열 데이터 세트(Mock 데이터)를 구성했습니다.

### 상위 거래원 리스트 (InvestorTradingRankList) 구현
- 매수 및 매도 상위 5개 거래원을 시각적으로 파악할 수 있는 바(Bar) 리스트 컴포넌트를 개발했습니다.

### 매매 동향 라인 차트 (InvestorTrendChart) 구현
- 투자자 주체별(개인/기관/외국인) 매매 동향 흐름을 보여주는 라인 차트 컴포넌트를 구현했습니다.

### Storybook 상태별 등록
- 구현된 두 컴포넌트를 Default, Skeleton, Error, Playground 총 4가지 상태로 분기하여 Storybook에 등록했습니다.

## 📸 3. 스크린샷
| `InvestorTradingRankList` | `InvestorTrendChart` |
|:---:|:---:|
| <img width="1085" height="370" alt="image" src="https://github.com/user-attachments/assets/4b48b1e3-4872-40f3-8b73-ee362bb72496" /> | <img width="1048" height="837" alt="image" src="https://github.com/user-attachments/assets/35630c0f-17b8-4f3c-9e92-bc33ea32e43f" /> |

## 📋 4. 파일 변경 목록
- `InvestorTradePanel.tsx`: `InvestorTradingRankList` 및 `InvestorTrendChart` 컴포넌트 마크업/로직 구현, 시계열 Mock 데이터 연동
- `InvestorTradePanel.stories.tsx`: 4가지 상태(Default, Skeleton, Error, Playground)에 대한 컴포넌트별 Story 시나리오 추가

## 💬 5. 리뷰 포인트
- **차트 렌더링 및 가독성**: `InvestorTrendChart`의 라인 차트가 개인, 기관, 외국인 데이터를 명확하게 구분하여 렌더링하는지 스크린샷으로 확인해 주시기 바랍니다.
- **상위 거래원 바(Bar) 비율**: `InvestorTradingRankList`에서 매수/매도 상위 5개 거래원의 바 길이 비율이 데이터 수치에 맞게 시각적으로 정확히 표현되는지 검토 부탁드립니다.
- **예외 상태 (Skeleton/Error)**: 데이터 로딩 시의 스켈레톤 애니메이션과 에러 발생 시의 UI가 디자인 가이드에 맞춰 자연스럽게 노출되는지 Storybook 환경에서 확인해 주시기 바랍니다.