### PR TITLE
[Feat] KIS 웹소켓 Timeout(code: 1006) 방지를 위한 Ping-Pong 생명주기 관리 및 단위 테스트 구축

### DIFF
--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
@@ -9,6 +9,7 @@ import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.par
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,7 +53,7 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
     // 연결 전 요청을 임시 저장할 대기열 (동기화 리스트)
     private final List<String> pendingSubscriptionList = Collections.synchronizedList(new ArrayList<>());
 
-    // HearBeat(Ping) 타이머 관리 변수
+    // Heartbeat(Ping) 타이머 관리 변수
     private ScheduledFuture<?> pingTask;
 
     public KisWebSocketHandler(String approveKey, Account account, List<String> chunk, ObjectMapper objectMapper, KisRealTimeDataParser dataParser,
@@ -108,7 +109,7 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
         log.info("[KIS WS Handler] 세션 연결 성공 (Session ID : {})", session.getId());
         this.currentSession = session;
 
-        // HeartBeat(Ping) 스케줄러 등록 60초마다 실행
+        // Heartbeat(Ping) 스케줄러 등록 60초마다 실행
         startHeartbeatTimer();
 
         // 대기중인 요청 일괄 처리
@@ -141,7 +142,7 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
                         log.error("[KIS WS Handler] HeartBeat(Ping) 전송 실패", e);
                     }
                 }
-            }, 60000); // 60초
+            }, Duration.ofMinutes(1)); // 60초
         }
     }
 
@@ -196,6 +197,9 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        // 연결 종료 시 Heartbeat 타이머 해제
+        stopHeartbeatTimer();
+
         log.warn("[KIS WS Handler] 연결 종료됨. Code: {}, Reason: {}", status.getCode(), status.getReason());
         this.currentSession = null;
 
@@ -234,6 +238,9 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
      */
     public void closeConnection() {
         try {
+            // 외부 종료시 Heartbeat 타이머 해제
+            stopHeartbeatTimer();
+
             if (currentSession != null && currentSession.isOpen()) {
                 log.info("[KIS WS] 웹소켓 세션을 정상 종료합니다.");
                 currentSession.close(CloseStatus.NORMAL);
@@ -244,6 +251,14 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
             // 명시적으로 한 번 더 정리
             this.currentSession = null;
             this.subscribedStock.clear();
+        }
+    }
+
+    // Ping 전송 타이머 중지 메서드
+    private void stopHeartbeatTimer() {
+        if (this.pingTask != null && !this.pingTask.isCancelled()) {
+            this.pingTask.cancel(false); // 실행 중인 작업은 강제 중단 X
+            this.pingTask = null;
         }
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
@@ -15,10 +15,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.PingMessage;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
@@ -49,6 +51,9 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
 
     // 연결 전 요청을 임시 저장할 대기열 (동기화 리스트)
     private final List<String> pendingSubscriptionList = Collections.synchronizedList(new ArrayList<>());
+
+    // HearBeat(Ping) 타이머 관리 변수
+    private ScheduledFuture<?> pingTask;
 
     public KisWebSocketHandler(String approveKey, Account account, List<String> chunk, ObjectMapper objectMapper, KisRealTimeDataParser dataParser,
             KisEventMapper eventMapper, ApplicationEventPublisher eventPublisher, TaskScheduler taskScheduler) {
@@ -103,6 +108,9 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
         log.info("[KIS WS Handler] 세션 연결 성공 (Session ID : {})", session.getId());
         this.currentSession = session;
 
+        // HeartBeat(Ping) 스케줄러 등록 60초마다 실행
+        startHeartbeatTimer();
+
         // 대기중인 요청 일괄 처리
         if (!pendingSubscriptionList.isEmpty()) {
 
@@ -116,6 +124,24 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
                 String code = targets.get(i);
                 taskScheduler.schedule(() -> sendSubscriptionRequest(code), Instant.now().plusMillis(i * 50L));
             }
+        }
+    }
+
+    // Ping 전송 타이머 시작 메서드
+    // 60초에 한번씩 연결되어있는 세션을 통해 Ping 메세지를 보낸다.
+    private void startHeartbeatTimer() {
+        if (this.pingTask == null || this.pingTask.isCancelled()) {
+            this.pingTask = this.taskScheduler.scheduleAtFixedRate(() -> {
+                if (currentSession != null && currentSession.isOpen()) {
+                    try {
+                        // Spring WebSocket의 PingMessage 사용 (비어있는 데이터 전송)
+                        currentSession.sendMessage(new PingMessage());
+                        log.debug("[KIS WS Handler] HeartBeat(Ping) 전송 완료");
+                    } catch (IOException e) {
+                        log.error("[KIS WS Handler] HeartBeat(Ping) 전송 실패", e);
+                    }
+                }
+            }, 60000); // 60초
         }
     }
 

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandlerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandlerTest.java
@@ -8,6 +8,8 @@ import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.par
 import com.assetmind.server_stock.stock.application.listener.dto.RealTimeStockTradeEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -23,6 +25,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.PingMessage;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -59,6 +62,9 @@ class KisWebSocketHandlerTest {
     @Mock
     private TaskScheduler taskScheduler; // 스케줄러 Mock 추가
 
+    @Mock
+    private ScheduledFuture<?> scheduledFuture;
+
     private final String TEST_KEY = "TEST_APP_KEY";
     private final Account TEST_ACCOUNT = new Account("test-app-key", "test-app-secret");
     private final List<String> TEST_CHUNK = List.of("005930", "000660");
@@ -76,6 +82,10 @@ class KisWebSocketHandlerTest {
                 eventPublisher,
                 taskScheduler
         );
+
+        // afterConnectionEstablished 호출 시 NPE 방지를 위한 기본 Stubbing
+        lenient().when(taskScheduler.scheduleAtFixedRate(any(Runnable.class), any(Duration.class)))
+                .thenAnswer(invocation -> scheduledFuture);
     }
 
     @Nested
@@ -220,6 +230,69 @@ class KisWebSocketHandlerTest {
 
             // Then
             assertThat(output.getOut()).contains("Parser Crashed!");
+        }
+    }
+
+    @Nested
+    @DisplayName("Heartbeat(Ping) 타이머 테스트")
+    class HeartbeatTimerTests {
+        @Test
+        @DisplayName("성공: 연결 성공 시 60초 주기의 Heartbeat 타이머가 등록되어야 한다.")
+        void givenConnected_whenAfterConnection_thenRegisterPingTimer() throws Exception {
+            // When
+            handler.afterConnectionEstablished(session);
+
+            // Then
+            verify(taskScheduler, times(1)).scheduleAtFixedRate(any(Runnable.class), any(Duration.class));
+
+            assertThat(ReflectionTestUtils.getField(handler, "pingTask")).isNotNull();
+        }
+
+        @Test
+        @DisplayName("성공: Heartbeat 스케줄러가 실행되면 세션을 통해 PingMessage를 전송해야한다.")
+        void givenTimerRegistered_whenRunnableExecutes_thenSendPingMessage() throws Exception {
+            // Given: 스케줄러에 등록된 Runnable 캡처
+            ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+
+            handler.afterConnectionEstablished(session);
+            when(session.isOpen()).thenReturn(true);
+
+            verify(taskScheduler).scheduleAtFixedRate(runnableCaptor.capture(), any(Duration.class));
+
+            // When: 타이머가 작동하여 Runnable 내부 로직 실행
+            Runnable pingTaskRunnable = runnableCaptor.getValue();
+            pingTaskRunnable.run();
+
+            // Then: 세션에 PingMessage 전송 확인
+            verify(session).sendMessage(any(PingMessage.class));
+        }
+
+        @Test
+        @DisplayName("성공: 외부에서 세션 강제 종료 시 등록된 Heartbeat 타이머가 취소(Cancel)되어야 한다")
+        void givenTimerRegistered_whenCloseConnection_thenCancelTimer() throws Exception {
+            // Given: 연결 후 타이머 등록 상태
+            handler.afterConnectionEstablished(session);
+
+            // When: 외부에서 연결 종료 호출
+            handler.closeConnection();
+
+            // Then: 스케줄러 Cancel 호출 및 객체 null 초기화 확인
+            verify(scheduledFuture).cancel(false);
+            assertThat(ReflectionTestUtils.getField(handler, "pingTask")).isNull();
+        }
+
+        @Test
+        @DisplayName("성공: 서버/네트워크 에러로 연결이 끊어졌을 때도 Heartbeat 타이머가 취소되어야 한다")
+        void givenTimerRegistered_whenAfterConnectionClosed_thenCancelTimer() throws Exception {
+            // Given: 연결 후 타이머 등록 상태
+            handler.afterConnectionEstablished(session);
+
+            // When: 비정상 연결 종료 이벤트 발생
+            handler.afterConnectionClosed(session, CloseStatus.SERVER_ERROR);
+
+            // Then
+            verify(scheduledFuture).cancel(false);
+            assertThat(ReflectionTestUtils.getField(handler, "pingTask")).isNull();
         }
     }
 


### PR DESCRIPTION
## 📌 작업 내용
- **KIS 웹소켓 Heartbeat(Ping) 파이프라인 구축:** 장 시작 전이나 거래가 없는 종목 구독 시 발생하는 유휴 상태(Idle) Timeout 으로 인한 네트워크 강제 단절 문제를 해결하기 위해 60초 주기의 Ping 발송 로직 구현
- **WebSocket 생명주기에 맞춘 자원 관리:** 서버 구동 시점이 아닌, 실제 웹소켓 세션이 연결 및 종료 되는 시점에 맞춰 동적으로 스케줄러 타이머를 등록 및 해제하여 좀비 스레드로 인한 자원 낭비 차단
---
## 🏗 기술적 의사결정 및 설계
### 1. 정적 `@Scheduled` 대신 동적 `TaskScheduler` 채택
- **문제:** 스프링 서버 생명주기와 동일한 생명주기로 하나의 스레드를 고정적으로 잡아서 사용하는 정적인 `@Scheduled`를 사용하면 웹소켓 연결 전이나, 연결이 끊어진 세션에 대해서도 백그라운드에서 계속 Ping을 시도하여 자원 낭비를 유발한 위험이 존재.
- **해결:** 생성자로 주입받은 `TaskScheduler`를 활용하여 웹소켓 세션과 하트비트 스케줄러의 생명주기(연결 및 종료)를 동기화하여 연결 즉시 타이머를 켜고, 끊어지는 순간 타이머를 종려하여 깔끔하게 자원 낭비 없이 삭제 되도록 유도.
---
## ✅ 주요 변경점
- **Infrastructure (WebSocket):**
  - `KisWebSocketHandle.java`: `TaskScheduler`를 이용한 60초 주기 Heartbeat(Ping) 발송 및 세션 종료 시 스케줄러 해제 로직 추가
- **Test:**
  - `KisWebSocketHandlerTest.java`: 기존 웹소켓 로직 단위 테스트 전면 보완 및 추가된 기능인 `HeartbeatTimerTests` 기반 스케줄러 생명주기 검증 로직 추가
---
## 📝 리뷰 포인트
- **생명주기 동기화 및 메모리 관리:** `TaskScheduler`를 웹소켓 라이프사이클에 맞게 동적으로 등록하고, 예외 상황에서도 안전하게 취소(`cancel(false)`)하는 로직이 메모리 누수 방지에 적절한지 꼼꼼한 리뷰 부탁드립니다.
---
## 연관 이슈
- **Resolves: #392**