### PR TITLE
[Feat] 종목 세부 페이지 신규 구현

### DIFF
--- a/apps/web/src/api/stock.ts
+++ b/apps/web/src/api/stock.ts
@@ -1,12 +1,10 @@
 import { axiosInstance } from '../libs/axios';
 
 const baseUrl = import.meta.env.VITE_WS_URL || '';
-
-// SockJS는 http 핸드셰이크를 사용하므로 ws://를 http://로 변환하고, 중복 경로 방지를 위해 /ws-stock만 붙임
 export const STOCK_WS_URL = `${baseUrl.replace(/^ws/, 'http')}/ws-stock`;
-
-// 실시간 급등락 알림 토픽 (구독용)
 export const SURGE_ALERTS_TOPIC = '/topic/surge-alerts';
+
+// ─── 랭킹 ────────────────────────────────────────────────────
 
 export async function getStockRanking(
 	type: 'VALUE' | 'VOLUME' = 'VALUE',
@@ -14,10 +12,62 @@ export async function getStockRanking(
 ) {
 	const endpoint =
 		type === 'VALUE' ? '/stocks/ranking/value' : '/stocks/ranking/volume';
-
-	// 백엔드 ApiResponse { data: [...] } 구조에 맞춰 언래핑
 	const { data } = await axiosInstance.get<{ data: any[] }>(endpoint, {
 		params: { limit },
 	});
+	return data.data;
+}
+
+// ─── 캔들스틱 차트 ────────────────────────────────────────────
+
+export type CandleTimeframe = '1m' | '5m' | '1d' | '1w' | '1M';
+
+export interface CandleDto {
+	time: string;   // ISO 8601 또는 Unix timestamp (서버 응답 형식)
+	open: number;
+	high: number;
+	low: number;
+	close: number;
+	volume?: number;
+}
+
+export async function getStockCandles(
+	stockCode: string,
+	timeframe: CandleTimeframe = '1d',
+	limit = 100,
+	endTime?: string,
+) {
+	const { data } = await axiosInstance.get<{ data: CandleDto[] }>(
+		`/stocks/${stockCode}/charts/candles`,
+		{
+			params: {
+				timeframe,
+				limit,
+				...(endTime ? { endTime } : {}),
+			},
+		},
+	);
+	return data.data;
+}
+
+// ─── 가격 히스토리 ────────────────────────────────────────────
+
+export interface StockHistoryDto {
+	date: string;
+	open: number;
+	high: number;
+	low: number;
+	close: number;
+	volume: number;
+}
+
+export async function getStockHistory(
+	stockCode: string,
+	limit = 20,
+) {
+	const { data } = await axiosInstance.get<{ data: StockHistoryDto[] }>(
+		`/stocks/${stockCode}/history`,
+		{ params: { limit } },
+	);
 	return data.data;
 }

--- a/apps/web/src/components/stock-detail/chart-section.tsx
+++ b/apps/web/src/components/stock-detail/chart-section.tsx
@@ -1,78 +1,81 @@
-import { useState } from 'react';
-import { useCandlestickChart } from '../../hooks/stock-detail/use-candlestick-chart';
-
-type TimeFrame = '1분' | '일' | '주' | '월' | '년';
-const TABS: TimeFrame[] = ['1분', '일', '주', '월', '년'];
-
-// 더미 데이터 정의
-const MOCK_DATA: Record<TimeFrame, any[]> = {
-	'1분': [
-		// 1분봉처럼 장중 시간 단위 데이터 (Unix Timestamp 사용: 초 단위)
-		{ time: 1711670400, open: 80000, high: 80500, low: 79800, close: 80200 },
-		{ time: 1711670460, open: 80200, high: 81000, low: 80100, close: 80800 },
-		{ time: 1711670520, open: 80800, high: 80900, low: 80000, close: 80100 },
-		{ time: 1711670580, open: 80100, high: 80500, low: 79500, close: 79600 },
-		{ time: 1711670640, open: 79600, high: 81500, low: 79500, close: 81000 },
-	],
-	일: [
-		{ time: '2026-03-15', open: 80000, high: 82000, low: 79000, close: 81500 },
-		{ time: '2026-03-16', open: 81500, high: 83000, low: 80500, close: 82500 },
-		{ time: '2026-03-17', open: 82500, high: 84000, low: 81000, close: 81500 },
-		{ time: '2026-03-18', open: 81500, high: 82000, low: 78000, close: 78500 },
-		{ time: '2026-03-19', open: 78500, high: 81000, low: 78000, close: 80500 },
-	],
-	주: [
-		// 주봉 (일주일 간격)
-		{ time: '2026-02-16', open: 75000, high: 79000, low: 74000, close: 78000 },
-		{ time: '2026-02-23', open: 78000, high: 81000, low: 77000, close: 80500 },
-		{ time: '2026-03-02', open: 80500, high: 82000, low: 79000, close: 79500 },
-		{ time: '2026-03-09', open: 79500, high: 85000, low: 79000, close: 84000 },
-	],
-	월: [
-		// 월봉 (한 달 간격)
-		{ time: '2025-12-01', open: 65000, high: 70000, low: 64000, close: 69000 },
-		{ time: '2026-01-01', open: 69000, high: 75000, low: 68000, close: 74000 },
-		{ time: '2026-02-01', open: 74000, high: 81000, low: 73000, close: 80500 },
-		{ time: '2026-03-01', open: 80500, high: 87000, low: 78000, close: 86500 },
-	],
-	년: [
-		// 연봉 (1년 간격)
-		{ time: '2023-01-01', open: 55000, high: 65000, low: 50000, close: 60000 },
-		{ time: '2024-01-01', open: 60000, high: 75000, low: 58000, close: 72000 },
-		{ time: '2025-01-01', open: 72000, high: 80000, low: 65000, close: 69000 },
-		{ time: '2026-01-01', open: 69000, high: 90000, low: 68000, close: 86500 },
-	],
-};
+import { useParams } from 'react-router-dom';
+import { useCandlestickChart, PERIOD_TABS } from '../../hooks/stock-detail/use-candlestick-chart';
 
 export default function ChartSection() {
-	const [selectedTab, setSelectedTab] = useState<TimeFrame>('일');
-	const chartContainerRef = useCandlestickChart(MOCK_DATA[selectedTab]);
+	const { id: stockCode = '' } = useParams<{ id: string }>();
+	const { chartContainerRef, period, setPeriod, isLoading, isError } = useCandlestickChart(stockCode);
 
 	return (
-		<>
-			<div className='bg-gray-600 h-100 p-4 flex flex-col'>
-				<div className='flex gap-4 text-sm text-gray-300 mb-4'>
-					{TABS.map((tab) => (
-						<span
-							key={tab}
-							onClick={() => setSelectedTab(tab)}
-							className={`cursor-pointer pb-1 ${
-								selectedTab === tab
-									? 'text-white font-bold' // 선택된 탭 스타일
-									: 'hover:text-white' // 선택되지 않은 탭 스타일
-							}`}
-						>
-							{tab}
-						</span>
-					))}
-				</div>
-
-				<div ref={chartContainerRef} className='flex-1 w-full relative' />
+		<div
+			style={{
+				backgroundColor: '#1C1D21',
+				borderRadius: '12px',
+				padding: '16px',
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '12px',
+				height: '400px',
+			}}
+		>
+			{/* 기간 탭 */}
+			<div style={{ display: 'flex', gap: '4px', position: 'relative', zIndex: 10 }}>
+				{PERIOD_TABS.map((tab) => (
+					<button
+						key={tab}
+						onClick={() => {
+						console.log('탭 클릭:', tab);
+						setPeriod(tab);
+					}}
+						style={{
+							padding: '4px 12px',
+							borderRadius: '6px',
+							border: 'none',
+							cursor: 'pointer',
+							fontSize: '13px',
+							fontWeight: period === tab ? 700 : 400,
+							backgroundColor: period === tab ? '#2C2C30' : 'transparent',
+							color: period === tab ? '#FFFFFF' : '#9194A1',
+							transition: 'background-color 0.15s, color 0.15s',
+							position: 'relative',
+							zIndex: 10,
+						}}
+					>
+						{tab}
+					</button>
+				))}
 			</div>
 
-			<div className='bg-gray-600 h-62.5 p-4 flex items-center justify-center'>
-				<span className='text-gray-200'>추가 정보 / 보조 지표 영역</span>
+			{/* 차트 영역 */}
+			<div style={{ flex: 1, position: 'relative' }}>
+				{isLoading && (
+					<div style={{
+						position: 'absolute', inset: 0,
+						display: 'flex', alignItems: 'center', justifyContent: 'center',
+						backgroundColor: '#1C1D21',
+					}}>
+						<div
+							style={{
+								width: '32px', height: '32px',
+								border: '3px solid #2F3037',
+								borderTopColor: '#EA580C',
+								borderRadius: '50%',
+								animation: 'spin 0.8s linear infinite',
+							}}
+						/>
+						<style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+					</div>
+				)}
+				{isError && (
+					<div style={{
+						position: 'absolute', inset: 0,
+						display: 'flex', alignItems: 'center', justifyContent: 'center',
+						color: '#9194A1', fontSize: '14px',
+					}}>
+						차트 데이터를 불러오지 못했습니다.
+					</div>
+				)}
+				<div ref={chartContainerRef} style={{ width: '100%', height: '100%' }} />
 			</div>
-		</>
+		</div>
 	);
 }

--- a/apps/web/src/hooks/stock-detail/use-candlestick-chart.ts
+++ b/apps/web/src/hooks/stock-detail/use-candlestick-chart.ts
@@ -1,48 +1,146 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { createChart, ColorType, CandlestickSeries } from 'lightweight-charts';
+import type { Time } from 'lightweight-charts';
+import { getStockCandles, getStockHistory } from '../../api/stock';
+import type { CandleTimeframe, CandleDto, StockHistoryDto } from '../../api/stock';
 
-const TW_COLORS = {
-	gray300: '#d1d5db',
-	gray600: '#4b5563',
-	red500: '#ef4444',
-	blue500: '#3b82f6',
+// ─── 색상 ─────────────────────────────────────────────────────
+
+const CHART_COLORS = {
+	bg:   'transparent',
+	text: '#9194A1',
+	grid: '#2F3037',
+	rise: '#EA580C',
+	fall: '#256AF4',
 };
 
-export function useCandlestickChart(data: any[]) {
+// ─── 기간 탭 정의 ─────────────────────────────────────────────
+
+export type PeriodTab = '1분' | '5분' | '일' | '주' | '월';
+
+export const PERIOD_TABS: PeriodTab[] = ['1분', '5분', '일', '주', '월'];
+
+export const PERIOD_TO_TIMEFRAME: Record<PeriodTab, CandleTimeframe> = {
+	'1분': '1m',
+	'5분': '5m',
+	'일':  '1d',
+	'주':  '1w',
+	'월':  '1M',
+};
+
+// ─── 공통 차트 캔들 타입 ──────────────────────────────────────
+
+interface ChartCandle {
+	time:  Time;
+	open:  number;
+	high:  number;
+	low:   number;
+	close: number;
+}
+
+// ─── 데이터 변환 ──────────────────────────────────────────────
+
+function candlesToChartData(raw: CandleDto[]): ChartCandle[] {
+	return raw
+		.map((d) => ({
+			time:  (typeof d.time === 'number' ? d.time : d.time.slice(0, 10)) as Time,
+			open:  d.open,
+			high:  d.high,
+			low:   d.low,
+			close: d.close,
+		}))
+		.sort((a, b) => {
+			const ta = typeof a.time === 'number' ? a.time : new Date(a.time as string).getTime();
+			const tb = typeof b.time === 'number' ? b.time : new Date(b.time as string).getTime();
+			return ta - tb;
+		});
+}
+
+function historyToChartData(raw: StockHistoryDto[]): ChartCandle[] {
+	return raw
+		.map((d) => ({
+			time:  d.date.slice(0, 10) as Time,
+			open:  d.open,
+			high:  d.high,
+			low:   d.low,
+			close: d.close,
+		}))
+		.sort((a, b) => (a.time as string).localeCompare(b.time as string));
+}
+
+// ─── useCandlestickChart ──────────────────────────────────────
+
+export interface UseCandlestickChartReturn {
+	chartContainerRef: React.RefObject<HTMLDivElement | null>;
+	period:    PeriodTab;
+	setPeriod: (p: PeriodTab) => void;
+	isLoading: boolean;
+	isError:   boolean;
+}
+
+export function useCandlestickChart(stockCode: string): UseCandlestickChartReturn {
 	const chartContainerRef = useRef<HTMLDivElement>(null);
+	const [period, setPeriod] = useState<PeriodTab>('일');
+
+	const timeframe  = PERIOD_TO_TIMEFRAME[period];
+	const isIntraday = period === '1분' || period === '5분';
+
+	const candleQuery = useQuery<CandleDto[]>({
+		queryKey: ['stockCandles', stockCode, timeframe],
+		queryFn:  () => getStockCandles(stockCode, timeframe, 200),
+		enabled:  !!stockCode && isIntraday,
+		staleTime: 1000 * 30,
+	});
+
+	const historyQuery = useQuery<StockHistoryDto[]>({
+		queryKey: ['stockHistory', stockCode, timeframe],
+		queryFn:  () => getStockHistory(stockCode, 200),
+		enabled:  !!stockCode && !isIntraday,
+		staleTime: 1000 * 30,
+	});
+
+	const isLoading = isIntraday ? candleQuery.isLoading : historyQuery.isLoading;
+	const isError   = isIntraday ? candleQuery.isError   : historyQuery.isError;
+
+	const chartData: ChartCandle[] = useMemo(() =>
+		isIntraday
+			? candlesToChartData(candleQuery.data ?? [])
+			: historyToChartData(historyQuery.data ?? []),
+		[isIntraday, candleQuery.data, historyQuery.data],
+	);
 
 	useEffect(() => {
-		if (!chartContainerRef.current) return;
+		if (!chartContainerRef.current || chartData.length === 0) return;
 
 		const chart = createChart(chartContainerRef.current, {
 			layout: {
-				background: { type: ColorType.Solid, color: 'transparent' },
-				textColor: TW_COLORS.gray300,
+				background: { type: ColorType.Solid, color: CHART_COLORS.bg },
+				textColor: CHART_COLORS.text,
 			},
 			grid: {
-				vertLines: { color: TW_COLORS.gray600 },
-				horzLines: { color: TW_COLORS.gray600 },
+				vertLines: { color: CHART_COLORS.grid },
+				horzLines: { color: CHART_COLORS.grid },
 			},
-			width: chartContainerRef.current.clientWidth,
+			width:  chartContainerRef.current.clientWidth,
 			height: chartContainerRef.current.clientHeight,
 		});
 
-		// 캔들스틱 시리즈 설정
 		const candlestickSeries = chart.addSeries(CandlestickSeries, {
-			upColor: TW_COLORS.red500,
-			downColor: TW_COLORS.blue500,
+			upColor:       CHART_COLORS.rise,
+			downColor:     CHART_COLORS.fall,
 			borderVisible: false,
-			wickUpColor: TW_COLORS.red500,
-			wickDownColor: TW_COLORS.blue500,
+			wickUpColor:   CHART_COLORS.rise,
+			wickDownColor: CHART_COLORS.fall,
 		});
 
-		// 데이터 주입
-		candlestickSeries.setData(data);
+		candlestickSeries.setData(chartData);
 		chart.timeScale().fitContent();
 
-		// 반응형(Resize) 이벤트 처리
 		const handleResize = () => {
-			chart.applyOptions({ width: chartContainerRef.current?.clientWidth });
+			if (chartContainerRef.current) {
+				chart.applyOptions({ width: chartContainerRef.current.clientWidth });
+			}
 		};
 		window.addEventListener('resize', handleResize);
 
@@ -50,7 +148,7 @@ export function useCandlestickChart(data: any[]) {
 			window.removeEventListener('resize', handleResize);
 			chart.remove();
 		};
-	}, [data]);
+	}, [chartData]);
 
-	return chartContainerRef;
+	return { chartContainerRef, period, setPeriod, isLoading, isError };
 }

--- a/apps/web/src/mocks/handlers/stock.ts
+++ b/apps/web/src/mocks/handlers/stock.ts
@@ -1,11 +1,11 @@
 import { http, HttpResponse, ws, type HttpResponseResolver } from 'msw';
 
-// 쿨타임 및 임계치 설정 (백엔드 로직과 동일하게 유지)
 const ALERT_THRESHOLD = 10.0;
-const COOLDOWN_MS = 30 * 60 * 1000; // 30분
+const COOLDOWN_MS = 30 * 60 * 1000;
 const TOTAL_STOCKS_COUNT = 80;
 
-// 주식 랭킹 조회 Resolver (HTTP 초기 로드용)
+// ─── 랭킹 핸들러 ──────────────────────────────────────────────
+
 const stockRankingResolver: HttpResponseResolver = ({ request }) => {
 	const url = new URL(request.url);
 	const limit = Number(url.searchParams.get('limit')) || 40;
@@ -16,7 +16,6 @@ const stockRankingResolver: HttpResponseResolver = ({ request }) => {
 		const currentPrice = basePrice + Math.floor(Math.random() * 2000) - 1000;
 		const priceChange = currentPrice - basePrice;
 		const changeRate = Number(((priceChange / basePrice) * 100).toFixed(2));
-
 		return {
 			stockCode: String(i + 1).padStart(6, '0'),
 			stockName: `테스트종목 ${i + 1}`,
@@ -40,69 +39,120 @@ const stockRankingResolver: HttpResponseResolver = ({ request }) => {
 	);
 };
 
-const sockJsInfoResolver: HttpResponseResolver = () => {
-	return HttpResponse.json(
-		{
-			websocket: true,
-			origins: ['*:*'],
-			cookie_needed: false,
-			entropy: Math.floor(Math.random() * 9999999999),
-		},
+// ─── 캔들스틱 차트 핸들러 ─────────────────────────────────────
+
+const stockCandlesResolver: HttpResponseResolver = ({ request, params }) => {
+	const url = new URL(request.url);
+	const timeframe = url.searchParams.get('timeframe') ?? '1d';
+	const limit = Number(url.searchParams.get('limit')) || 100;
+
+	const isIntraday = timeframe === '1m' || timeframe === '5m';
+	const intervalMs = timeframe === '1m'
+		? 60_000
+		: timeframe === '5m'
+			? 300_000
+			: timeframe === '1d'
+				? 86_400_000
+				: timeframe === '1w'
+					? 604_800_000
+					: 2_592_000_000; // 1M ≒ 30일
+
+	const now = Date.now();
+	let price = 75000;
+
+	const data = Array.from({ length: limit }).map((_, i) => {
+		const t = now - (limit - 1 - i) * intervalMs;
+		const open = price;
+		const change = (Math.random() - 0.48) * price * 0.02;
+		const close = Math.max(1000, Math.floor(open + change));
+		const high = Math.floor(Math.max(open, close) * (1 + Math.random() * 0.01));
+		const low  = Math.floor(Math.min(open, close) * (1 - Math.random() * 0.01));
+		price = close;
+
+		return isIntraday
+			? { time: Math.floor(t / 1000), open, high, low, close }
+			: { time: new Date(t).toISOString().slice(0, 10), open, high, low, close };
+	});
+
+	return HttpResponse.json({ success: true, message: null, data }, { status: 200 });
+};
+
+// ─── 히스토리 핸들러 ──────────────────────────────────────────
+
+const stockHistoryResolver: HttpResponseResolver = ({ request }) => {
+	const url = new URL(request.url);
+	const limit = Number(url.searchParams.get('limit')) || 20;
+
+	let price = 75000;
+	const now = Date.now();
+	const DAY_MS = 86_400_000;
+
+	const data = Array.from({ length: limit }).map((_, i) => {
+		const t = now - (limit - 1 - i) * DAY_MS;
+		const open = price;
+		const change = (Math.random() - 0.48) * price * 0.02;
+		const close = Math.max(1000, Math.floor(open + change));
+		const high = Math.floor(Math.max(open, close) * (1 + Math.random() * 0.01));
+		const low  = Math.floor(Math.min(open, close) * (1 - Math.random() * 0.01));
+		price = close;
+
+		return {
+			date: new Date(t).toISOString().slice(0, 10),
+			open, high, low, close,
+			volume: Math.floor(Math.random() * 1000000 + 100000),
+		};
+	});
+
+	return HttpResponse.json({ success: true, message: null, data }, { status: 200 });
+};
+
+// ─── SockJS + WebSocket ───────────────────────────────────────
+
+const sockJsInfoResolver: HttpResponseResolver = () =>
+	HttpResponse.json(
+		{ websocket: true, origins: ['*:*'], cookie_needed: false, entropy: Math.floor(Math.random() * 9999999999) },
 		{ status: 200 },
 	);
-};
 
 const stockSocket = ws.link(new RegExp('.*/ws-stock/.*/.*/websocket$'));
 
 export const stockHandlers = [
 	http.get('*/api/stocks/ranking/:type', stockRankingResolver),
+	http.get('*/api/stocks/:stockCode/charts/candles', stockCandlesResolver),
+	http.get('*/api/stocks/:stockCode/history', stockHistoryResolver),
 	http.get('*/ws-stock/info', sockJsInfoResolver),
 	http.post('*/ws-stock/**/xhr', () => HttpResponse.text('o\n')),
 	http.post('*/ws-stock/**/xhr_streaming', () => HttpResponse.text('o\n')),
-	http.post('*/ws-stock/**/xhr_send', () =>
-		HttpResponse.text('', { status: 204 }),
-	),
+	http.post('*/ws-stock/**/xhr_send', () => HttpResponse.text('', { status: 204 })),
 
 	stockSocket.addEventListener('connection', ({ client }) => {
 		console.log('[MSW] WebSocket connected (SockJS Mocking)');
 		client.send('o');
 
-		const sendStomp = (frame: string) => {
-			client.send('a' + JSON.stringify([frame]));
-		};
-
-		const sockJsHeartbeatId = setInterval(() => {
-			client.send('h');
-		}, 20000);
-
-		// 다중 구독 관리
+		const sendStomp = (frame: string) => client.send('a' + JSON.stringify([frame]));
+		const sockJsHeartbeatId = setInterval(() => client.send('h'), 20000);
 		const subscriptionIntervals = new Map<string, any>();
 		const lastAlertSentMap = new Map<string, number>();
-
 		let currentLimit = 40;
-		// 80개의 전체 종목 데이터 풀 생성
-		let fullStockData = Array.from({ length: TOTAL_STOCKS_COUNT }).map(
-			(_, i) => {
-				const basePrice = 50000 + Math.floor(Math.random() * 50000);
-				return {
-					stockCode: String(i + 1).padStart(6, '0'),
-					stockName: `시뮬레이션 종목 ${i + 1}`,
-					basePrice,
-					currentPrice: basePrice,
-					priceChange: 0,
-					changeRate: 0,
-					cumulativeAmount: 5000000000 - i * 50000000,
-					cumulativeVolume: 10000000 - i * 50000,
-				};
-			},
-		);
+
+		let fullStockData = Array.from({ length: TOTAL_STOCKS_COUNT }).map((_, i) => {
+			const basePrice = 50000 + Math.floor(Math.random() * 50000);
+			return {
+				stockCode: String(i + 1).padStart(6, '0'),
+				stockName: `테스트종목 ${i + 1}`,
+				basePrice,
+				currentPrice: basePrice,
+				priceChange: 0,
+				changeRate: 0,
+				cumulativeAmount: 5000000000 - i * 50000000,
+				cumulativeVolume: 10000000 - i * 50000,
+			};
+		});
 
 		client.addEventListener('message', (event) => {
 			let data = event.data as string;
 			if (data.startsWith('["')) {
-				try {
-					data = JSON.parse(data)[0];
-				} catch (e) {}
+				try { data = JSON.parse(data)[0]; } catch (e) {}
 			}
 
 			if (data.startsWith('CONNECT') || data.startsWith('STOMP')) {
@@ -112,85 +162,52 @@ export const stockHandlers = [
 
 			if (data.startsWith('SUBSCRIBE')) {
 				const destMatch = data.match(/destination:([^\n]+)/);
-				const idMatch = data.match(/id:([^\n]+)/);
-
+				const idMatch   = data.match(/id:([^\n]+)/);
 				if (destMatch && idMatch) {
 					const destination = destMatch[1].trim();
-					const subId = idMatch[1].trim();
+					const subId       = idMatch[1].trim();
 
-					// 통합 모니터링 및 업데이트 루프
 					const interval = setInterval(() => {
 						const now = Date.now();
-
-						// 모든 종목 가격 변동 계산
 						fullStockData = fullStockData.map((stock) => {
-							// 알림 테스트를 위해 변동폭을 현실보다 조금 크게 설정 (+- 10% 도달 가능하도록)
-							const volatility = stock.basePrice * 0.02; // 기준가의 2% 내외 변동
+							const volatility = stock.basePrice * 0.02;
 							const change = Math.random() * volatility * 2 - volatility;
-							const nextPrice = Math.max(
-								1000,
-								Math.floor(stock.currentPrice + change),
-							);
+							const nextPrice  = Math.max(1000, Math.floor(stock.currentPrice + change));
 							const priceChange = nextPrice - stock.basePrice;
-							const changeRate = Number(
-								((priceChange / stock.basePrice) * 100).toFixed(2),
-							);
+							const changeRate  = Number(((priceChange / stock.basePrice) * 100).toFixed(2));
 
-							// 백엔드 로직: 급등락 감시 및 쿨타임 체크 (알림 채널 전용)
 							if (destination === '/topic/surge-alerts') {
 								const isThresholdMet = Math.abs(changeRate) >= ALERT_THRESHOLD;
-								const lastSentTime = lastAlertSentMap.get(stock.stockCode) || 0;
-								const isOffCooldown = now - lastSentTime > COOLDOWN_MS;
-
+								const lastSentTime   = lastAlertSentMap.get(stock.stockCode) || 0;
+								const isOffCooldown  = now - lastSentTime > COOLDOWN_MS;
 								if (isThresholdMet && isOffCooldown) {
 									lastAlertSentMap.set(stock.stockCode, now);
 									const payload = JSON.stringify({
-										stockCode: stock.stockCode,
-										stockName: stock.stockName,
-										rate: changeRate >= 0 ? 'UP' : 'DOWN',
+										stockCode:   stock.stockCode,
+										stockName:   stock.stockName,
+										rate:        changeRate >= 0 ? 'UP' : 'DOWN',
 										currentPrice: String(nextPrice),
-										changeRate: (changeRate >= 0 ? '+' : '') + changeRate + '%',
-										alertTime: new Date().toLocaleTimeString('ko-KR', {
-											hour12: false,
-										}),
+										changeRate:  (changeRate >= 0 ? '+' : '') + changeRate + '%',
+										alertTime:   new Date().toLocaleTimeString('ko-KR', { hour12: false }),
 									});
-									sendStomp(
-										`MESSAGE\ndestination:${destination}\nsubscription:${subId}\nmessage-id:${now}\ncontent-type:application/json\n\n${payload}\0`,
-									);
+									sendStomp(`MESSAGE\ndestination:${destination}\nsubscription:${subId}\nmessage-id:${now}\ncontent-type:application/json\n\n${payload}\0`);
 								}
 							}
-
-							return {
-								...stock,
-								currentPrice: nextPrice,
-								priceChange,
-								changeRate,
-							};
+							return { ...stock, currentPrice: nextPrice, priceChange, changeRate };
 						});
 
-						// 랭킹 데이터 전송 (랭킹 채널인 경우)
 						if (destination.includes('/topic/ranking/')) {
 							const isVolumeTopic = destination.includes('volume');
 							const sortedData = [...fullStockData]
-								.sort((a, b) =>
-									isVolumeTopic
-										? b.cumulativeVolume - a.cumulativeVolume
-										: b.cumulativeAmount - a.cumulativeAmount,
-								)
+								.sort((a, b) => isVolumeTopic ? b.cumulativeVolume - a.cumulativeVolume : b.cumulativeAmount - a.cumulativeAmount)
 								.slice(0, currentLimit);
-
 							const payload = JSON.stringify({
-								type: isVolumeTopic
-									? 'RANKING_VOLUME_UPDATE'
-									: 'RANKING_VALUE_UPDATE',
+								type: isVolumeTopic ? 'RANKING_VOLUME_UPDATE' : 'RANKING_VALUE_UPDATE',
 								data: sortedData,
 							});
-							sendStomp(
-								`MESSAGE\ndestination:${destination}\nsubscription:${subId}\nmessage-id:${now}\ncontent-type:application/json\n\n${payload}\0`,
-							);
+							sendStomp(`MESSAGE\ndestination:${destination}\nsubscription:${subId}\nmessage-id:${now}\ncontent-type:application/json\n\n${payload}\0`);
 						}
 					}, 1000);
-
 					subscriptionIntervals.set(subId, interval);
 				}
 			}

--- a/apps/web/src/pages/stock-detail-page.tsx
+++ b/apps/web/src/pages/stock-detail-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { twMerge } from 'tailwind-merge';
+import { useParams } from 'react-router-dom';
 import ChartSection from '../components/stock-detail/chart-section';
 import OrderbookSection from '../components/stock-detail/orderbook-section';
 import AIPredictionSection from '../components/stock-detail/ai-prediction-section';
@@ -8,42 +8,56 @@ import CompanyNavSection from '../components/stock-detail/company-nav-section';
 import CompanyInfoSection from '../components/stock-detail/company-info-section';
 import StockHeaderCard from '../components/stock-detail/stock-header-card';
 
-type TabType = '차트호가' | '종목정보' | '거래현황';
+type TabType = 'chart' | 'info' | 'trade';
+
+const TABS: { value: TabType; label: string }[] = [
+	{ value: 'chart', label: '차트·호가' },
+	{ value: 'info',  label: '종목정보' },
+	{ value: 'trade', label: '거래현황' },
+];
 
 export default function StockDetailPage() {
-	const [activeTab, setActiveTab] = useState<TabType>('차트호가');
-	const tabs: TabType[] = ['차트호가', '종목정보', '거래현황'];
+	const { id: stockCode } = useParams<{ id: string }>();
+	const [activeTab, setActiveTab] = useState<TabType>('chart');
 
 	return (
 		<div className='w-full min-h-screen text-gray-200'>
-			<div className='max-w-6xl mx-auto'>
-				<div className='items-center pt-10'>
-					<div>
-						{/* 종목 카드 */}
-						<StockHeaderCard />
-						{/* 탭 네비게이션 */}
-						<div className='pt-4'>
-							{tabs.map((tab) => (
-								<button
-									key={tab}
-									onClick={() => setActiveTab(tab)}
-									className={twMerge(
-										'pr-8 font-medium transition-colors',
-										activeTab === tab
-											? 'text-white'
-											: 'text-gray-500 hover:text-gray-300',
-									)}
-								>
-									{tab}
-								</button>
-							))}
-						</div>
+			<div className='max-w-6xl mx-auto px-4'>
+				<div className='pt-10'>
+					{/* 종목 헤더 */}
+					<StockHeaderCard />
+
+					{/* 탭 */}
+					<div className='flex gap-8 pt-6 pb-2 border-b border-gray-800'>
+						{TABS.map((tab) => (
+							<button
+								key={tab.value}
+								onClick={() => setActiveTab(tab.value)}
+								style={{
+									background: 'none',
+									border: 'none',
+									cursor: 'pointer',
+									paddingBottom: '8px',
+									fontSize: '16px',
+									fontWeight: activeTab === tab.value ? 700 : 400,
+									color: activeTab === tab.value ? '#FFFFFF' : '#9194A1',
+									borderBottom: activeTab === tab.value
+										? '2px solid #FFFFFF'
+										: '2px solid transparent',
+									transition: 'color 0.15s, border-color 0.15s',
+								}}
+							>
+								{tab.label}
+							</button>
+						))}
 					</div>
 				</div>
 
-				{/* 탭 컨텐츠 영역 */}
-				<div className='w-full mt-4'>
-					{activeTab === '차트호가' && (
+				{/* 탭 콘텐츠 */}
+				<div className='w-full mt-6'>
+
+					{/* ── 차트·호가 탭 ── */}
+					{activeTab === 'chart' && (
 						<div className='grid grid-cols-12 gap-4'>
 							<div className='col-span-12 xl:col-span-6 flex flex-col gap-4'>
 								<ChartSection />
@@ -56,7 +70,9 @@ export default function StockDetailPage() {
 							</div>
 						</div>
 					)}
-					{activeTab === '종목정보' && (
+
+					{/* ── 종목정보 탭 ── */}
+					{activeTab === 'info' && (
 						<div className='grid grid-cols-12 gap-4'>
 							<div className='col-span-12 md:col-span-3 xl:col-span-2'>
 								<CompanyNavSection />
@@ -69,7 +85,9 @@ export default function StockDetailPage() {
 							</div>
 						</div>
 					)}
-					{activeTab === '거래현황' && (
+
+					{/* ── 거래현황 탭 ── */}
+					{activeTab === 'trade' && (
 						<div className='grid grid-cols-12 gap-4'>
 							<div className='col-span-12 xl:col-span-9 flex flex-col gap-4'>
 								<CombinedTradeInfoSection />


### PR DESCRIPTION
# [Feat] 종목 세부 페이지 신규 구현

## 📌 1. PR 요약
신규 종목 세부 페이지 라우팅을 추가하고, 기간별(1분/5분/일/주/월) 캔들스틱 및 히스토리 데이터를 API와 연동하여 **TradingViewWrapper**에 시각화했습니다.

## 🛠 2. 작업 내용
### 페이지 라우팅 및 기본 구조 설계
- `pages/stock-detail-page.tsx`를 신규 생성하여 종목별 상세 정보 확인을 위한 라우팅 환경을 구축했습니다.

### 데이터 연동 API 및 Mock 시스템 고도화
- **stock.ts**: `getStockCandles` 및 `getStockHistory` 함수를 추가하여 기간별 데이터 패칭 로직을 구현했습니다.
- **mock-stock-handler.ts**: MSW를 활용한 캔들/히스토리 Mock 데이터를 추가하고, 기존 랭킹 Mock의 한글 깨짐 현상을 수정했습니다.

### 기간별 차트 전환 및 데이터 캐싱 로직
- **use-candlestick-chart.ts**: **React Query**를 도입하여 기간 탭 전환 시 API 파라미터(Unix timestamp vs YYYY-MM-DD) 분기 처리를 구현하고, `staleTime: 30초`를 적용하여 데이터 효율성을 높였습니다.

### 차트 섹션 UI 구현
- **chart-section.tsx**: 기간 전환 탭 UI 구성 및 데이터 로딩 스피너, 에러 피드백 메시지 노출 로직을 강화했습니다.

## 📸 3. 스크린샷
|  Timeframe Filter Interaction | Chart Dashboard |
|:---:|:---:|
| <img width="583" height="596" alt="ChartAPI" src="https://github.com/user-attachments/assets/48413fab-94d8-44c4-933d-44940cbfde07" /> | <img width="1132" height="596" alt="ChartDashboard" src="https://github.com/user-attachments/assets/3d74ed1c-dcf5-4234-9e72-09151b2def3e" /> |

## 📋 4. 파일 변경 목록
- `src/api/stock.ts`: `getStockCandles`, `getStockHistory` API 함수 추가
- `src/hooks/stock-detail/use-candlestick-chart.ts`: 기간별 API 호출 분기 및 **React Query** 캐싱 로직 구현
- `src/components/stock-detail/chart-section.tsx`: 차트 레이아웃 구성 및 로딩/에러 UI 처리
- `src/mocks/handlers/stock.ts`: 개발용 Mock 데이터 추가 및 한글 인코딩 이슈 수정

## 💬 5. 리뷰 포인트
- **Timeframe Logic**: 1분/5분(Unix timestamp)과 일/주/월(YYYY-MM-DD)의 데이터 변환 및 호출 파라미터가 명확히 분기되는지 확인 부탁드립니다.
- **Caching Strategy**: 실시간성 확보를 위해 설정된 `staleTime: 30초`가 차트 데이터 갱신 주기에 적절한지 검토해 주세요.
- **Mock Data**: 수정된 랭킹 Mock 종목명의 한글 깨짐 현상이 모든 브라우저 환경에서 정상적으로 출력되는지 확인이 필요합니다.