### PR TITLE
 [Feat] 호가창 API 연동

### DIFF
--- a/apps/web/src/api/stock.ts
+++ b/apps/web/src/api/stock.ts
@@ -69,3 +69,56 @@ export async function getStockHistory(stockCode: string, limit = 20) {
 	);
 	return data.data;
 }
+
+// ─── 호가 (Orderbook) ─────────────────────────────────────────
+
+/** 개별 호가 행 */
+export interface OrderbookRowDto {
+	price: number;
+	changeRate: number;
+	quantity: number;
+}
+
+export interface TradeTickDto {
+	price: number;
+	quantity: number;
+	isBuy: boolean;
+	time: string;
+}
+
+export interface MarketInfoDto {
+	weekHigh: number;
+	weekLow: number;
+	upperLimit: number;
+	lowerLimit: number;
+	riseVI?: number;
+	fallVI?: number;
+	open: number;
+	high: number;
+	low: number;
+	volume: number;
+	volumeUnit: string;
+	changeFromYesterday: number;
+	midPrice?: number;
+}
+
+export interface OrderbookDto {
+	stockCode: string;
+	currentPrice: number;
+	currentChangeRate: number;
+	asks: OrderbookRowDto[];
+	bids: OrderbookRowDto[];
+	trades: TradeTickDto[];
+	tradeStrength: number;
+	marketInfo: MarketInfoDto;
+}
+
+export async function getOrderbook(stockCode: string): Promise<OrderbookDto> {
+	const { data } = await axiosInstance.get<{ data: OrderbookDto }>(
+		`/stocks/${stockCode}/orderbook`,
+	);
+	return data.data;
+}
+
+export const getOrderbookTopic = (stockCode: string) =>
+	`/topic/orderbook/${stockCode}`;

--- a/apps/web/src/api/stock.ts
+++ b/apps/web/src/api/stock.ts
@@ -27,39 +27,49 @@ export async function getStockRanking(
 
 // ─── 캔들스틱 차트 ────────────────────────────────────────────
 
-export type CandleTimeframe = '1m' | '5m' | '1d' | '1w' | '1M';
+export type CandleTimeframe = '1m' | '5m' | '1d' | '1w' | '1mo';
 
+/** 실제 API 응답: data.candles[] - 모든 필드가 String */
 export interface CandleDto {
-	time: string | number;
-	open: number;
-	high: number;
-	low: number;
-	close: number;
-	volume?: number;
+	timestamp: string; // ISO-8601 (예: "2026-04-01T10:00:00")
+	open:      string;
+	high:      string;
+	low:       string;
+	close:     string;
+	volume:    string;
 }
 
 export async function getStockCandles(
 	stockCode: string,
 	timeframe: CandleTimeframe = '1d',
-	limit = 100,
+	limit = 200,
 	endTime?: string,
 ) {
-	const { data } = await axiosInstance.get<{ data: CandleDto[] }>(
+	const { data } = await axiosInstance.get<{
+		data: { stockCode: string; timeframe: string; candles: CandleDto[] };
+	}>(
 		`/stocks/${stockCode}/charts/candles`,
 		{ params: { timeframe, limit, ...(endTime ? { endTime } : {}) } },
 	);
-	return data.data;
+	return data.data.candles;
 }
 
-// ─── 가격 히스토리 ────────────────────────────────────────────
+// ─── 시계열 (history) ─────────────────────────────────────────
+// 체결 틱 데이터 — 캔들 차트에는 candles API 사용
 
+/** 실제 API 응답: data[] - 모든 필드가 String */
 export interface StockHistoryDto {
-	date: string;
-	open: number;
-	high: number;
-	low: number;
-	close: number;
-	volume: number;
+	stockCode:        string;
+	currentPrice:     string;
+	openPrice:        string | null;
+	highPrice:        string | null;
+	lowPrice:         string | null;
+	priceChange:      string;
+	changeRate:       string | null;
+	executionVolume:  string;
+	cumulativeAmount: string | null;
+	cumulativeVolume: string | null;
+	time:             string; // HHmmss
 }
 
 export async function getStockHistory(stockCode: string, limit = 20) {

--- a/apps/web/src/components/stock-detail/orderbook-section.tsx
+++ b/apps/web/src/components/stock-detail/orderbook-section.tsx
@@ -1,20 +1,23 @@
-/*
-	호가창 리스트 
-*/
-export default function OrderbookSection() {
-	return (
-		<div className='bg-gray-600 p-4 h-166.5 flex flex-col'>
-			<div className='flex justify-between items-center mb-4'>
-				<h3 className='font-bold text-gray-200'>호가</h3>
-				<button className='text-xs px-2 py-1 text-gray-300 border'>
-					빠른 주문
-				</button>
-			</div>
+import { useParams } from 'react-router-dom';
+import { useOrderbook } from '../../hooks/stock-detail/use-orderbook';
+import { OrderbookTable } from './orderbook-table';
 
-			{/* 호가 리스트 영역 */}
-			<div className='flex-1 flex flex-col text-sm items-center justify-center'>
-				호가리스트 영역
-			</div>
-		</div>
+export default function OrderbookSection() {
+	const { id: stockCode = '' } = useParams<{ id: string }>();
+	const { data, status } = useOrderbook(stockCode);
+
+	return (
+		<OrderbookTable
+			status={status as any}
+			viewport='desktop'
+			currentPrice={data?.currentPrice}
+			currentChangeRate={data?.currentChangeRate}
+			asks={data?.asks}
+			bids={data?.bids}
+			trades={data?.trades?.map((t, i) => ({ ...t, id: `trade-${i}` }))}
+			tradeStrength={data?.tradeStrength}
+			marketInfo={data?.marketInfo}
+			onRetry={() => window.location.reload()}
+		/>
 	);
 }

--- a/apps/web/src/components/stock-detail/orderbook-table.tsx
+++ b/apps/web/src/components/stock-detail/orderbook-table.tsx
@@ -1,0 +1,326 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+// ─── Types ────────────────────────────────────────────────────
+
+export type OrderbookStatus = 'default' | 'skeleton' | 'error' | 'empty';
+export type Viewport = 'desktop' | 'tablet' | 'mobile';
+
+export interface OrderbookRow {
+	price: number;
+	changeRate: number;
+	quantity: number;
+}
+
+export interface TradeTickRow {
+	id: string;
+	price: number;
+	quantity: number;
+	isBuy: boolean;
+}
+
+export interface MarketInfo {
+	weekHigh: number;
+	weekLow: number;
+	upperLimit: number;
+	lowerLimit: number;
+	riseVI?: number;
+	fallVI?: number;
+	open: number;
+	high: number;
+	low: number;
+	volume: number;
+	volumeUnit: string;
+	changeFromYesterday: number;
+	midPrice?: number;
+}
+
+interface OrderbookTableProps {
+	status?: OrderbookStatus;
+	viewport?: Viewport;
+	isMarketClosed?: boolean;
+	onRetry?: () => void;
+	currentPrice?: number;
+	currentChangeRate?: number;
+	asks?: OrderbookRow[];
+	bids?: OrderbookRow[];
+	trades?: TradeTickRow[];
+	tradeStrength?: number;
+	marketInfo?: MarketInfo;
+	onQuickOrder?: () => void;
+	className?: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────
+
+const fmt = (v: number) => v.toLocaleString('ko-KR');
+const fmtRate = (v: number) => `${v >= 0 ? '+' : ''}${v.toFixed(2)}%`;
+
+// ─── TradeTickerList (인라인) ─────────────────────────────────
+
+const RISE_FLASH = 'rgba(234,88,12,0.18)';
+const FALL_FLASH = 'rgba(37,106,244,0.18)';
+
+const TradeTickItem = ({ trade, isNew }: { trade: TradeTickRow; isNew: boolean }) => {
+	const [bg, setBg] = useState('transparent');
+	const [slideIn, setSlideIn] = useState(false);
+	const mountedRef = useRef(false);
+
+	useEffect(() => {
+		if (!isNew) return;
+		if (!mountedRef.current) {
+			mountedRef.current = true;
+			const raf = requestAnimationFrame(() => setSlideIn(true));
+			return () => cancelAnimationFrame(raf);
+		}
+	}, [isNew]);
+
+	useEffect(() => {
+		if (!isNew) return;
+		setBg(trade.isBuy ? RISE_FLASH : FALL_FLASH);
+		const t = setTimeout(() => setBg('transparent'), 150);
+		return () => clearTimeout(t);
+	}, [isNew, trade.isBuy]);
+
+	return (
+		<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', height: '32px', padding: '0 0 0 8px', backgroundColor: bg, transform: slideIn || !isNew ? 'translateY(0)' : 'translateY(-8px)', opacity: slideIn || !isNew ? 1 : 0, transition: isNew ? 'transform 120ms ease-out, opacity 120ms ease-out, background-color 150ms ease-out' : 'background-color 150ms ease-out', flexShrink: 0 }}>
+			<span style={{ fontSize: '12px', fontWeight: 400, color: '#9F9F9F' }}>{fmt(trade.price)}</span>
+			<span style={{ fontSize: '12px', fontWeight: 400, color: trade.isBuy ? '#EA580C' : '#256AF4', textAlign: 'right', minWidth: '32px' }}>{trade.quantity}</span>
+		</div>
+	);
+};
+
+const TradeTickerList = ({ trades, height = 320, tradeStrength }: { trades: TradeTickRow[]; height?: number; tradeStrength?: number }) => {
+	const prevIdsRef = useRef<Set<string>>(new Set());
+	const newIds = new Set<string>();
+	for (const t of trades) {
+		if (!prevIdsRef.current.has(t.id)) newIds.add(t.id);
+	}
+	useEffect(() => { prevIdsRef.current = new Set(trades.map((t) => t.id)); });
+
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column' }}>
+			<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '4px 0 4px 8px', height: '24px', flexShrink: 0 }}>
+				<span style={{ fontSize: '12px', fontWeight: 400, color: '#9F9F9F' }}>체결강도</span>
+				{tradeStrength !== undefined && <span style={{ fontSize: '12px', fontWeight: 400, color: '#256AF4' }}>{tradeStrength}%</span>}
+			</div>
+			<div style={{ height: `${height}px`, overflowY: 'auto', overflowX: 'hidden', display: 'flex', flexDirection: 'column', scrollbarWidth: 'none' }}>
+				{trades.map((trade) => <TradeTickItem key={trade.id} trade={trade} isNew={newIds.has(trade.id)} />)}
+			</div>
+		</div>
+	);
+};
+
+// ─── Skeleton ─────────────────────────────────────────────────
+
+const SkeletonBox = ({ width = '100%', height = 16 }: { width?: string | number; height?: number }) => (
+	<div style={{ width, height: `${height}px`, borderRadius: '6px', backgroundColor: '#21242C', flexShrink: 0 }} />
+);
+
+const DesktopOrderbookSkeleton = () => (
+	<div style={{ display: 'flex', position: 'relative' }}>
+		<div style={{ display: 'flex', flexDirection: 'column', width: '100px' }}>
+			<div style={{ height: '32px' }} />
+			{Array.from({ length: 10 }).map((_, i) => (
+				<div key={i} style={{ height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'flex-end', paddingRight: '8px' }}>
+					<SkeletonBox width={76} height={20} />
+				</div>
+			))}
+		</div>
+		<div style={{ display: 'flex', flexDirection: 'column', flex: 1, alignItems: 'center' }}>
+			{Array.from({ length: 21 }).map((_, i) => (
+				<div key={i} style={{ height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%' }}>
+					<SkeletonBox width={76} height={20} />
+				</div>
+			))}
+		</div>
+		<div style={{ display: 'flex', flexDirection: 'column', width: '110px' }}>
+			<div style={{ height: '32px' }} />
+			{Array.from({ length: 10 }).map((_, i) => (
+				<div key={i} style={{ height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'flex-start', paddingLeft: '8px' }}>
+					<SkeletonBox width={76} height={20} />
+				</div>
+			))}
+		</div>
+	</div>
+);
+
+// ─── Error ────────────────────────────────────────────────────
+
+const OrderbookError = ({ onRetry }: { onRetry?: () => void }) => (
+	<div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '600px', gap: '16px' }}>
+		<p style={{ fontSize: '14px', color: '#9F9F9F', textAlign: 'center', lineHeight: '1.6', margin: 0 }}>
+			호가 데이터를 불러오지 못했습니다.<br />잠시 후 다시 시도해 주세요.
+		</p>
+		<button onClick={onRetry} style={{ width: '100px', height: '38px', backgroundColor: '#6B4EFF', border: 'none', borderRadius: '8px', cursor: 'pointer', fontSize: '14px', fontWeight: 500, color: '#FFFFFF' }}>
+			다시 시도
+		</button>
+	</div>
+);
+
+// ─── Desktop: AskRow ──────────────────────────────────────────
+
+const AskRow = ({ row, maxQty = 1, isEmpty }: { row?: OrderbookRow; maxQty?: number; isEmpty?: boolean }) => {
+	const barWidth = isEmpty || !row ? 0 : Math.round((row.quantity / maxQty) * 100);
+	return (
+		<div style={{ position: 'relative', width: '100px', height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'flex-end', paddingRight: '8px', overflow: 'hidden' }}>
+			<div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: '1px', background: 'linear-gradient(to left, rgba(255,255,255,0.15), transparent)' }} />
+			{!isEmpty && row && (
+				<>
+					<div style={{ position: 'absolute', top: '50%', transform: 'translateY(-50%)', right: 0, width: `${barWidth}%`, height: '20px', background: 'linear-gradient(to left, rgba(37,106,244,0.3), rgba(37,106,244,0.05))', borderRadius: '2px 0 0 2px' }} />
+					<span style={{ position: 'relative', fontSize: '13px', fontWeight: 400, color: '#256AF4' }}>{fmt(row.quantity)}</span>
+				</>
+			)}
+		</div>
+	);
+};
+
+// ─── Desktop: BidRow ──────────────────────────────────────────
+
+const BidRow = ({ row, maxQty }: { row: OrderbookRow; maxQty: number }) => {
+	const barWidth = Math.round((row.quantity / maxQty) * 100);
+	return (
+		<div style={{ position: 'relative', width: '100px', height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'flex-start', paddingLeft: '8px', overflow: 'hidden' }}>
+			<div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: '1px', background: 'linear-gradient(to right, rgba(255,255,255,0.15), transparent)' }} />
+			<div style={{ position: 'absolute', top: '50%', transform: 'translateY(-50%)', left: 0, width: `${barWidth}%`, height: '20px', background: 'linear-gradient(to right, rgba(234,88,12,0.3), rgba(234,88,12,0.05))', borderRadius: '0 2px 2px 0' }} />
+			<span style={{ position: 'relative', fontSize: '13px', fontWeight: 400, color: '#EA580C' }}>{fmt(row.quantity)}</span>
+		</div>
+	);
+};
+
+// ─── Desktop: PriceCell ───────────────────────────────────────
+
+const PriceCell = ({ price, changeRate }: { price: number; changeRate: number }) => (
+	<div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', padding: '0 4px' }}>
+		<span style={{ fontSize: '14px', fontWeight: 400, color: '#256AF4', lineHeight: 1.2 }}>{fmt(price)}</span>
+		<span style={{ fontSize: '8px', fontWeight: 500, color: '#256AF4', lineHeight: 1.2 }}>{fmtRate(changeRate)}</span>
+	</div>
+);
+
+// ─── Desktop: MarketInfoPanel ─────────────────────────────────
+
+const MarketInfoPanel = ({ info }: { info: MarketInfo }) => {
+	const D = <div style={{ height: '1px', background: 'rgba(255,255,255,0.08)', margin: '6px 0' }} />;
+	const R = ({ label, value, color }: { label: string; value: string; color?: string }) => (
+		<div style={{ display: 'flex', justifyContent: 'space-between', gap: '6px' }}>
+			<span style={{ fontSize: '11px', fontWeight: 400, color: '#9F9F9F', whiteSpace: 'nowrap' }}>{label}</span>
+			<span style={{ fontSize: '11px', fontWeight: 400, color: color ?? '#9F9F9F', whiteSpace: 'nowrap' }}>{value}</span>
+		</div>
+	);
+	return (
+		<div style={{ width: '110px', display: 'flex', flexDirection: 'column' }}>
+			<R label='52주최고' value={fmt(info.weekHigh)} />
+			<R label='52주최저' value={fmt(info.weekLow)} />
+			{D}
+			<R label='상한가' value={fmt(info.upperLimit)} />
+			<R label='하한가' value={fmt(info.lowerLimit)} />
+			<R label='상승VI' value={info.riseVI ? fmt(info.riseVI) : '-'} />
+			<R label='하락VI' value={info.fallVI ? fmt(info.fallVI) : '-'} />
+			{D}
+			<R label='시가' value={fmt(info.open)} />
+			<R label='고가' value={fmt(info.high)} color='#EA580C' />
+			<R label='저가' value={fmt(info.low)} color='#256AF4' />
+			{D}
+			<div style={{ fontSize: '11px', color: '#9F9F9F', whiteSpace: 'nowrap' }}>거래량</div>
+			<div style={{ fontSize: '11px', color: '#9F9F9F', whiteSpace: 'nowrap' }}>{info.volumeUnit}</div>
+			<R label='전일대비' value={`${info.changeFromYesterday}%`} />
+			{D}
+			<R label='예상체결가' value={info.midPrice ? fmt(info.midPrice) : '-'} />
+		</div>
+	);
+};
+
+// ─── OrderbookTable ───────────────────────────────────────────
+
+export const OrderbookTable = ({
+	status: statusProp,
+	viewport = 'desktop',
+	isMarketClosed,
+	onRetry,
+	currentPrice = 0,
+	currentChangeRate = 0,
+	asks = [],
+	bids = [],
+	trades = [],
+	tradeStrength = 0,
+	marketInfo,
+	onQuickOrder,
+	className,
+}: OrderbookTableProps) => {
+	const status: OrderbookStatus = statusProp ?? (isMarketClosed ? 'empty' : 'default');
+
+	const maxAskQty = Math.max(...asks.map((a) => a.quantity), 1);
+	const maxBidQty = Math.max(...bids.map((b) => b.quantity), 1);
+
+	return (
+		<div
+			className={className}
+			style={{ width: '340px', height: '820px', backgroundColor: '#1C1D21', borderRadius: '12px', padding: '16px', display: 'flex', flexDirection: 'column', gap: '16px', position: 'relative', overflow: 'hidden', boxSizing: 'border-box' }}
+		>
+			{/* 배경 그라디언트 */}
+			<div style={{ position: 'absolute', top: 0, left: 0, width: '200px', height: '200px', background: 'radial-gradient(ellipse at top left, rgba(37,106,244,0.1) 0%, transparent 70%)', pointerEvents: 'none' }} />
+			<div style={{ position: 'absolute', bottom: 0, right: 0, width: '200px', height: '200px', background: 'radial-gradient(ellipse at bottom right, rgba(234,88,12,0.1) 0%, transparent 70%)', pointerEvents: 'none' }} />
+
+			{/* 헤더 */}
+			<div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', position: 'relative' }}>
+				<span style={{ fontSize: '14px', fontWeight: 400, color: '#FFFFFF' }}>호가</span>
+				{(status === 'default' || status === 'skeleton') && (
+					<button onClick={onQuickOrder} style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: '4px', width: '79px', height: '24px', border: '1px solid rgba(255,255,255,0.25)', borderRadius: '8px', background: 'transparent', cursor: 'pointer' }}>
+						<span style={{ fontSize: '14px', fontWeight: 400, color: '#9F9F9F' }}>빠른 주문</span>
+					</button>
+				)}
+			</div>
+
+			{/* 상태별 렌더링 */}
+			{status === 'skeleton' && <DesktopOrderbookSkeleton />}
+			{status === 'error' && <OrderbookError onRetry={onRetry} />}
+			{status === 'empty' && (
+				<div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1, color: '#9F9F9F', fontSize: '14px' }}>
+					장이 휴장 중입니다.
+				</div>
+			)}
+
+			{status === 'default' && marketInfo && (
+				<div style={{ display: 'flex', position: 'relative' }}>
+					{/* 왼쪽: 매도 잔량 및 체결 목록 */}
+					<div style={{ display: 'flex', flexDirection: 'column' }}>
+						<AskRow isEmpty />
+						{asks.map((ask, i) => <AskRow key={i} row={ask} maxQty={maxAskQty} />)}
+						<TradeTickerList
+							trades={trades}
+							tradeStrength={tradeStrength}
+							height={trades.length * 32 + 24}
+						/>
+					</div>
+
+					{/* 중앙: 호가 가격 */}
+					<div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+						<div style={{ height: '32px', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+							<span style={{ fontSize: '14px', fontWeight: 400, color: '#256AF4', lineHeight: 1.2 }}>{fmt(currentPrice)}</span>
+							<span style={{ fontSize: '8px', fontWeight: 500, color: '#EA580C', lineHeight: 1.2 }}>{fmtRate(currentChangeRate)}</span>
+						</div>
+						{asks.map((ask, i) => (
+							<div key={i} style={{ height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+								<PriceCell price={ask.price} changeRate={ask.changeRate} />
+							</div>
+						))}
+						{bids.map((bid, i) => (
+							<div key={i} style={{ height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+								<PriceCell price={bid.price} changeRate={bid.changeRate} />
+							</div>
+						))}
+					</div>
+
+					{/* 오른쪽: 시장 정보 및 매수 잔량 */}
+					<div style={{ display: 'flex', flexDirection: 'column' }}>
+						<div style={{ height: '32px' }} />
+						<MarketInfoPanel info={marketInfo} />
+						<div style={{ height: '50px' }} />
+						{bids.map((bid, i) => <BidRow key={i} row={bid} maxQty={maxBidQty} />)}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default OrderbookTable;

--- a/apps/web/src/hooks/stock-detail/use-candlestick-chart.ts
+++ b/apps/web/src/hooks/stock-detail/use-candlestick-chart.ts
@@ -2,8 +2,8 @@ import { useEffect, useRef, useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { createChart, ColorType, CandlestickSeries } from 'lightweight-charts';
 import type { Time } from 'lightweight-charts';
-import { getStockCandles, getStockHistory } from '../../api/stock';
-import type { CandleTimeframe, CandleDto, StockHistoryDto } from '../../api/stock';
+import { getStockCandles } from '../../api/stock';
+import type { CandleTimeframe, CandleDto } from '../../api/stock';
 
 // ─── 색상 ─────────────────────────────────────────────────────
 
@@ -26,7 +26,7 @@ export const PERIOD_TO_TIMEFRAME: Record<PeriodTab, CandleTimeframe> = {
 	'5분': '5m',
 	'일':  '1d',
 	'주':  '1w',
-	'월':  '1M',
+	'월':  '1mo',
 };
 
 // ─── 공통 차트 캔들 타입 ──────────────────────────────────────
@@ -40,33 +40,32 @@ interface ChartCandle {
 }
 
 // ─── 데이터 변환 ──────────────────────────────────────────────
+// 실제 API: timestamp(ISO-8601 string), open/high/low/close 모두 string
 
 function candlesToChartData(raw: CandleDto[]): ChartCandle[] {
+	const isIntraday = raw.length > 0 && raw[0].timestamp.includes('T') &&
+		!raw[0].timestamp.endsWith('T00:00:00');
+
 	return raw
-		.map((d) => ({
-			time:  (typeof d.time === 'number' ? d.time : d.time.slice(0, 10)) as Time,
-			open:  d.open,
-			high:  d.high,
-			low:   d.low,
-			close: d.close,
-		}))
+		.map((d) => {
+			const time = isIntraday
+				? Math.floor(new Date(d.timestamp).getTime() / 1000) as unknown as Time
+				: d.timestamp.slice(0, 10) as Time;
+
+			return {
+				time,
+				open:  Number(d.open),
+				high:  Number(d.high),
+				low:   Number(d.low),
+				close: Number(d.close),
+			};
+		})
+		.filter((d) => !isNaN(d.open) && !isNaN(d.close))
 		.sort((a, b) => {
 			const ta = typeof a.time === 'number' ? a.time : new Date(a.time as string).getTime();
 			const tb = typeof b.time === 'number' ? b.time : new Date(b.time as string).getTime();
 			return ta - tb;
 		});
-}
-
-function historyToChartData(raw: StockHistoryDto[]): ChartCandle[] {
-	return raw
-		.map((d) => ({
-			time:  d.date.slice(0, 10) as Time,
-			open:  d.open,
-			high:  d.high,
-			low:   d.low,
-			close: d.close,
-		}))
-		.sort((a, b) => (a.time as string).localeCompare(b.time as string));
 }
 
 // ─── useCandlestickChart ──────────────────────────────────────
@@ -83,35 +82,23 @@ export function useCandlestickChart(stockCode: string): UseCandlestickChartRetur
 	const chartContainerRef = useRef<HTMLDivElement>(null);
 	const [period, setPeriod] = useState<PeriodTab>('일');
 
-	const timeframe  = PERIOD_TO_TIMEFRAME[period];
-	const isIntraday = period === '1분' || period === '5분';
+	const timeframe = PERIOD_TO_TIMEFRAME[period];
 
-	const candleQuery = useQuery<CandleDto[]>({
+	// 모든 기간 → candles API 사용 (history는 체결 틱이라 차트에 부적합)
+	const { data: candleData, isLoading, isError } = useQuery<CandleDto[]>({
 		queryKey: ['stockCandles', stockCode, timeframe],
 		queryFn:  () => getStockCandles(stockCode, timeframe, 200),
-		enabled:  !!stockCode && isIntraday,
+		enabled:  !!stockCode,
 		staleTime: 1000 * 30,
 	});
-
-	const historyQuery = useQuery<StockHistoryDto[]>({
-		queryKey: ['stockHistory', stockCode, timeframe],
-		queryFn:  () => getStockHistory(stockCode, 200),
-		enabled:  !!stockCode && !isIntraday,
-		staleTime: 1000 * 30,
-	});
-
-	const isLoading = isIntraday ? candleQuery.isLoading : historyQuery.isLoading;
-	const isError   = isIntraday ? candleQuery.isError   : historyQuery.isError;
 
 	const chartData: ChartCandle[] = useMemo(() =>
-		isIntraday
-			? candlesToChartData(candleQuery.data ?? [])
-			: historyToChartData(historyQuery.data ?? []),
-		[isIntraday, candleQuery.data, historyQuery.data],
+		candlesToChartData(candleData ?? []),
+		[candleData],
 	);
 
 	useEffect(() => {
-		if (!chartContainerRef.current || chartData.length === 0) return;
+		if (!chartContainerRef.current) return;
 
 		const chart = createChart(chartContainerRef.current, {
 			layout: {
@@ -134,8 +121,10 @@ export function useCandlestickChart(stockCode: string): UseCandlestickChartRetur
 			wickDownColor: CHART_COLORS.fall,
 		});
 
-		candlestickSeries.setData(chartData);
-		chart.timeScale().fitContent();
+		if (chartData.length > 0) {
+			candlestickSeries.setData(chartData);
+			chart.timeScale().fitContent();
+		}
 
 		const handleResize = () => {
 			if (chartContainerRef.current) {
@@ -148,7 +137,7 @@ export function useCandlestickChart(stockCode: string): UseCandlestickChartRetur
 			window.removeEventListener('resize', handleResize);
 			chart.remove();
 		};
-	}, [chartData]);
+	}, [chartData, period]);
 
 	return { chartContainerRef, period, setPeriod, isLoading, isError };
 }

--- a/apps/web/src/hooks/stock-detail/use-orderbook.ts
+++ b/apps/web/src/hooks/stock-detail/use-orderbook.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useWebSocket } from '../web-socket/use-web-socket';
+import {
+	getOrderbook,
+	getOrderbookTopic,
+	STOCK_WS_URL,
+} from '../../api/stock';
+import type { OrderbookDto } from '../../api/stock';
+
+export function useOrderbook(stockCode: string) {
+	const [data, setData] = useState<OrderbookDto | null>(null);
+
+	// 초기 REST API 로드
+	const { data: queryData, isLoading, isError } = useQuery<OrderbookDto>({
+		queryKey: ['orderbook', stockCode],
+		queryFn: () => getOrderbook(stockCode),
+		enabled: !!stockCode,
+		staleTime: 1000 * 10,
+	});
+
+	// queryData가 오면 로컬 state에 반영
+	useEffect(() => {
+		if (queryData) setData(queryData);
+	}, [queryData]);
+
+	// WebSocket 실시간 업데이트
+	const { isConnected, subscribe } = useWebSocket(STOCK_WS_URL);
+
+	useEffect(() => {
+		if (!isConnected || !stockCode) return;
+
+		const topic = getOrderbookTopic(stockCode);
+		const subscription = subscribe(topic, (raw: unknown) => {
+			const update = raw as Partial<OrderbookDto>;
+			setData((prev) => {
+				if (!prev) return prev;
+				return { ...prev, ...update };
+			});
+		});
+
+		return () => {
+			subscription?.unsubscribe();
+		};
+	}, [isConnected, stockCode, subscribe]);
+
+	const status = isLoading
+		? 'skeleton'
+		: isError
+			? 'error'
+			: !data
+				? 'skeleton'
+				: 'default';
+
+	return { data, status, isConnected };
+}

--- a/apps/web/src/mocks/handlers/stock.ts
+++ b/apps/web/src/mocks/handlers/stock.ts
@@ -79,6 +79,59 @@ const stockHistoryResolver: HttpResponseResolver = ({ request }) => {
 	return HttpResponse.json({ success: true, message: null, data }, { status: 200 });
 };
 
+// ─── 호가 핸들러 ──────────────────────────────────────────────
+
+const orderbookResolver: HttpResponseResolver = ({ params }) => {
+	const stockCode = params.stockCode as string;
+	const basePrice = 75000 + Math.floor(Math.random() * 10000);
+
+	const asks = Array.from({ length: 10 }).map((_, i) => ({
+		price: basePrice + (10 - i) * 100,
+		changeRate: Number((((basePrice + (10 - i) * 100 - 70000) / 70000) * 100).toFixed(2)),
+		quantity: Math.floor(Math.random() * 5000 + 500),
+	}));
+
+	const bids = Array.from({ length: 10 }).map((_, i) => ({
+		price: basePrice - (i + 1) * 100,
+		changeRate: Number((((basePrice - (i + 1) * 100 - 70000) / 70000) * 100).toFixed(2)),
+		quantity: Math.floor(Math.random() * 5000 + 500),
+	}));
+
+	const trades = Array.from({ length: 14 }).map((_, i) => ({
+		price: basePrice + Math.floor(Math.random() * 200 - 100),
+		quantity: Math.floor(Math.random() * 100 + 1),
+		isBuy: Math.random() > 0.5,
+		time: new Date(Date.now() - i * 3000).toTimeString().slice(0, 8).replace(/:/g, ''),
+	}));
+
+	const data = {
+		stockCode,
+		currentPrice: basePrice,
+		currentChangeRate: Number((((basePrice - 70000) / 70000) * 100).toFixed(2)),
+		asks,
+		bids,
+		trades,
+		tradeStrength: Math.floor(Math.random() * 100),
+		marketInfo: {
+			weekHigh: basePrice + 15000,
+			weekLow: basePrice - 20000,
+			upperLimit: Math.floor(basePrice * 1.3),
+			lowerLimit: Math.floor(basePrice * 0.7),
+			riseVI: Math.floor(basePrice * 1.1),
+			fallVI: Math.floor(basePrice * 0.9),
+			open: basePrice - 500,
+			high: basePrice + 1200,
+			low: basePrice - 800,
+			volume: 3240000,
+			volumeUnit: '백만주',
+			changeFromYesterday: 2.34,
+			midPrice: basePrice + 50,
+		},
+	};
+
+	return HttpResponse.json({ success: true, message: null, data }, { status: 200 });
+};
+
 // ─── WebSocket 핸들러 ─────────────────────────────────────────
 // brokerURL: ws://localhost:5173/ws-stock 으로 직접 연결
 
@@ -88,6 +141,7 @@ export const stockHandlers = [
 	http.get('*/api/stocks/ranking/:type', stockRankingResolver),
 	http.get('*/api/stocks/:stockCode/charts/candles', stockCandlesResolver),
 	http.get('*/api/stocks/:stockCode/history', stockHistoryResolver),
+	http.get('*/api/stocks/:stockCode/orderbook', orderbookResolver),
 
 	stockSocket.addEventListener('connection', ({ client }) => {
 		console.log('[MSW] WebSocket connected');
@@ -164,6 +218,31 @@ export const stockHandlers = [
 						const payload = JSON.stringify({
 							type: isVolumeTopic ? 'RANKING_VOLUME_UPDATE' : 'RANKING_VALUE_UPDATE',
 							data: sortedData,
+						});
+						sendStomp(`MESSAGE\ndestination:${destination}\nsubscription:${subId}\nmessage-id:${now}\ncontent-type:application/json\n\n${payload}\0`);
+					}
+
+					// 호가 실시간 업데이트 (/topic/orderbook/{stockCode})
+					if (destination.startsWith('/topic/orderbook/')) {
+						const code = destination.split('/').pop() ?? '';
+						const basePrice = 75000 + Math.floor(Math.random() * 2000 - 1000);
+						const asks = Array.from({ length: 10 }).map((_, i) => ({
+							price: basePrice + (10 - i) * 100,
+							changeRate: Number((((basePrice + (10 - i) * 100 - 70000) / 70000) * 100).toFixed(2)),
+							quantity: Math.floor(Math.random() * 5000 + 500),
+						}));
+						const bids = Array.from({ length: 10 }).map((_, i) => ({
+							price: basePrice - (i + 1) * 100,
+							changeRate: Number((((basePrice - (i + 1) * 100 - 70000) / 70000) * 100).toFixed(2)),
+							quantity: Math.floor(Math.random() * 5000 + 500),
+						}));
+						const payload = JSON.stringify({
+							stockCode: code,
+							currentPrice: basePrice,
+							currentChangeRate: Number((((basePrice - 70000) / 70000) * 100).toFixed(2)),
+							asks,
+							bids,
+							tradeStrength: Math.floor(Math.random() * 100),
 						});
 						sendStomp(`MESSAGE\ndestination:${destination}\nsubscription:${subId}\nmessage-id:${now}\ncontent-type:application/json\n\n${payload}\0`);
 					}

--- a/apps/web/src/mocks/handlers/stock.ts
+++ b/apps/web/src/mocks/handlers/stock.ts
@@ -32,48 +32,75 @@ const stockRankingResolver: HttpResponseResolver = ({ request }) => {
 	return HttpResponse.json({ success: true, message: null, data: sortedData }, { status: 200 });
 };
 
-const stockCandlesResolver: HttpResponseResolver = ({ request }) => {
+const stockCandlesResolver: HttpResponseResolver = ({ request, params }) => {
 	const url = new URL(request.url);
 	const timeframe = url.searchParams.get('timeframe') ?? '1d';
-	const limit = Number(url.searchParams.get('limit')) || 100;
+	const limit = Number(url.searchParams.get('limit')) || 200;
+	const stockCode = (params as any).stockCode as string;
+
 	const isIntraday = timeframe === '1m' || timeframe === '5m';
-	const intervalMs = timeframe === '1m' ? 60_000 : timeframe === '5m' ? 300_000
-		: timeframe === '1d' ? 86_400_000 : timeframe === '1w' ? 604_800_000 : 2_592_000_000;
+	const intervalMs = timeframe === '1m' ? 60_000
+		: timeframe === '5m' ? 300_000
+		: timeframe === '1d' ? 86_400_000
+		: timeframe === '1w' ? 604_800_000
+		: 2_592_000_000; // 1mo
 
 	const now = Date.now();
 	let price = 75000;
-	const data = Array.from({ length: limit }).map((_, i) => {
+
+	const candles = Array.from({ length: limit }).map((_, i) => {
 		const t = now - (limit - 1 - i) * intervalMs;
 		const open = price;
 		const change = (Math.random() - 0.48) * price * 0.02;
 		const close = Math.max(1000, Math.floor(open + change));
 		const high = Math.floor(Math.max(open, close) * (1 + Math.random() * 0.01));
-		const low = Math.floor(Math.min(open, close) * (1 - Math.random() * 0.01));
+		const low  = Math.floor(Math.min(open, close) * (1 - Math.random() * 0.01));
 		price = close;
-		return isIntraday
-			? { time: Math.floor(t / 1000), open, high, low, close }
-			: { time: new Date(t).toISOString().slice(0, 10), open, high, low, close };
+		const timestamp = isIntraday
+			? new Date(t).toISOString().slice(0, 19)
+			: new Date(t).toISOString().slice(0, 10) + 'T00:00:00';
+		return {
+			timestamp,
+			open:   String(open),
+			high:   String(high),
+			low:    String(low),
+			close:  String(close),
+			volume: String(Math.floor(Math.random() * 1000000 + 100000)),
+		};
 	});
 
-	return HttpResponse.json({ success: true, message: null, data }, { status: 200 });
+	return HttpResponse.json({
+		success: true, message: null,
+		data: { stockCode, timeframe, candles },
+	}, { status: 200 });
 };
 
-const stockHistoryResolver: HttpResponseResolver = ({ request }) => {
+const stockHistoryResolver: HttpResponseResolver = ({ request, params }) => {
 	const url = new URL(request.url);
 	const limit = Number(url.searchParams.get('limit')) || 20;
+	const stockCode = (params as any).stockCode as string;
 	const now = Date.now();
-	const DAY_MS = 86_400_000;
-	let price = 75000;
 
 	const data = Array.from({ length: limit }).map((_, i) => {
-		const t = now - (limit - 1 - i) * DAY_MS;
-		const open = price;
-		const change = (Math.random() - 0.48) * price * 0.02;
-		const close = Math.max(1000, Math.floor(open + change));
-		const high = Math.floor(Math.max(open, close) * (1 + Math.random() * 0.01));
-		const low = Math.floor(Math.min(open, close) * (1 - Math.random() * 0.01));
-		price = close;
-		return { date: new Date(t).toISOString().slice(0, 10), open, high, low, close, volume: Math.floor(Math.random() * 1000000 + 100000) };
+		const t = now - (limit - 1 - i) * 3000; // 3초 간격 체결 틱
+		const currentPrice = String(75000 + Math.floor(Math.random() * 2000 - 1000));
+		const priceChange = String(Math.floor(Math.random() * 2000 - 1000));
+		const changeRate = (Math.random() * 4 - 2).toFixed(2);
+		const executionVolume = String(Math.floor(Math.random() * 1000 + 1));
+		const time = new Date(t).toTimeString().slice(0, 8).replace(/:/g, '');
+		return {
+			stockCode,
+			currentPrice,
+			openPrice: null,
+			highPrice: null,
+			lowPrice: null,
+			priceChange,
+			changeRate,
+			executionVolume,
+			cumulativeAmount: null,
+			cumulativeVolume: null,
+			time,
+		};
 	});
 
 	return HttpResponse.json({ success: true, message: null, data }, { status: 200 });

--- a/apps/web/src/pages/stock-detail-page.tsx
+++ b/apps/web/src/pages/stock-detail-page.tsx
@@ -22,7 +22,7 @@ export default function StockDetailPage() {
 
 	return (
 		<div className='w-full min-h-screen text-gray-200'>
-			<div className='max-w-6xl mx-auto px-4'>
+			<div className='max-w-[1400px] mx-auto px-4'>
 				<div className='pt-10'>
 					{/* 종목 헤더 */}
 					<StockHeaderCard />
@@ -58,14 +58,17 @@ export default function StockDetailPage() {
 
 					{/* ── 차트·호가 탭 ── */}
 					{activeTab === 'chart' && (
-						<div className='grid grid-cols-12 gap-4'>
-							<div className='col-span-12 xl:col-span-6 flex flex-col gap-4'>
+						<div style={{ display: 'flex', gap: '16px', alignItems: 'flex-start' }}>
+							{/* 차트 — 나머지 공간 */}
+							<div style={{ flex: 1, minWidth: 0 }}>
 								<ChartSection />
 							</div>
-							<div className='col-span-12 md:col-span-6 xl:col-span-3'>
+							{/* 호가창 — 340px 고정 */}
+							<div style={{ flexShrink: 0 }}>
 								<OrderbookSection />
 							</div>
-							<div className='col-span-12 md:col-span-6 xl:col-span-3'>
+							{/* AI 예측 — 340px 고정 */}
+							<div style={{ flexShrink: 0 }}>
 								<AIPredictionSection />
 							</div>
 						</div>


### PR DESCRIPTION
# [Feat] 호가창 API 연동

## 📌 1. PR 요약
호가창 컴포넌트인 **OrderbookTable**을 성공적으로 이식하고, 실시간 데이터 동기화를 위한 **WebSocket** 및 **REST API** 연동 환경을 구축했습니다. 현재 호가창 API가 구현되지 않은 상태라 **Mock 데이터**를 활용하여 기능을 구현했으며, 실제 스펙에 맞춘 데이터 파싱 로직을 선제적으로 반영했습니다.

## 🛠 2. 작업 내용
### 호가창 UI 및 데이터 연동
- **Storybook**에서 검증된 **OrderbookTable** 컴포넌트를 프로젝트 내부로 이식했습니다.
- **useOrderbook** 커스텀 훅을 신규 생성하여 초기 데이터 로드(REST)와 실시간 업데이트(WebSocket) 구독 로직을 통합했습니다.
- **OrderbookSection**을 통해 컴포넌트와 훅을 연결하여 실제 데이터 바인딩을 완료했습니다.

### 캔들스틱 차트 로직 고도화 및 API 정비
- **src/api/stock.ts**: **CandleDto** 및 **StockHistoryDto**의 필드명을 실제 백엔드 스펙에 맞춰 수정하고, 호가 관련 타입 및 Mock용 API를 추가했습니다.
- **use-candlestick-chart.ts**: 불필요한 history API 참조를 제거하고 **candles API**로 단일화하였으며, 타임스탬프 변환 로직을 보완했습니다.

### 페이지 레이아웃 개선
- **stock-detail-page.tsx**: 대화면 대응을 위해 최대 너비를 **1400px**로 확장하고, 레이아웃 구조를 **flex** 체제로 전환하여 유연성을 확보했습니다.

### Mock 시스템 최적화
- **mock-stock-handler.ts**: 캔들 및 히스토리 응답 구조를 실제 API 명세와 일치하도록 수정하고, 실시간 호가 테스트를 위한 Mock 데이터를 추가했습니다.

## 📸 3. 스크린샷
| Orderbook UI Integration | Real-time WebSocket Updates |
|:---:|:---:|
| <img width="1895" height="912" alt="image" src="https://github.com/user-attachments/assets/e55bea66-553a-412a-9d72-3be8f9a29e23" /> | <img width="358" height="731" alt="Real-time WebSocket Updates" src="https://github.com/user-attachments/assets/854dfde9-b85d-4fcd-958d-f74cd16c630f" /> |

## 📋 4. 파일 변경 목록
- `src/api/stock.ts`: **CandleDto** 스펙 반영 및 호가 API/타입 정의 추가
- `src/hooks/stock-detail/use-candlestick-chart.ts`: **candles API** 활용 로직 단일화 및 타임스탬프 변환 수정
- `src/hooks/stock-detail/use-orderbook.ts`: 초기 로드 및 **WebSocket** 구독 로직을 포함한 신규 훅 생성
- `src/components/stock-detail/orderbook-table.tsx`: **Storybook** 컴포넌트 프로젝트 이식
- `src/components/stock-detail/orderbook-section.tsx`: 호가 섹션 레이아웃 및 훅 연동
- `src/pages/stock-detail-page.tsx`: 페이지 레이아웃 **flex** 전환 및 최대 너비 확장 적용
- `src/mocks/handlers/stock.ts`: 실데이터 스펙에 맞춘 **Mock** 응답 구조 최적화 및 호가 데이터 추가

## 💬 5. 리뷰 포인트
- **Mock 데이터 활용**: 호가창 API가 아직 구현되지 않아 현재 **Mock 데이터**로 동작 중입니다. 차후 실제 API 배포 시 엔드포인트 전환이 용이하도록 설계되었는지 검토 부탁드립니다.
- **레이아웃 확장**: 페이지 최대 너비 확장(`max-w-[1400px]`) 및 **flex** 전환 이후, 다른 섹션(차트 등)의 반응형 동작에 사이드 이펙트가 없는지 확인이 필요합니다.
- **데이터 파싱 로직**: `getStockCandles` 응답에서 `data.candles`를 추출하는 구조와 타임스탬프 변환 로직이 실제 데이터 규격과 부합하는지 체크해 주세요.