### PR TITLE
[Test] 차트 조회 API 부하 테스트 및 로깅을 통한 성능 저하 원인 진단

### DIFF
--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/global/aspect/ExecutionTimeAspect.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/global/aspect/ExecutionTimeAspect.java
@@ -1,0 +1,29 @@
+package com.assetmind.server_stock.global.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class ExecutionTimeAspect {
+
+    @Around("@annotation(LogExecutionTime)")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+
+        Object proceed = joinPoint.proceed();
+
+        long executionTime = System.currentTimeMillis() - start;
+
+        String className = joinPoint.getSignature().getDeclaringType().getSimpleName();
+        String methodName = joinPoint.getSignature().getName();
+
+        log.info("[{}.{}] 실행 시간: {}ms", className, methodName, executionTime);
+
+        return proceed;
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/global/aspect/LogExecutionTime.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/global/aspect/LogExecutionTime.java
@@ -1,0 +1,12 @@
+package com.assetmind.server_stock.global.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogExecutionTime {
+
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
@@ -1,5 +1,6 @@
 package com.assetmind.server_stock.stock.application;
 
+import com.assetmind.server_stock.global.aspect.LogExecutionTime;
 import com.assetmind.server_stock.global.error.ErrorCode;
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1dRepository;
@@ -24,6 +25,7 @@ public class ChartService {
     private final Ohlcv1mRepository ohlcv1mRepository;
     private final Ohlcv1dRepository ohlcv1dRepository;
 
+    @LogExecutionTime
     public ChartResponseDto getCandles(String stockCode, String timeframe, LocalDateTime endTime, int limit) {
         if (endTime == null) {
             endTime = LocalDateTime.now();

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
@@ -1,5 +1,6 @@
 package com.assetmind.server_stock.stock.infrastructure.persistence.jpa;
 
+import com.assetmind.server_stock.global.aspect.LogExecutionTime;
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1mRepository;
 import com.assetmind.server_stock.stock.infrastructure.persistence.entity.Ohlcv1dJpaEntity;
@@ -69,6 +70,7 @@ public class Ohlcv1mJpaAdapter implements Ohlcv1mRepository {
                 .toList();
     }
 
+    @LogExecutionTime
     @Override
     public List<OhlcvDto> findDynamicMinuteCandles(String stockCode, String intervalString,
             LocalDateTime endTime, int limit) {

--- a/apps/server-stock/src/main/resources/logback-spring.xml
+++ b/apps/server-stock/src/main/resources/logback-spring.xml
@@ -28,6 +28,19 @@
     <encoder><pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern></encoder>
   </appender>
 
+  <appender name="FILE_PERF" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>logs/performance.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>logs/performance.%d{yyyy-MM-dd}.gz</fileNamePattern>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <encoder><pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern></encoder>
+  </appender>
+
+  <logger name="com.assetmind.server_stock.global.aspect.ExecutionTimeAspect" level="INFO" additivity="false">
+    <appender-ref ref="FILE_PERF" />
+  </logger>
+
   <root level="INFO">
     <appender-ref ref="CONSOLE" />
     <appender-ref ref="FILE_GENERAL" />


### PR DESCRIPTION
##  ✏️ 작업 내용
- **메서드 실행 시간 로깅:** **스프링 AOP**를 활용해서 공통 관심사인 해당 메서드의 실행 시간 로깅 로직은 어노테이션으로 분리를 하고 해당 메서드는 비즈니스 로직에만 집중하도록 구성
- **로깅 분리 파일:** 스프링 Logback 설정 파일을 통해 무수히 쏟아지는 여러 `INFO` 타입의 정보들과 성능 저하 원인을 진단하기 위한 메서드 실행 시간 로깅 파일을 분리하여 추후에 메서드 실행 시간 로깅을 추적하기 쉽도록 구성
---

## 💡기술적 의사 결정
### 1. 스프링 AOP를 활용한 로직의 관심사 분리
> 목적: "메서드의 실행 시간 측정" 이라는 공통적으로 사용되는 로직을 분리하여 유지보수성 및 핵심 로직의 집중 증가
- 메서드의 실행 시간을 측정하는 하나의 어노테이션을 만들어 놓으면 어노테이션 하나만으로도 여러 메서드의 실행 시간을 측정할 수 있음
- `p(95) = 52s` 지표가 나오는데 원인이 되는 예상 범인 메서드의 실행 시간을 쉽게 측정할 수 있음
---

## ✅ 주요 변경점
- **global/aspect:**
  - `ExecutionTimeAspect.java`: 메서드의 실행 시간과 어떤 클래스의 어떤 메서드인지 로깅을 찍어주는 로직
- **resource:**
  - `logback-spring.xml`: 메서드의 실행 시간 로직 정보를 더 쉽게 추적하기 위해 로그 파일을 분리
---
## 📄 결과물
<img width="1149" height="171" alt="image" src="https://github.com/user-attachments/assets/5b6c2a23-8576-40a5-9a42-8c434f9524bd" />

## 🚨 진단 결과 및 다음 작업
- **진단 결과:** 구축한 로깅 시스템으로 확인 결과, Service 계층의 로직 지연은 2ms에 불과했으나 JPA 계층(`Ohlcv1mJpaAdapter.findDynamicMinuteCandles`)의 단일 조회 쿼리 실행에 **평균 3500ms(3.5초)**가 소요됨을 확인했습니다.
- **원인 확정:** 해당 쿼리가 10개의 DB 커넥션 풀(HikariCP)을 장기 점유하면서, 후행 요청들이 대기열에 쌓여 50초 이상의 타임아웃 지연이 발생하여 타임 아웃으로 인한 에러율도 증가했습니다.
- **다음 작업:** 다음 이슈(#359)에서 해당 동적 쿼리의 성능 튜닝을 진행하여 병목을 해소할 예정입니다.
