### PR TITLE
[Refactor] DB 성능 개선을 위한 차트 조회 로직 변경

### DIFF
--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
@@ -6,9 +6,14 @@ import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1dRepository;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1mRepository;
 import com.assetmind.server_stock.stock.exception.InvalidChartParameterException;
+import com.assetmind.server_stock.stock.presentation.dto.ChartRequestDto;
 import com.assetmind.server_stock.stock.presentation.dto.ChartResponseDto;
+import com.assetmind.server_stock.stock.presentation.dto.ChartResponseDto.CandleDto;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,68 +31,95 @@ public class ChartService {
     private final Ohlcv1dRepository ohlcv1dRepository;
 
     @LogExecutionTime
-    public ChartResponseDto getCandles(String stockCode, String timeframe, LocalDateTime endTime, int limit) {
-        if (endTime == null) {
-            endTime = LocalDateTime.now();
+    public ChartResponseDto getNCandles(String stockCode, String timeframe, LocalDateTime endTime, int limit) {
+
+        // 변수 intervalString 에서 정수 값만 추출
+        int minuteInterval = parseMinuteInterval(timeframe);
+
+        // 필요한 1분봉 개수 역산 (예: 5분봉 20개 -> 1분봉 100개)
+        int requireRawCount = limit * minuteInterval;
+
+        // 필요한 만큼만 1분봉 데이터 조회
+        List<OhlcvDto> rawCandles = ohlcv1mRepository.findOneMinuteCandles(stockCode, endTime,
+                requireRawCount);
+
+        if (rawCandles.isEmpty()) {
+            return ChartResponseDto.builder()
+                    .stockCode(stockCode)
+                    .timeframe(timeframe)
+                    .candles(Collections.emptyList())
+                    .build();
         }
 
-        log.info("[ChartService] 차트 조회 - 종목: {}, 타임프레임: {}, 기준시간: {}, 조회 요청 개수: {}", stockCode, timeframe, endTime, limit);
+        // 1분봉 데이터를 그룹화 하고 N분봉으로 병합
+        List<CandleDto> result = rawCandles.stream()
+                // N분 단위로 시간을 자르고 그룹화 (예: 5분봉, 10:04 데이터 -> 10:00 그룹)
+                .collect(Collectors.groupingBy(
+                        candle -> truncateNMinute(candle.candleTimestamp(), minuteInterval)))
+                .entrySet().stream()
+                // 시간대 별로 묶인(10:00, 10:05, 10:10 ..) 1분봉 리스트를 하나의 N분봉으로 합침
+                .map(entry -> {
+                    LocalDateTime groupTime = entry.getKey();
+                    List<OhlcvDto> group = entry.getValue();
 
-        List<OhlcvDto> dtoList;
+                    // 시가/종가를 위한 시간순(오름차순) 정렬
+                    group.sort(Comparator.comparing(OhlcvDto::candleTimestamp));
 
-        // 요청 받은 timeframe이 분봉(1m) 테이블로 갈지, 일봉(1d) 테이블로 갈지 결정
-        if (isMinuteTimeframe(timeframe)) {
-            String intervalString = getMinuteInterval(timeframe);
-            dtoList = ohlcv1mRepository.findDynamicMinuteCandles(stockCode, intervalString, endTime, limit);
-        } else {
-            dtoList = getOhlcvDtoBasedDailyCandles(stockCode, timeframe, endTime, limit);
-        }
+                    Double open = group.get(0).openPrice();
+                    Double close = group.getLast().closePrice();
+                    Double high = group.stream().mapToDouble(OhlcvDto::highPrice).max()
+                            .orElse(open);
+                    Double low = group.stream().mapToDouble(OhlcvDto::lowPrice).min()
+                            .orElse(open);
+                    Long volume = group.stream().mapToLong(OhlcvDto::volume).sum();
 
-        List<ChartResponseDto.CandleDto> candleDtos = dtoList.stream()
-                .map(dto -> ChartResponseDto.CandleDto.builder()
-                        .timestamp(dto.candleTimestamp())
-                        .open(String.valueOf(dto.openPrice()))
-                        .high(String.valueOf(dto.highPrice()))
-                        .low(String.valueOf(dto.lowPrice()))
-                        .close(String.valueOf(dto.closePrice()))
-                        .volume(String.valueOf(dto.volume()))
-                        .build()
-                ).toList();
+                    return CandleDto.builder()
+                            .timestamp(groupTime)
+                            .open(String.valueOf(open))
+                            .high(String.valueOf(high))
+                            .low(String.valueOf(low))
+                            .close(String.valueOf(close))
+                            .volume(String.valueOf(volume))
+                            .build();
+                })
+                // N분봉으로 그룹화된 결과들을 최신순(내림차순)으로 정렬
+                .sorted(Comparator.comparing(CandleDto::timestamp).reversed())
+                .limit(limit)
+                .toList();
 
         return ChartResponseDto.builder()
                 .stockCode(stockCode)
                 .timeframe(timeframe)
-                .candles(candleDtos)
+                .candles(result)
                 .build();
     }
 
-    private boolean isMinuteTimeframe(String timeframe) {
-        return timeframe.endsWith("m") && !timeframe.endsWith("mo");
+    /**
+     * "3m", "5m" 등의 문자열에서 숫자만 추출
+     * @param timeframe 분봉 간격
+     * @return 숫자만 추출한 분봉
+     */
+    private int parseMinuteInterval(String timeframe) {
+        if (timeframe != null && timeframe.endsWith("m")) {
+            try {
+                return Integer.parseInt(timeframe.replace("m", ""));
+            } catch (NumberFormatException e) {
+                log.error("[ChartService] 잘못된 분봉 간격 포맷입니다: {}", timeframe);
+            }
+        }
+        throw new InvalidChartParameterException(ErrorCode.INVALID_CHART_PARAMETER, "지원하지 않는 분봉 간격입니다:" + timeframe);
     }
 
-    private String getMinuteInterval(String timeframe) {
-        return switch (timeframe.toLowerCase()) {
-            case "1m" -> "1 minute";
-            case "3m" -> "3 minutes";
-            case "5m" -> "5 minutes";
-            case "15m" -> "15 minutes";
-            default -> throw new InvalidChartParameterException(ErrorCode.INVALID_CHART_PARAMETER, "지원하지 않는 분봉 타임프레임입니다.");
-        };
-    }
-
-    private List<OhlcvDto> getOhlcvDtoBasedDailyCandles(String stockCode, String timeframe, LocalDateTime endTime, int limit) {
-        return switch (timeframe.toLowerCase()) {
-            // 고정 길이 (date_bin 사용)
-            case "1d" -> ohlcv1dRepository.findDynamicDailyCandles(stockCode, "1 day", endTime, limit);
-            case "3d" -> ohlcv1dRepository.findDynamicDailyCandles(stockCode, "3 days", endTime, limit);
-            case "5d" -> ohlcv1dRepository.findDynamicDailyCandles(stockCode, "5 days", endTime, limit);
-            case "1w" -> ohlcv1dRepository.findDynamicDailyCandles(stockCode, "1 week", endTime, limit);
-
-            // 가변 길이 (date_trunc 사용)
-            case "1mo" -> ohlcv1dRepository.findMonthlyCandles(stockCode, endTime, limit);
-            case "1y" -> ohlcv1dRepository.findYearlyCandles(stockCode, endTime, limit);
-
-            default -> throw new InvalidChartParameterException(ErrorCode.INVALID_CHART_PARAMETER, "지원하지 않는 일/주/월/년봉 타임프레임입니다: ");
-        };
+    /**
+     * 시간을 N분 단위로 내림
+     * 예: time=10:13, n=5 -> return=10:10
+     * @param time N분 단위로 내림할 시간
+     * @param n N분에 해당되는 분
+     * @return N분 단위로 내림 된 시간
+     */
+    private LocalDateTime truncateNMinute(LocalDateTime time, int n) {
+        int minute = time.getMinute();
+        int truncatedMinute = (minute / n) * n;
+        return time.withMinute(truncatedMinute).withSecond(0).withNano(0);
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/ChartService.java
@@ -1,12 +1,10 @@
 package com.assetmind.server_stock.stock.application;
 
 import com.assetmind.server_stock.global.aspect.LogExecutionTime;
-import com.assetmind.server_stock.global.error.ErrorCode;
 import com.assetmind.server_stock.stock.domain.dtos.OhlcvDto;
+import com.assetmind.server_stock.stock.domain.enums.CandleType;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1dRepository;
 import com.assetmind.server_stock.stock.domain.repository.Ohlcv1mRepository;
-import com.assetmind.server_stock.stock.exception.InvalidChartParameterException;
-import com.assetmind.server_stock.stock.presentation.dto.ChartRequestDto;
 import com.assetmind.server_stock.stock.presentation.dto.ChartResponseDto;
 import com.assetmind.server_stock.stock.presentation.dto.ChartResponseDto.CandleDto;
 import java.time.LocalDateTime;
@@ -33,8 +31,13 @@ public class ChartService {
     @LogExecutionTime
     public ChartResponseDto getNCandles(String stockCode, String timeframe, LocalDateTime endTime, int limit) {
 
-        // 변수 intervalString 에서 정수 값만 추출
-        int minuteInterval = parseMinuteInterval(timeframe);
+        CandleType candleType = CandleType.from(timeframe);
+
+        int minuteInterval = candleType.getWindowMinutes();
+
+        if (endTime == null) {
+            endTime = LocalDateTime.now();
+        }
 
         // 필요한 1분봉 개수 역산 (예: 5분봉 20개 -> 1분봉 100개)
         int requireRawCount = limit * minuteInterval;
@@ -92,22 +95,6 @@ public class ChartService {
                 .timeframe(timeframe)
                 .candles(result)
                 .build();
-    }
-
-    /**
-     * "3m", "5m" 등의 문자열에서 숫자만 추출
-     * @param timeframe 분봉 간격
-     * @return 숫자만 추출한 분봉
-     */
-    private int parseMinuteInterval(String timeframe) {
-        if (timeframe != null && timeframe.endsWith("m")) {
-            try {
-                return Integer.parseInt(timeframe.replace("m", ""));
-            } catch (NumberFormatException e) {
-                log.error("[ChartService] 잘못된 분봉 간격 포맷입니다: {}", timeframe);
-            }
-        }
-        throw new InvalidChartParameterException(ErrorCode.INVALID_CHART_PARAMETER, "지원하지 않는 분봉 간격입니다:" + timeframe);
     }
 
     /**

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/enums/CandleType.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/enums/CandleType.java
@@ -1,6 +1,7 @@
 package com.assetmind.server_stock.stock.domain.enums;
 
 import com.assetmind.server_stock.global.error.ErrorCode;
+import com.assetmind.server_stock.stock.exception.InvalidChartParameterException;
 import com.assetmind.server_stock.stock.exception.InvalidStockParameterException;
 import lombok.Getter;
 
@@ -32,6 +33,6 @@ public enum CandleType {
                 return type;
             }
         }
-        throw new InvalidStockParameterException("지원하지 않는 캔들 타입입니다.:" + value, ErrorCode.INVALID_STOCK_PARAMETER);
+        throw new InvalidChartParameterException(ErrorCode.INVALID_CHART_PARAMETER, "지원하지 않는 캔들 타입입니다.:" + value);
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/Ohlcv1mRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/domain/repository/Ohlcv1mRepository.java
@@ -33,4 +33,13 @@ public interface Ohlcv1mRepository {
      * @return N분봉 OHLCV DTO 리스트
      */
     List<OhlcvDto> findDynamicMinuteCandles(String stockCode, String intervalString, LocalDateTime endTime, int limit);
+
+    /**
+     * DB에서 endTime 부터 이전까지의 Limit개의 1분봉 데이터를 조회
+     * @param stockCode 종목 코드
+     * @param endTime 조회의 마지막 시점 시간
+     * @param limit 조회 요청에 필요한 1분봉 개수
+     * @return 1분봉 OHLCV DTO 리스트
+     */
+    List<OhlcvDto> findOneMinuteCandles(String stockCode, LocalDateTime endTime, int limit);
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
@@ -86,7 +86,7 @@ public class Ohlcv1mJpaAdapter implements Ohlcv1mRepository {
     public List<OhlcvDto> findOneMinuteCandles(String stockCode, LocalDateTime endTime, int limit) {
         return ohlcv1mJpaRepository.findRawCandles(stockCode, endTime, limit)
                 .stream()
-                .map(projection -> toDto(stockCode, projection))
+                .map(this::toDto)
                 .toList();
     }
 

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaAdapter.java
@@ -81,6 +81,15 @@ public class Ohlcv1mJpaAdapter implements Ohlcv1mRepository {
 
     }
 
+    @LogExecutionTime
+    @Override
+    public List<OhlcvDto> findOneMinuteCandles(String stockCode, LocalDateTime endTime, int limit) {
+        return ohlcv1mJpaRepository.findRawCandles(stockCode, endTime, limit)
+                .stream()
+                .map(projection -> toDto(stockCode, projection))
+                .toList();
+    }
+
     private OhlcvDto toDto(Ohlcv1mJpaEntity entity) {
         return new OhlcvDto(
                 entity.getStockCode(),

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaRepository.java
@@ -45,4 +45,17 @@ public interface Ohlcv1mJpaRepository extends JpaRepository<Ohlcv1mJpaEntity, Oh
             @Param("endTime") LocalDateTime endTime,
             @Param("limit") int limit
     );
+
+    @Query(value = """
+        SELECT * FROM ohlcv_1m
+        WHERE stock_code = :stockCdoe 
+            AND candle_timestamp <= :endTime
+        ORDER BY candle_timestamp DESC
+        LIMIT :rawLimit
+      """, nativeQuery = true)
+    List<ChartCandleProjection> findRawCandles(
+            @Param("stockCode") String stockCode,
+            @Param("endTime") LocalDateTime endTime,
+            @Param("limit") int limit
+    );
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaRepository.java
@@ -47,15 +47,15 @@ public interface Ohlcv1mJpaRepository extends JpaRepository<Ohlcv1mJpaEntity, Oh
     );
 
     @Query(value = """
-        SELECT * FROM ohlcv_1m
-        WHERE stock_code = :stockCode 
-            AND candle_timestamp <= :endTime
-        ORDER BY candle_timestamp DESC
-        LIMIT :rawLimit
-      """, nativeQuery = true)
-    List<ChartCandleProjection> findRawCandles(
+        SELECT o FROM Ohlcv1mJpaEntity o
+        WHERE o.stockCode = :stockCode 
+            AND o.candleTimestamp <= :endTime
+        ORDER BY o.candleTimestamp DESC
+        LIMIT :limit
+      """)
+    List<Ohlcv1mJpaEntity> findRawCandles(
             @Param("stockCode") String stockCode,
             @Param("endTime") LocalDateTime endTime,
-            @Param("rawLimit") int limit
+            @Param("limit") int limit
     );
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/persistence/jpa/Ohlcv1mJpaRepository.java
@@ -48,7 +48,7 @@ public interface Ohlcv1mJpaRepository extends JpaRepository<Ohlcv1mJpaEntity, Oh
 
     @Query(value = """
         SELECT * FROM ohlcv_1m
-        WHERE stock_code = :stockCdoe 
+        WHERE stock_code = :stockCode 
             AND candle_timestamp <= :endTime
         ORDER BY candle_timestamp DESC
         LIMIT :rawLimit
@@ -56,6 +56,6 @@ public interface Ohlcv1mJpaRepository extends JpaRepository<Ohlcv1mJpaEntity, Oh
     List<ChartCandleProjection> findRawCandles(
             @Param("stockCode") String stockCode,
             @Param("endTime") LocalDateTime endTime,
-            @Param("limit") int limit
+            @Param("rawLimit") int limit
     );
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/ChartController.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/ChartController.java
@@ -37,7 +37,7 @@ public class ChartController {
         log.info("[ChartController] 캔들 조회 요청 - 종목: {}, 타임프레임: {}, Limit: {}, 기준시간: {}",
                 stockCode, dto.timeframe(), dto.limit(), dto.endTime());
 
-        ChartResponseDto response = chartService.getCandles(stockCode, dto.timeframe(), dto.endTime(), dto.limit());
+        ChartResponseDto response = chartService.getNCandles(stockCode, dto.timeframe(), dto.endTime(), dto.limit());
 
         return ApiResponse.success(response);
     }

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/ChartServiceTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/ChartServiceTest.java
@@ -44,101 +44,81 @@ class ChartServiceTest {
     @DisplayName("endTime이 null일 경우 현재 시간(now)을 기준으로 조회한다.")
     void givenEndTimeIsNull_whenGetCandles_thenQueryEndTimeNow() {
         // given
-        when(ohlcv1mRepository.findDynamicMinuteCandles(any(), any(), any(), anyInt()))
+        when(ohlcv1mRepository.findOneMinuteCandles(any(), any(), anyInt()))
                 .thenReturn(List.of());
 
         // when
-        chartService.getCandles(STOCK_CODE, "1m", null, LIMIT);
+        chartService.getNCandles(STOCK_CODE, "1m", null, LIMIT);
 
         // then
         // findDynamicMinuteCandles의 3번째 인자로 LocalDateTime이 전달되었는지 확인
-        verify(ohlcv1mRepository).findDynamicMinuteCandles(eq(STOCK_CODE), any(), any(LocalDateTime.class), eq(LIMIT));
+        verify(ohlcv1mRepository).findOneMinuteCandles(eq(STOCK_CODE), any(LocalDateTime.class), eq(LIMIT));
     }
 
-    @ParameterizedTest
-    @CsvSource({
-            "1m, 1 minute",
-            "3m, 3 minutes",
-            "5m, 5 minutes",
-            "15m, 15 minutes",
-    })
-    @DisplayName("다양한 분봉 타임프레임 요청 시 1분봉 레포지토리의 정확한 interval로 라우팅된다.")
-    void givenNMinutes_whenGetCandles_thenRoutingCollectInterval(String timeframe, String expectedInterval) {
-        // given
-        when(ohlcv1mRepository.findDynamicMinuteCandles(any(), any(), any(), anyInt()))
-                .thenReturn(List.of());
-
-        // when
-        chartService.getCandles(STOCK_CODE, timeframe, END_TIME, LIMIT);
-
-        // then
-        verify(ohlcv1mRepository).findDynamicMinuteCandles(STOCK_CODE, expectedInterval, END_TIME, LIMIT);
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-            "1d, 1 day",
-            "3d, 3 days",
-            "5d, 5 days",
-            "1w, 1 week"
-    })
-    @DisplayName("일/주봉 타임프레임 요청 시 1일봉 레포지토리의 고정 간격 메서드로 라우팅된다.")
-    void givenNDays_whenGetCandles_thenRoutingCollectInterval(String timeframe, String expectedInterval) {
-        // given
-        when(ohlcv1dRepository.findDynamicDailyCandles(any(), any(), any(), anyInt()))
-                .thenReturn(List.of());
-
-        // when
-        chartService.getCandles(STOCK_CODE, timeframe, END_TIME, LIMIT);
-
-        // then
-        verify(ohlcv1dRepository).findDynamicDailyCandles(STOCK_CODE, expectedInterval, END_TIME, LIMIT);
-    }
-
-    @Test
-    @DisplayName("1mo(월봉) 요청 시 1일봉 레포지토리의 findMonthlyCandles 메서드로 라우팅된다.")
-    void given1MonthTimeframe_whenGetCandles_thenRoutingCollectInterval() {
-        // given
-        when(ohlcv1dRepository.findMonthlyCandles(any(), any(), anyInt()))
-                .thenReturn(List.of());
-
-        // when
-        chartService.getCandles(STOCK_CODE, "1mo", END_TIME, LIMIT);
-
-        // then
-        verify(ohlcv1dRepository).findMonthlyCandles(STOCK_CODE, END_TIME, LIMIT);
-    }
-
-    @Test
-    @DisplayName("1y(년봉) 요청 시 1일봉 레포지토리의 findYearlyCandles 메서드로 라우팅된다.")
-    void given1YearTimeframe_whenGetCandles_thenRoutingCollectInterval() {
-        // given
-        when(ohlcv1dRepository.findYearlyCandles(any(), any(), anyInt()))
-                .thenReturn(List.of());
-
-        // when
-        chartService.getCandles(STOCK_CODE, "1y", END_TIME, LIMIT);
-
-        // then
-        verify(ohlcv1dRepository).findYearlyCandles(STOCK_CODE, END_TIME, LIMIT);
-    }
+//    @ParameterizedTest
+//    @CsvSource({
+//            "1d, 1 day",
+//            "3d, 3 days",
+//            "5d, 5 days",
+//            "1w, 1 week"
+//    })
+//    @DisplayName("일/주봉 타임프레임 요청 시 1일봉 레포지토리의 고정 간격 메서드로 라우팅된다.")
+//    void givenNDays_whenGetCandles_thenRoutingCollectInterval(String timeframe, String expectedInterval) {
+//        // given
+//        when(ohlcv1dRepository.findDynamicDailyCandles(any(), any(), any(), anyInt()))
+//                .thenReturn(List.of());
+//
+//        // when
+//        chartService.getNCandles(STOCK_CODE, timeframe, END_TIME, LIMIT);
+//
+//        // then
+//        verify(ohlcv1dRepository).findDynamicDailyCandles(STOCK_CODE, expectedInterval, END_TIME, LIMIT);
+//    }
+//
+//    @Test
+//    @DisplayName("1mo(월봉) 요청 시 1일봉 레포지토리의 findMonthlyCandles 메서드로 라우팅된다.")
+//    void given1MonthTimeframe_whenGetCandles_thenRoutingCollectInterval() {
+//        // given
+//        when(ohlcv1dRepository.findMonthlyCandles(any(), any(), anyInt()))
+//                .thenReturn(List.of());
+//
+//        // when
+//        chartService.getNCandles(STOCK_CODE, "1mo", END_TIME, LIMIT);
+//
+//        // then
+//        verify(ohlcv1dRepository).findMonthlyCandles(STOCK_CODE, END_TIME, LIMIT);
+//    }
+//
+//    @Test
+//    @DisplayName("1y(년봉) 요청 시 1일봉 레포지토리의 findYearlyCandles 메서드로 라우팅된다.")
+//    void given1YearTimeframe_whenGetCandles_thenRoutingCollectInterval() {
+//        // given
+//        when(ohlcv1dRepository.findYearlyCandles(any(), any(), anyInt()))
+//                .thenReturn(List.of());
+//
+//        // when
+//        chartService.getCandles(STOCK_CODE, "1y", END_TIME, LIMIT);
+//
+//        // then
+//        verify(ohlcv1dRepository).findYearlyCandles(STOCK_CODE, END_TIME, LIMIT);
+//    }
 
     @Test
     @DisplayName("지원하지 않는 잘못된 타임프레임(분봉) 요청 시 InvalidChartParameterException 발생한다.")
     void givenInvalidMinutesTimeframe_whenGetCandles_thenThrowException() {
         // then & when
-        assertThatThrownBy(() -> chartService.getCandles(STOCK_CODE, "23m", END_TIME, LIMIT))
+        assertThatThrownBy(() -> chartService.getNCandles(STOCK_CODE, "23m", END_TIME, LIMIT))
                 .isInstanceOf(InvalidChartParameterException.class)
-                .hasMessageContaining("지원하지 않는 분봉");
+                .hasMessageContaining("지원하지 않는 캔들 타입입니다.");
     }
 
     @Test
     @DisplayName("지원하지 않는 잘못된 타임프레임(일/주/월/년봉) 요청 시 InvalidChartParameterException 발생한다.")
     void givenInvalidTimeframe_whenGetCandles_thenThrowException() {
         // then & when
-        assertThatThrownBy(() -> chartService.getCandles(STOCK_CODE, "99h", END_TIME, LIMIT))
+        assertThatThrownBy(() -> chartService.getNCandles(STOCK_CODE, "99h", END_TIME, LIMIT))
                 .isInstanceOf(InvalidChartParameterException.class)
-                .hasMessageContaining("지원하지 않는 일/주/월/년봉");
+                .hasMessageContaining("지원하지 않는 캔들 타입입니다.");
     }
 
     @Test
@@ -146,11 +126,11 @@ class ChartServiceTest {
     void givenValidParameters_whenGetCandles_thenReturnResponse() {
         // given
         OhlcvDto mockDto = new OhlcvDto(STOCK_CODE, END_TIME, 100.0, 150.0, 90.0, 120.0, 1000L);
-        when(ohlcv1mRepository.findDynamicMinuteCandles(any(), any(), any(), anyInt()))
+        when(ohlcv1mRepository.findOneMinuteCandles(any(), any(), anyInt()))
                 .thenReturn(List.of(mockDto));
 
         // when
-        ChartResponseDto response = chartService.getCandles(STOCK_CODE, "1m", END_TIME, LIMIT);
+        ChartResponseDto response = chartService.getNCandles(STOCK_CODE, "1m", END_TIME, LIMIT);
 
         // then
         assertThat(response.candles()).hasSize(1);

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/domain/enums/CandleTypeTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/domain/enums/CandleTypeTest.java
@@ -2,8 +2,7 @@ package com.assetmind.server_stock.stock.domain.enums;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.assetmind.server_stock.stock.exception.InvalidStockParameterException;
-import org.assertj.core.api.Assertions;
+import com.assetmind.server_stock.stock.exception.InvalidChartParameterException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -39,11 +38,11 @@ public class CandleTypeTest {
 
         // When & Then
         assertThatThrownBy(() -> CandleType.from(invalidInput))
-                .isInstanceOf(InvalidStockParameterException.class)
+                .isInstanceOf(InvalidChartParameterException.class)
                 .hasMessageContaining("지원하지 않는 캔들 타입입니다");
 
         assertThatThrownBy(() -> CandleType.from(weirdInput))
-                .isInstanceOf(InvalidStockParameterException.class);
+                .isInstanceOf(InvalidChartParameterException.class);
     }
 
     @Test
@@ -51,6 +50,6 @@ public class CandleTypeTest {
     void givenNull_whenFrom_thenThrowsException() {
         // When & Then
         assertThatThrownBy(() -> CandleType.from(null))
-                .isInstanceOf(InvalidStockParameterException.class);
+                .isInstanceOf(InvalidChartParameterException.class);
     }
 }

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/ChartApiIntegrationTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/ChartApiIntegrationTest.java
@@ -65,7 +65,7 @@ public class ChartApiIntegrationTest extends IntegrationTestSupport {
                 .andExpect(jsonPath("$.data.candles[0].high").value("160.0"))   // 3분 중 최고가
                 .andExpect(jsonPath("$.data.candles[0].low").value("80.0"))     // 3분 중 최저가
                 .andExpect(jsonPath("$.data.candles[0].close").value("155.0"))  // 09:02의 종가
-                .andExpect(jsonPath("$.data.candles[0].volume").value("60L"));  // 거래량 총합 (10+20+30)
+                .andExpect(jsonPath("$.data.candles[0].volume").value("60"));  // 거래량 총합 (10+20+30)
     }
 
     @Test

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/ChartApiIntegrationTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/ChartApiIntegrationTest.java
@@ -61,11 +61,11 @@ public class ChartApiIntegrationTest extends IntegrationTestSupport {
 
                 // 3분봉 롤업이 잘 동작하는지 검증
                 .andExpect(jsonPath("$.data.candles[0].timestamp").value("2000-01-01T09:00:00"))
-                .andExpect(jsonPath("$.data.candles[0].open").value(100.0))   // 09:00의 시가
-                .andExpect(jsonPath("$.data.candles[0].high").value(160.0))   // 3분 중 최고가
-                .andExpect(jsonPath("$.data.candles[0].low").value(80.0))     // 3분 중 최저가
-                .andExpect(jsonPath("$.data.candles[0].close").value(155.0))  // 09:02의 종가
-                .andExpect(jsonPath("$.data.candles[0].volume").value(60L));  // 거래량 총합 (10+20+30)
+                .andExpect(jsonPath("$.data.candles[0].open").value("100.0"))   // 09:00의 시가
+                .andExpect(jsonPath("$.data.candles[0].high").value("160.0"))   // 3분 중 최고가
+                .andExpect(jsonPath("$.data.candles[0].low").value("80.0"))     // 3분 중 최저가
+                .andExpect(jsonPath("$.data.candles[0].close").value("155.0"))  // 09:02의 종가
+                .andExpect(jsonPath("$.data.candles[0].volume").value("60L"));  // 거래량 총합 (10+20+30)
     }
 
     @Test

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/ChartControllerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/ChartControllerTest.java
@@ -63,7 +63,7 @@ class ChartControllerTest {
                 .candles(List.of(candle))
                 .build();
 
-        given(chartService.getCandles(eq(stockCode), eq(timeframe), eq(endTime), eq(limit)))
+        given(chartService.getNCandles(eq(stockCode), eq(timeframe), eq(endTime), eq(limit)))
                 .willReturn(responseDto);
 
         // when & then


### PR DESCRIPTION
## 🛠️ 작업 내용
- **1분봉 조회 쿼리 변경:** 'JPA의 JPQL을 사용하여 특정 데이터베이스(PostgreSQL)의 Dialect나 Native 쿼리 함수(date_bin 등)에 대한 의존성을 제거하고 단순 조회 쿼리로 변경하였습니다.
- **1분봉 집계 로직 위임:** 기존 DB 쿼리 내에서 작업했던 1분봉을 N분봉으로 집계하는 로직을 `ChartService`로 위임했습니다.
- **테스트 코드 보완 및 검증:** 쿼리 변경 및 집계 로직 위임에 따라 통합 테스트 코드를 수정하여 새로운 구조에서도 데이터 정합성이 완벽히 유지됨을 검증했습니다.

---

## 🔎 기술적 의사결정
### 1. 특정 DB Dialect에 종속되지 않은 JPA 추상화 적용
> 목적: 특정 DB 인프라에 의존하지 않는 유연하고 유지보수하기 쉬운 아키텍처 구성
- **문제:** 이해하기 힘든 `PostgreSQL`에서만 지원하는 `date_bin`등 고급 개념의 집계 함수가 포함되어 있고, 추후에 다른 SQL로 변경된다고 했을 때 쿼리 자체를 바꿔야하는 문제 발생
- **해결:** 하나의 DB SQL에 종속되어있는 쿼리를 과감하게 삭제하고 **단순 엔티티만 조회하는 쿼리** 로 변경

### 2. 조회시에 필요한 부분만 조회할 수 있도록 효율적인 쿼리로 변경
> 목적: 필요한 데이터가 있는 부분만 조회하도록 하여 조회에 필요한 물리적인 시간을 감소
- **문제:** 조회 시에 조건이 되는 `candle_timestamp`가 `2000-01-01` 부터 입력 받은 `endTime`에 해당되기 때문에 작업 시간이 오래걸리고 그에 따라서 DB Connection을 오래 점유하게 되는 문제 발생
- **해결:** 필요한 데이터가 있는 부분을 구하기 위해 `CandleType`, `endTime`, `limit`을 입력으로 받아서 **필요한 1분봉의 데이터 개수를 역산**하여 산출된 데이터의 개수 만큼 조회를 요청하고 이를 `ChartResponseDto`에 담도록 `ChartService`에 집계 로직을 위임
  - **예시:** 예를 들어, 5분붕(CandleType), 현재시간(endTime), 20개(limt)을 입력으로 받았다면, `ChartService`에서 1분봉 100개(5분봉 * 20개)를 DB에서 가져와 5분봉에 맞게 각각 OHLCV를 집계하게 됩니다. 
  - 기존의 풀스캔 방식에서 `LIMIT` 조건을 활용해 딱 필요한 데이터만 인덱스 스캔으로 가져오도록 하여 DB의 연산 및 I/O 부하를 낮추도록 설계

---

## 주요 변경점
- **Infrastructure(JPA)**
 - `Ohlcv1mJpaRepository` : PostgreSQL만의 집계함수가 적용된 쿼리를 삭제하고 단순하게 1분봉을 조회하는 로직으로 변경
 - `Ohlcv1mJpaAdapter` : `Ohlcv1mJpaRepository`에서 쿼리 변경에 대한 구현체 로직 변경
- **Application(Service)**
 - `ChartService`: 입력받은 변수를 통해 필요한 1분봉 데이터 역산 로직 추가 및 1분봉 데이터를 N분봉으로 집계하는 로직 추가
- **Domain**
 - `CandleType` : 예외 `ErrorCode`가 잘못 표기되어있어서 이부분을 수정
 - `Ohlcv1mRepository` : 메서드 이름 및 파라미터 변경에 따른 인터페이스 메서드 이름 및 파라미터 변경

---

## 리뷰 포인트
- `ChartService`로 위임된 1분봉 기반의 N분봉 데이터 집계 로직이 요구사항에 어긋나지 않는지 의견 부탁드립니다.

*(💡 참고: 이번 아키텍처 개선을 바탕으로 진행한 k6 부하 테스트 결과, 응답 속도가 획기적으로 개선되었으며 상세한 수치(3500ms -> 20ms)와 결과 리포트는 성능 최적화 관련 후속 논의나 블로그 포스팅에서 자세히 공유할 예정입니다)*