### PR TITLE
[Feat] 인증키 만료 방지 및 일일 파이프라인 초기화

### DIFF
--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/application/RealTimeMarketService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/application/RealTimeMarketService.java
@@ -5,6 +5,8 @@ import com.assetmind.server_stock.market_access.domain.ApiApprovalKey;
 import com.assetmind.server_stock.market_access.infrastructure.kis.config.KisProperties;
 import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
 import jakarta.annotation.PreDestroy;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +38,10 @@ public class RealTimeMarketService {
      */
     @EventListener(ApplicationReadyEvent.class)
     public void startMarketDataCollection() {
+        if (!isMarketOperatingTime()) {
+            log.info(">>> [RealTimeMarketService] 현재는 장 운영 시간이 아닙니다. '[DailyMarketLifecycleScheduler]' 스케줄러가 연결을 담당합니다.");
+            return;
+        }
         log.info(">>> [RealTimeMarketService] 실시간 주식 데이터 수집 서비스를 시작합니다.");
 
         try {
@@ -67,5 +73,12 @@ public class RealTimeMarketService {
     public void stopMarketDataCollection() {
         log.warn(">>> [RealTimeMarketService] 서버 종료 감지. 연결을 해제합니다.");
         realTimeStockDataPort.disconnect();
+    }
+
+    private boolean isMarketOperatingTime() {
+        LocalTime now = LocalTime.now();
+
+        // 8:30 ~ 16:30 사이의 경우에만 true 반환
+        return !now.isBefore(LocalTime.of(8, 30)) && !now.isAfter(LocalTime.of(16, 30));
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisRealTimeStockDataAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisRealTimeStockDataAdapter.java
@@ -54,6 +54,10 @@ public class KisRealTimeStockDataAdapter implements RealTimeStockDataPort {
     public void prepareConnection() {
         log.info("[KIS Adapter] 웹소켓 클라이언트 초기화");
 
+        if (!activeHandlers.isEmpty()) {
+            disconnect();
+        }
+
         this.webSocketClient = new StandardWebSocketClient();
     }
 

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/scheduler/DailyMarketLifecycleScheduler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/scheduler/DailyMarketLifecycleScheduler.java
@@ -1,0 +1,62 @@
+package com.assetmind.server_stock.market_access.infrastructure.scheduler;
+
+import com.assetmind.server_stock.market_access.application.port.RealTimeStockDataPort;
+import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 장 시작/마감시에 KIS 세션과 연결을 수립 및 종료 하여 실시간 체결 데이터 수집 파이프라인을 초기화 및 종료를 담당하는 스케줄러
+ * 장 시작 전(오전 8시 30분)에 실시간 체결 데이터 파이프라인을 연결하고
+ * 장(정규장) 마감 이후 (오후 4시 30분)에 실시간 체결 데이터 파이프라인을 종료하여
+ * 새벽내내 핑퐁을 쏘는 자원 낭비를 방지
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class DailyMarketLifecycleScheduler {
+    private final RealTimeStockDataPort realTimeStockDataPort;
+
+    private final StockMetadataProvider stockMetadataProvider;
+
+    /**
+     * 매주 월~금 오전 8시 30분 파이프라인 연결
+     */
+    @Scheduled(cron = "0 30 8 * * MON-FRI", zone = "Asia/Seoul")
+    public void wakeUpPipeline() {
+        log.info("[DailyMarketLifecycleScheduler] 장 시작 준비: 체결 데이터 수집 파이프라인 초기화 및 연결 시작");
+        try {
+            // 네트워크 연결을 위한 기초 세팅
+            realTimeStockDataPort.prepareConnection();
+
+            Thread.sleep(1000);
+
+            // KOSPI 80 개의 종목 조회
+            List<String> targetStocks = stockMetadataProvider.getAllStockCodes();
+
+            // 종목 구독 요청(Adapter 내부에서 40개씩 청킹하여 구독)
+            realTimeStockDataPort.subscribe(targetStocks);
+        } catch (Exception e) {
+            log.error("[DailyMarketLifecycleScheduler] 체결 데이터 수집 파이프라인 연결 중 에러 발생", e);
+        }
+    }
+
+    /**
+     * 매주 월~금 오후 4시 30분 파이프라인 종료
+     */
+    @Scheduled(cron = "0 30 16 * * MON-FRI", zone = "Asia/Seoul")
+    public void sleepPipeline() {
+        log.info("[DailyMarketLifecycleScheduler] 장 마감: 체결 데이터 수집 파이프라인 자원 반환 및 웹소켓 연결 종료");
+        try {
+            // 진행 중인 모든 실시간 연결 안전하게 종료
+            realTimeStockDataPort.disconnect();
+
+            log.info("[DailyMarketLifecycleScheduler] 체결 데이터 수잡 파이프라인 정상적으로 종료");
+        } catch (Exception e) {
+            log.error("[DailyMarketLifecycleScheduler] 체결 데이터 수집 파이프라인 종료 중 에러 발생", e);
+        }
+    }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/scheduler/DailyMarketLifecycleSchedulerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/scheduler/DailyMarketLifecycleSchedulerTest.java
@@ -1,0 +1,89 @@
+package com.assetmind.server_stock.market_access.infrastructure.scheduler;
+
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.inOrder;
+
+import com.assetmind.server_stock.market_access.application.port.RealTimeStockDataPort;
+import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DailyMarketLifecycleSchedulerTest {
+
+    @Mock
+    private RealTimeStockDataPort realTimeStockDataPort;
+
+    @Mock
+    private StockMetadataProvider stockMetadataProvider;
+
+    @InjectMocks
+    private DailyMarketLifecycleScheduler scheduler;
+
+    @Test
+    @DisplayName("성공: 장 시작 시 연결 준비, 종목 조회, 구독 요청이 순서대로 실행되어야 한다.")
+    void givenStockCodes_whenWakeUpPipeline_thenSuccessSequence() {
+        // given
+        List<String> mockStockCodes = List.of("005930", "000660", "035420");
+        given(stockMetadataProvider.getAllStockCodes()).willReturn(mockStockCodes);
+
+        // when
+        scheduler.wakeUpPipeline();
+
+        // then
+        // 호출 순서 검증을 위한 InOrder 객체 생성
+        InOrder inOrder = inOrder(realTimeStockDataPort, stockMetadataProvider);
+
+        // 1. 연결 준비 -> 2. 종목 조회 -> 3. 구독 순서 확인
+        inOrder.verify(realTimeStockDataPort).prepareConnection();
+        inOrder.verify(stockMetadataProvider).getAllStockCodes();
+        inOrder.verify(realTimeStockDataPort).subscribe(mockStockCodes);
+    }
+
+    @Test
+    @DisplayName("실패방어: 연결 준비 중 에러가 발생해도 예외를 내부에서 처리하고 중단되지 않는다.")
+    void givenFailCase_whenWakeUpPipeline_thenHandleException() {
+        // given
+        willThrow(new RuntimeException("KIS Connection Timeout"))
+                .given(realTimeStockDataPort).prepareConnection();
+
+        // when & then
+        // 예외가 외부로 던져지지 않아야 스케줄러 스레드가 유지됨
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> {
+            scheduler.wakeUpPipeline();
+        });
+
+        // prepareConnection 이후의 로직은 실행되지 않았는지 확인
+        verify(stockMetadataProvider, never()).getAllStockCodes();
+        verify(realTimeStockDataPort, never()).subscribe(any());
+    }
+
+    @Test
+    @DisplayName("성공: 장 마감 시 disconnect가 정상적으로 호출되어야 한다.")
+    void whenSleepPipeline_thenSuccess() {
+        // when
+        scheduler.sleepPipeline();
+
+        // then
+        verify(realTimeStockDataPort, times(1)).disconnect();
+    }
+
+    @Test
+    @DisplayName("실패방어: 종료 중 에러가 발생해도 예외를 내부에서 처리한다.")
+    void givenFailCase_whenSleepPipeline_thenHandleException() {
+        // given
+        willThrow(new RuntimeException("Disconnect Error"))
+                .given(realTimeStockDataPort).disconnect();
+
+        // when & then
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> {
+            scheduler.sleepPipeline();
+        });
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
- **일일 생명주기 초기화 스케줄러 구축:** 매일 아침 장 시작 전(08:30) KIS 실시간 파이프라인을 자동으로 연결하고, 장 마감 후(16:30) 사용 중인 자원과 웹소켓 세션을 안전하게 종료하는 배치 로직 구현.
- **낭비 커넥션 방지:** 스케줄러에 의한 재접속 시도 시, 이전에 닫히지 않고 남아있는 활성 세션(메모리 누수 원인)을 사전에 감지하고 강제 초기화하는 로직 추가.

---
## 🏗 기술적 의사결정 및 설계
### 1. 서버 시작 시점의 연결 위임
- **문제:** 기존에는 서버 구동 이벤트(`ApplicationReadyEvent`)에 무조건 웹소켓을 연결하도록 구성했음, 야간이나 새벽 배포 시 장이 열릴 때까지 빈 세션을 유지하며 Ping만 쏘는 서버 자원 낭비가 발생함.
- **해결:** `RealTimeMarketService` 내부에 `isMarketOperatingTime()` 검증 로직을 도입하여, 장 시간이 아닐 경우 연결을 즉시 끊고 오전 8시 30분 `DailyMarketLifecycleScheduler`가 연결을 담당하도록 책임을 위임.

### 2. 낭비 커넥션 방지
- **문제:** 오전 8시 30분 스케줄러가 동작할 때, 예기치 못한 서버 상태(전날 마감 실패, 수동 조작 등)로 인해 이전 세션이 살아있을 경우 핸들러가 이중으로 생성되어 메모리 누수 및 중복 데이터 수신 위험 존재.
- **해결:** 어댑터의 `prepareConnection()` 호출 시 제일 먼저 `activeHandlers`의 상태를 검사하고, 비어있지 않다면 `disconnect()`를 수행해 이전 세션을 제거한 후 새로운 연결을 맺도록 방어 로직 설계.

---
## ✅ 주요 변경점
- **Application:**
  - `RealTimeMarketService.java`: 서버 구동 시 시간대 검증(`isMarketOperatingTime`) 및 연결 분기 로직 추가.
- **Infrastructure:**
  - `DailyMarketLifecycleScheduler.java`: `0 30 8 * * MON-FRI`, `0 30 16 * * MON-FRI` 크론식을 활용한 파이프라인 연결 및 해제 스케줄러 구현.
  - `KisRealTimeStockDataAdapter.java`: 연결 준비 시 활성 세션 클리어 로직 보강.
- **Test:**
  - `DailyMarketLifecycleSchedulerTest.java`: `InOrder`를 활용한 호출 순서 검증 및 예외 격리(Fail-safe) 보장 테스트 작성.
  - `RealTimeMarketServiceTest.java`: 시간대별 검증을 위해 `MockedStatic<LocalTime>`을 활용한 단위 테스트 추가.
  - `MarketAccessServiceTest.java`: 기존 코드를 BDD 스타일(`given-when-then`)로 통일하여 가독성 리팩토링.

---
## 📝 리뷰 포인트
- **시간 의존성 테스트 (MockedStatic):** `RealTimeMarketService`를 테스트하기 위해 `LocalTime.now()`를 Mocking 하였습니다. `@AfterEach`에서 `close()`를 호출해 다른 테스트에 영향을 주지 않도록(Thread-safe) 격리했는데, 이 방식이 적절한지 확인 부탁드립니다.
- **스케줄러 예외 격리:** 백그라운드 스케줄러가 외부 API(KIS) 에러로 인해 스레드 자체가 죽어버리는 것을 막기 위해 `try-catch`로 감쌌습니다. 현재의 예외 로깅 정책이 충분한지 리뷰 부탁드립니다.

---
## 연관 이슈
- **Resolves: #393**