### PR TITLE
[Story] 거래현황 탭 StockDetailPage 통합 및 반응형 검증

### DIFF
--- a/apps/web/Design_UI/src/components/common/stock/InvestorTradePanel/InvestorTradePanel.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/InvestorTradePanel/InvestorTradePanel.tsx
@@ -102,6 +102,9 @@ export interface InvestorTradePanelProps {
   cfdData?: CfdTradeRow[];
   onRetry?: () => void;
   onViewNetBuy?: () => void;
+  // 패널 크기 (뷰포트별 override)
+  panelWidth?: number;
+  panelHeight?: number;
 }
 
 // ─── 색상 ─────────────────────────────────────────────────────
@@ -547,6 +550,8 @@ export const InvestorTradePanel: React.FC<InvestorTradePanelProps> = ({
   cfdData = [],
   onRetry,
   onViewNetBuy,
+  panelWidth = 1036,
+  panelHeight = 820,
 }) => {
   const [period, setPeriod] = useState<TrendPeriod>("daily");
   const [activeTab, setActiveTab] = useState<InvestorType>("program");
@@ -562,27 +567,18 @@ export const InvestorTradePanel: React.FC<InvestorTradePanelProps> = ({
     { label: "CFD",          value: "cfd"     },
   ];
 
-  // 공통 섹션 카드 스타일
-  const cardStyle: React.CSSProperties = {
-    backgroundColor: "#1C1D21",
-    borderRadius: "12px",
-    padding: "24px",
-    boxSizing: "border-box",
-    width: "100%",
-  };
-
   return (
-    // 외부 프레임: 1036x820, 좌우 패딩 30px, 내부 스크롤
+    // 외부 프레임: 뷰포트별 크기, 좌우 패딩 30px, 내부 스크롤
     <div
       style={{
-        width: "1036px",
-        height: "820px",
+        width: `${panelWidth}px`,
+        height: `${panelHeight}px`,
         backgroundColor: "#1C1D21",
         borderRadius: "12px",
-        padding: "24px 30px",
+        padding: "24px 16px",
         boxSizing: "border-box",
         overflowY: "auto",
-        overflowX: "hidden",
+        overflowX: panelWidth <= 345 ? "auto" : "hidden",
         scrollbarWidth: "none",
         display: "flex",
         flexDirection: "column",
@@ -614,7 +610,12 @@ export const InvestorTradePanel: React.FC<InvestorTradePanelProps> = ({
         )}
         {status === "error" && <ErrorBlock onRetry={onRetry} />}
         {status === "default" && (
-          <div style={{ display: "flex", gap: "40px" }}>
+          /* 모바일(345px): 매수/매도 상하 배치 / 그 외: 좌우 배치 */
+          <div style={{
+            display: "flex",
+            flexDirection: panelWidth <= 345 ? "column" : "row",
+            gap: panelWidth <= 345 ? "24px" : "40px",
+          }}>
             <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "10px" }}>
               <span style={{ fontSize: "14px", fontWeight: 700, color: "#FFFFFF" }}>매수 상위 5</span>
               {buyList.map((item) => (

--- a/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.stories.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.stories.tsx
@@ -6,6 +6,11 @@ import type { OrderbookRow, MarketInfo } from "../OrderbookTable/OrderbookTable"
 import type { TradeTickRow } from "../TradeTickerList/TradeTickerList";
 import type { SparklineDataPoint } from "../AIPredictionPanel/SparklineChart";
 import type { AnalysisData } from "../AIPredictionPanel/PredictionAnalysisWidget";
+import type {
+  TrendDataPoint, TrendTableRow,
+  ProgramTradeRow, CreditTradeRow, LendingTradeRow,
+  ShortTradeRow, CfdTradeRow,
+} from "../InvestorTradePanel/InvestorTradePanel";
 
 // ════════════════════════════════════════════════════════════════
 // Mock Data
@@ -153,6 +158,111 @@ const MOCK_AI_ANALYSIS: AnalysisData = {
 
 // ─── 공통 args ────────────────────────────────────────────────
 
+const MOCK_BUY_LIST = [
+  { rank: 1, name: "미래에셋증권", quantity: 1240000 },
+  { rank: 2, name: "키움증권",     quantity: 980000  },
+  { rank: 3, name: "삼성증권",     quantity: 750000  },
+  { rank: 4, name: "NH투자증권",   quantity: 620000  },
+  { rank: 5, name: "한국투자증권", quantity: 430000  },
+];
+
+const MOCK_SELL_LIST = [
+  { rank: 1, name: "외국계A",      quantity: 1100000 },
+  { rank: 2, name: "외국계B",      quantity: 870000  },
+  { rank: 3, name: "KB증권",       quantity: 650000  },
+  { rank: 4, name: "신한투자증권", quantity: 490000  },
+  { rank: 5, name: "메리츠증권",   quantity: 310000  },
+];
+
+const MOCK_TREND_DATA: TrendDataPoint[] = [
+  { time: "2026-03-19", individual: -5200000,  foreign:  8100000,  institution:  2300000 },
+  { time: "2026-03-20", individual:  3100000,  foreign: -4200000,  institution:  1800000 },
+  { time: "2026-03-23", individual: -1800000,  foreign:  6500000,  institution: -3200000 },
+  { time: "2026-03-24", individual:  7400000,  foreign: -9800000,  institution:  4100000 },
+  { time: "2026-03-25", individual: -6300000,  foreign: 12000000,  institution: -2700000 },
+  { time: "2026-03-26", individual:  2900000,  foreign: -5600000,  institution:  3500000 },
+  { time: "2026-03-27", individual: -4100000,  foreign:  7300000,  institution: -1900000 },
+  { time: "2026-03-30", individual:  8200000,  foreign: -11000000, institution:  5600000 },
+  { time: "2026-03-31", individual: -3700000,  foreign:  9400000,  institution: -4300000 },
+  { time: "2026-04-01", individual:  5100000,  foreign: -6800000,  institution:  2100000 },
+];
+
+const MOCK_TRADE_TABLE: TrendTableRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  closePrice: 75000 + Math.floor((Math.random() - 0.5) * 3000),
+  changeRate: parseFloat(((Math.random() - 0.5) * 4).toFixed(2)),
+  changeAmount: Math.floor((Math.random() - 0.5) * 2000),
+  individualNet: Math.floor((Math.random() - 0.5) * 10000000),
+  foreignNet: Math.floor((Math.random() - 0.5) * 15000000),
+  foreignRatio: parseFloat((52 + (Math.random() - 0.5) * 2).toFixed(2)),
+  institutionNet: Math.floor((Math.random() - 0.5) * 8000000),
+}));
+
+const MOCK_PROGRAM_DATA: ProgramTradeRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  netBuyChange: Math.floor((Math.random() - 0.5) * 5000000),
+  netBuy: Math.floor((Math.random() - 0.5) * 20000000),
+  buy: Math.floor(Math.random() * 50000000 + 10000000),
+  sell: Math.floor(Math.random() * 50000000 + 10000000),
+  nonArbitrageNet: Math.floor((Math.random() - 0.5) * 15000000),
+}));
+
+const MOCK_CREDIT_DATA: CreditTradeRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  type: i % 2 === 0 ? "융자" : "대주",
+  changeQty: Math.floor((Math.random() - 0.5) * 100000),
+  newQty: Math.floor(Math.random() * 200000 + 50000),
+  repayQty: Math.floor(Math.random() * 150000 + 30000),
+  balanceQty: Math.floor(Math.random() * 5000000 + 1000000),
+  balanceRate: parseFloat((Math.random() * 5).toFixed(2)),
+}));
+
+const MOCK_LENDING_DATA: LendingTradeRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  changeQty: Math.floor((Math.random() - 0.5) * 50000),
+  newQty: Math.floor(Math.random() * 100000 + 20000),
+  repayQty: Math.floor(Math.random() * 80000 + 15000),
+  balanceQty: Math.floor(Math.random() * 2000000 + 500000),
+}));
+
+const MOCK_SHORT_DATA: ShortTradeRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  tradeAmountRatio: parseFloat((Math.random() * 8 + 1).toFixed(2)),
+  shortQty: Math.floor(Math.random() * 500000 + 100000),
+  shortAmount: Math.floor(Math.random() * 30000000000 + 5000000000),
+  shortAvgPrice: Math.floor(74000 + (Math.random() - 0.5) * 2000),
+  tradeAmount: Math.floor(Math.random() * 400000000000 + 50000000000),
+}));
+
+const MOCK_CFD_DATA: CfdTradeRow[] = Array.from({ length: 10 }, (_, i) => ({
+  date: `2026-04-${String(15 - i).padStart(2, "0")}`,
+  newBuyQty: Math.floor(Math.random() * 50000),
+  repayBuyQty: Math.floor(Math.random() * 40000),
+  balanceBuyQty: Math.floor(Math.random() * 200000 + 50000),
+  buyBalanceRate: parseFloat((Math.random() * 3).toFixed(2)),
+  newSellQty: Math.floor(Math.random() * 45000),
+  repaySellQty: Math.floor(Math.random() * 35000),
+  balanceSellQty: Math.floor(Math.random() * 180000 + 40000),
+  sellBalanceRate: parseFloat((Math.random() * 3).toFixed(2)),
+}));
+
+// 거래현황 공통 args
+const TRADE_ARGS = {
+  tradeState: "default" as const,
+  buyList: MOCK_BUY_LIST,
+  sellList: MOCK_SELL_LIST,
+  rankBaseDateTime: "2026.04.20 15:30",
+  trendData: MOCK_TREND_DATA,
+  trendBaseDateTime: "2026.04.20 15:30",
+  tradeTableData: MOCK_TRADE_TABLE,
+  programData: MOCK_PROGRAM_DATA,
+  creditData: MOCK_CREDIT_DATA,
+  lendingData: MOCK_LENDING_DATA,
+  shortData: MOCK_SHORT_DATA,
+  cfdData: MOCK_CFD_DATA,
+  onViewNetBuy: () => alert("투자자별 순매수 보기"),
+};
+
 const COMMON_ARGS = {
   stock: MOCK_STOCK,
   chartData: MOCK_CHART_DATA,
@@ -183,6 +293,9 @@ const COMMON_ARGS = {
   aiUpProbability: 72,
   aiDownProbability: 28,
   aiAnalysisData: MOCK_AI_ANALYSIS,
+
+  // 거래현황 데이터
+  ...TRADE_ARGS,
 };
 
 // ════════════════════════════════════════════════════════════════
@@ -235,6 +348,11 @@ const meta: Meta<typeof StockDetailPage> = {
       control: "radio",
       options: ["default", "skeleton", "error", "empty"],
       description: "AI 예측 패널 상태",
+    },
+    tradeState: {
+      control: "radio",
+      options: ["default", "skeleton", "error"],
+      description: "거래현황 패널 상태",
     },
     viewport: {
       control: "radio",
@@ -451,6 +569,80 @@ export const MobileTabSwitching: Story = {
           activeTab={tab}
           onTabChange={(t) => setTab(t as any)}
           viewport="mobile"
+        />
+      </div>
+    );
+  },
+};
+
+// ════════════════════════════════════════════════════════════════
+// 거래현황 탭 Stories
+// ════════════════════════════════════════════════════════════════
+
+export const DesktopTrade: Story = {
+  name: "Desktop / Trade Tab — Default",
+  args: { ...COMMON_ARGS, activeTab: "trade", viewport: "desktop" },
+  decorators: [desktopDec],
+};
+
+export const DesktopTradeSkeleton: Story = {
+  name: "Desktop / Trade Tab — Skeleton",
+  args: { ...COMMON_ARGS, activeTab: "trade", viewport: "desktop", tradeState: "skeleton" },
+  decorators: [desktopDec],
+};
+
+export const DesktopTradeError: Story = {
+  name: "Desktop / Trade Tab — Error",
+  args: { ...COMMON_ARGS, activeTab: "trade", viewport: "desktop", tradeState: "error" },
+  decorators: [desktopDec],
+};
+
+export const TabletTrade: Story = {
+  name: "Tablet / Trade Tab — Default",
+  args: { ...COMMON_ARGS, activeTab: "trade", viewport: "tablet" },
+  parameters: { viewport: { defaultViewport: "tablet" } },
+  decorators: [tabletDec],
+};
+
+export const TabletTradeSkeleton: Story = {
+  name: "Tablet / Trade Tab — Skeleton",
+  args: { ...COMMON_ARGS, activeTab: "trade", viewport: "tablet", tradeState: "skeleton" },
+  parameters: { viewport: { defaultViewport: "tablet" } },
+  decorators: [tabletDec],
+};
+
+export const MobileTrade: Story = {
+  name: "Mobile / Trade Tab — Default",
+  args: { ...COMMON_ARGS, activeTab: "trade", viewport: "mobile" },
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  decorators: [mobileDec],
+};
+
+export const MobileTradeSkeleton: Story = {
+  name: "Mobile / Trade Tab — Skeleton",
+  args: { ...COMMON_ARGS, activeTab: "trade", viewport: "mobile", tradeState: "skeleton" },
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  decorators: [mobileDec],
+};
+
+export const DesktopTradeTabSwitching: Story = {
+  name: "Desktop / Trade Tab Switching Demo",
+  parameters: {
+    docs: {
+      description: {
+        story: "거래현황 탭 전환 인터랙션 데모. 탭 클릭으로 차트·거래현황 간 전환을 확인합니다.",
+      },
+    },
+  },
+  render: () => {
+    const [tab, setTab] = useState<"chart" | "orderbook" | "trade" | "ai">("trade");
+    return (
+      <div style={{ minWidth: "1440px" }}>
+        <StockDetailPage
+          {...COMMON_ARGS}
+          activeTab={tab}
+          onTabChange={(t) => setTab(t as any)}
+          viewport="desktop"
         />
       </div>
     );

--- a/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.tsx
+++ b/apps/web/Design_UI/src/components/common/stock/StockDetailPage/StockDetailPage.tsx
@@ -4,6 +4,7 @@ import { MobileTabSwitcher } from "../../../common/MobileTabSwitcher/MobileTabSw
 import { TradingViewWrapper } from "../TradingViewWrapper/TradingViewWrapper";
 import { OrderbookTable } from "../OrderbookTable/OrderbookTable";
 import { AIPredictionPanel } from "../AIPredictionPanel/AIPredictionPanel";
+import { InvestorTradePanel } from "../InvestorTradePanel/InvestorTradePanel";
 import { ChartIcon } from "../../../icons/ChartIcon";
 import { StockInfoIcon } from "../../../icons/StockInfoIcon";
 import { TradeStatusIcon } from "../../../icons/TradeStatusIcon";
@@ -14,6 +15,16 @@ import type { TradeTickRow } from "../TradeTickerList/TradeTickerList";
 import type { Viewport } from "../StockTable/StockTable";
 import type { SparklineDataPoint } from "../AIPredictionPanel/SparklineChart";
 import type { AnalysisData } from "../AIPredictionPanel/PredictionAnalysisWidget";
+import type {
+  TraderRankItem,
+  TrendDataPoint,
+  TrendTableRow,
+  ProgramTradeRow,
+  CreditTradeRow,
+  LendingTradeRow,
+  ShortTradeRow,
+  CfdTradeRow,
+} from "../InvestorTradePanel/InvestorTradePanel";
 
 // ─── Types ────────────────────────────────────────────────────
 
@@ -70,6 +81,21 @@ export interface StockDetailPageProps {
   aiUpProbability?: number;
   aiDownProbability?: number;
   aiAnalysisData?: AnalysisData;
+
+  // ── 거래현황 패널 ─────────────────────────────────────────
+  tradeState?: PanelState;
+  buyList?: TraderRankItem[];
+  sellList?: TraderRankItem[];
+  rankBaseDateTime?: string;
+  trendData?: TrendDataPoint[];
+  trendBaseDateTime?: string;
+  tradeTableData?: TrendTableRow[];
+  programData?: ProgramTradeRow[];
+  creditData?: CreditTradeRow[];
+  lendingData?: LendingTradeRow[];
+  shortData?: ShortTradeRow[];
+  cfdData?: CfdTradeRow[];
+  onViewNetBuy?: () => void;
 }
 
 // ─── 탭 정의 ──────────────────────────────────────────────────
@@ -225,6 +251,20 @@ export const StockDetailPage = ({
   aiUpProbability = 0,
   aiDownProbability = 0,
   aiAnalysisData,
+
+  tradeState = "default",
+  buyList = [],
+  sellList = [],
+  rankBaseDateTime = "",
+  trendData = [],
+  trendBaseDateTime = "",
+  tradeTableData = [],
+  programData = [],
+  creditData = [],
+  lendingData = [],
+  shortData = [],
+  cfdData = [],
+  onViewNetBuy,
 }: StockDetailPageProps) => {
   const [internalTab, setInternalTab] = useState<DetailTab>("chart");
   const activeTab = activeTabProp ?? internalTab;
@@ -304,6 +344,38 @@ export const StockDetailPage = ({
       analysisData={aiAnalysisData}
     />
   );
+
+  // ── 거래현황 패널 ─────────────────────────────────────────
+  // desktop: 1036x820 / tablet: 710x820 / mobile: 345x657
+  const TRADE_PANEL_SIZE: Record<Viewport, { width: number; height: number }> = {
+    desktop: { width: 1036, height: 820 },
+    tablet:  { width: 710,  height: 820 },
+    mobile:  { width: 345,  height: 657 },
+  };
+
+  const renderTrade = () => {
+    const { width, height } = TRADE_PANEL_SIZE[viewport];
+    return (
+      <InvestorTradePanel
+        status={tradeState === "skeleton" ? "skeleton" : tradeState === "error" ? "error" : "default"}
+        buyList={buyList}
+        sellList={sellList}
+        rankBaseDateTime={rankBaseDateTime}
+        trendData={trendData}
+        trendBaseDateTime={trendBaseDateTime}
+        tableData={tradeTableData}
+        programData={programData}
+        creditData={creditData}
+        lendingData={lendingData}
+        shortData={shortData}
+        cfdData={cfdData}
+        onRetry={onRetry}
+        onViewNetBuy={onViewNetBuy}
+        panelWidth={width}
+        panelHeight={height}
+      />
+    );
+  };
 
   return (
     <div
@@ -416,15 +488,8 @@ export const StockDetailPage = ({
 
         {/* ══ 거래현황 탭 ══════════════════════════════════════ */}
         {activeTab === "trade" && (
-          <div
-            style={{
-              padding: "40px 24px",
-              color: "#9194A1",
-              fontSize: "14px",
-              textAlign: "center",
-            }}
-          >
-            거래현황 탭 — InvestorTable 구현 예정 (이슈 6+)
+          <div style={{ padding: isMobile ? "12px" : "16px 24px", boxSizing: "border-box" }}>
+            {renderTrade()}
           </div>
         )}
 


### PR DESCRIPTION
# [Story] 거래현황 탭 StockDetailPage 통합 및 반응형 검증

## 📌 1. PR 요약
이전 태스크에서 개발된 거래현황 탭 컴포넌트들을 `StockDetailPage`에 통합하고, 데스크톱, 태블릿, 모바일 등 다양한 뷰포트 해상도에 맞춘 반응형 레이아웃 분기 로직 적용 및 Storybook 검증 시나리오 구성을 완료했습니다.

## 🛠 2. 작업 내용
### 컴포넌트 크기 동적 제어 (`InvestorTradePanel`)
- 패널 내부에 하드코딩되어 있던 크기 속성을 제거하고, `panelWidth` 및 `panelHeight` prop을 도입하여 외부에서 반응형 크기를 주입할 수 있도록 개선했습니다.

### 거래현황 탭 페이지 통합 (`StockDetailPage`)
- 거래현황 데이터 관련 14개의 신규 prop(`tradeState`, `buyList`, `sellList`, `trendData` 등)을 추가했습니다.
- `renderTrade()` 함수를 구현하여, 뷰포트 해상도에 따라 패널 크기가 자동으로 분기되도록 적용했습니다.
  - Desktop: 1036 × 820
  - Tablet: 710 × 820
  - Mobile: 345 × 657

### Mock 데이터 연동 및 반응형 Story 작성
- 시계열 및 매매 동향 검증을 위한 7종의 Mock 데이터(`MOCK_BUY_LIST`, `MOCK_TREND_DATA` 등)를 정의 및 연동했습니다.
- 해상도 및 상태를 검증할 수 있는 총 8종의 Page Story를 추가했습니다.
  - Desktop: Default, Skeleton, Error, Tab Switching Demo
  - Tablet: Default, Skeleton
  - Mobile: Default, Skeleton

## 📸 3. 스크린샷
| `Desktop View (Default & Tab)` | `Tablet View (Default & Tab)` | `Mobile View (Default & Tab)` |
|:---:|:---:|:---:|
| <img width="1093" height="872" alt="image" src="https://github.com/user-attachments/assets/03b53082-e93e-4b6b-9d43-f43a7d345531" /> | <img width="748" height="869" alt="image" src="https://github.com/user-attachments/assets/420f16f6-52a4-4f06-8f8a-79e9b8e05e83" /> | <img width="364" height="770" alt="image" src="https://github.com/user-attachments/assets/804fc657-a16c-496d-8419-ff7daf8b0c06" /> |

## 📋 4. 파일 변경 목록
- `InvestorTradePanel.tsx`: `panelWidth`, `panelHeight` prop 추가(기본값 1036/820) 및 내부 하드코딩 크기 변수 교체
- `StockDetailPage.tsx`: `InvestorTradePanel` 통합, 거래현황 연동용 prop 14개 추가 및 뷰포트별 패널 크기 자동 분기를 위한 `renderTrade()` 함수 구현
- `StockDetailPage.stories.tsx`: 거래현황 Mock 데이터 7종 정의, `TRADE_ARGS` 추가 및 뷰포트별/상태별 8종 Story 시나리오 등록

## 💬 5. 리뷰 포인트
- **뷰포트별 해상도 대응**: 스크린샷을 통해 모바일(345×657) 및 태블릿(710×820) 해상도 환경에서 차트와 랭킹 리스트가 겹치거나 잘리는 현상 없이 자연스럽게 배치되었는지 시각적으로 검토 부탁드립니다.
- **탭 전환 인터랙션**: 데스크톱 환경의 `Tab Switching Demo` Story에서 차트/호가 탭에서 거래현황 탭으로 전환될 때, 레이아웃의 높이나 너비가 튀는 현상 없이 매끄럽게 렌더링되는지 확인해 주시기 바랍니다.
- **예외 상태 렌더링**: 거래현황 탭 진입 시 Skeleton(로딩 중) 및 Error 상태 UI가 컴포넌트 크기에 맞춰 올바르게 노출되는지 스크린샷으로 확인해 주시기 바랍니다.