### PR TITLE
[Feat] 호가 응답 스펙 확정 및 Mock 데이터 전송 스케줄러 구현

### DIFF
--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/OrderBookResponseDto.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/OrderBookResponseDto.java
@@ -1,0 +1,29 @@
+package com.assetmind.server_stock.stock.presentation.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * 프론트엔드 호가 데이터 STOMP 채널로 내려갈 최종 응답 객체
+ */
+@Builder
+public record OrderBookResponseDto(
+        String stockCode,   // 종목 코드
+        String marketTime,  // 호가 수신 시간
+        String totalAskSize,// 총 매도 호가 잔량
+        String totalBidSize,// 총 매수 호가 잔량
+        List<OrderBookLevelResponse> levels // 10개의 호가
+) {
+
+    /**
+     * 단일 호가 레벨 데이터
+     */
+    @Builder
+    public record OrderBookLevelResponse(
+            int level, // 호가 단계 (1 ~ 10)
+            String askPrice,// 매도 호가
+            String askSize, // 매도 잔량
+            String bidPrice,// 매수 호가
+            String bidSize // 매수 잔량
+    ) {}
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/scheduler/MockOrderBookScheduler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/scheduler/MockOrderBookScheduler.java
@@ -1,0 +1,78 @@
+package com.assetmind.server_stock.stock.presentation.scheduler;
+
+import com.assetmind.server_stock.stock.presentation.dto.OrderBookResponseDto;
+import com.assetmind.server_stock.stock.presentation.dto.OrderBookResponseDto.OrderBookLevelResponse;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("!prod")
+@RequiredArgsConstructor
+public class MockOrderBookScheduler {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final Random random = new Random();
+
+    @Scheduled(fixedRate = 1000)
+    public void sendMockOrderBook() {
+        String targetStockCode = "005930";
+        OrderBookResponseDto mockData = createMockData(targetStockCode);
+
+        // 프론트엔드가 구독 중인 대상 주소로 브로드캐스팅
+        String destination = "/topic/orderbook/" + targetStockCode;
+        messagingTemplate.convertAndSend(destination, mockData);
+
+        log.info("[MockOrderBookScheduler] 가짜 호가 데이터 전송 완료 -> {}", destination);
+    }
+
+    private OrderBookResponseDto createMockData(String stockCode) {
+        String currentTime = LocalTime.now().format(DateTimeFormatter.ofPattern("HHmmss"));
+        List<OrderBookLevelResponse> levels = new ArrayList<>();
+
+        long basePrice = 270000;
+        long totalAsk = 0;
+        long totalBid = 0;
+
+        // 1호가 ~ 10호가 가짜 데이터 생성
+        for (int i = 1; i <= 10; i++) {
+            long askPrice = basePrice + (i * 1000);
+            long bidPrice = basePrice - (i * 1000);
+
+            // 매수/매도 호가 잔량은 1000 ~ 5000
+            long askSize = 1000 + random.nextInt(4000);
+            long bidSize = 1000 + random.nextInt(4000);
+
+            totalAsk += askSize;
+            totalBid += bidSize;
+
+            levels.add(
+                    OrderBookLevelResponse.builder()
+                            .level(i)
+                            .askPrice(String.valueOf(askPrice))
+                            .askSize(String.valueOf(askSize))
+                            .bidPrice(String.valueOf(bidPrice))
+                            .bidSize(String.valueOf(bidSize))
+                            .build()
+            );
+        }
+
+        return OrderBookResponseDto.builder()
+                .stockCode(stockCode)
+                .marketTime(currentTime)
+                .totalAskSize(String.valueOf(totalAsk))
+                .totalBidSize(String.valueOf(totalBid))
+                .levels(levels)
+                .build();
+    }
+
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/scheduler/MockOrderBookSchedulerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/scheduler/MockOrderBookSchedulerTest.java
@@ -1,0 +1,59 @@
+package com.assetmind.server_stock.stock.presentation.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.assetmind.server_stock.stock.presentation.dto.OrderBookResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class MockOrderBookSchedulerTest {
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private MockOrderBookScheduler mockOrderBookScheduler;
+
+    @Test
+    @DisplayName("성공: 1초마다 삼성전자 가짜 호가 데이터가 올바른 형식으로 발송되어야 한다.")
+    void givenStockCode_whenSendMockOrderBook_thenSendCorrectData() {
+        // given
+        String expectedStockCode = "005930";
+        String expectedDestination = "/topic/orderbook/" + expectedStockCode;
+
+        // 어떤 데이터가 전송되는지 낚아채기 위한 캡터 준비
+        ArgumentCaptor<OrderBookResponseDto> captor = ArgumentCaptor.forClass(OrderBookResponseDto.class);
+
+        // when
+        mockOrderBookScheduler.sendMockOrderBook();
+
+        // then
+        // messagingTemplate의 convertAndSend가 호출되었는지, 경로가 맞는지 검증
+        then(messagingTemplate).should(times(1))
+                .convertAndSend(eq(expectedDestination), captor.capture());
+
+        // 캡쳐된 실제 전송 데이터를 꺼내서 검증
+        OrderBookResponseDto capturedDto = captor.getValue();
+
+        assertThat(capturedDto.stockCode()).isEqualTo(expectedStockCode);
+        assertThat(capturedDto.marketTime()).hasSize(6); // HHmmss 포맷 확인
+        assertThat(capturedDto.levels()).hasSize(10); // 1~10호가가 다 들어있는지 확인
+
+        // 1호가의 가격과 잔량이 설정한 basePrice 기준으로 적절히 들어갔는지 확인
+        assertThat(capturedDto.levels().getFirst().level()).isEqualTo(1);
+        assertThat(Long.parseLong(capturedDto.levels().getFirst().askPrice())).isGreaterThan(270000);
+
+        // 총 잔량이 0이 아닌지 확인
+        assertThat(Long.parseLong(capturedDto.totalAskSize())).isPositive();
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
- **프론트엔드 협업용 '호가창 응답 DTO' 설계 및 확정:** KIS 실시간 호가 스펙을 분석하여 매도/매수 1~10호가 단계를 배열 구조로 구조화한 `OrderBookResponseDto` 설계.
- **UI 지원용 'Mock 호가 데이터 발송 스케줄러' 구현:** 실제 KIS 웹소켓 연동 전, 프론트엔드 UI 개발을 지원하기 위해 1초 주기로 가짜 삼성전자(005930) 호가 데이터를 STOMP 채널로 쏘는 스케줄러 구현.
- **안전한 개발 환경 격리:** 운영 환경(`prod`) 배포 시 가짜 데이터가 발송되는 대참사를 방지하기 위해 `@Profile("!prod")` 환경에서만 작동하도록 빈(Bean) 생성 조건 설정.

---
## 🏗 기술적 의사결정 및 설계
### 1. 호가 단계(Level)의 배열 구조화 (UI 친화적 설계)
- **문제:** KIS 원본 데이터는 100개 이상의 필드가 평면적으로 나열(`ASKP1`, `ASKP2`...)되어 있어 프론트엔드에서 루프를 돌며 호가창을 그리기 매우 불편한 구조임.
- **해결:** 1호가부터 10호가까지를 `List<OrderBookLevelResponse>`로 묶어 제공함으로써, 프론트엔드에서의 편의성 증진.

### 2. 가짜 데이터 발송을 통한 개발 병목 해소
- **문제:** 실제 KIS 웹소켓 파이프라인(이벤트 기반 아키텍처) 구축이 완료될 때까지 프론트엔드 팀원이 데이터 수신 로직을 테스트할 수 없는 의존성 병목 발생.
- **해결:** 인터페이스 스펙만 먼저 확정하고, 고정된 규격의 가짜 데이터를 1초마다 쏴주는 스케줄러를 선제적으로 배포하여 백엔드 로직 완성 전에도 프론트엔드 UI 작업이 병행 가능하도록 조치.

---
## ✅ 주요 변경점
- **Presentation (DTO):**
  - `OrderBookResponseDto.java`: 10단계 호가 정보를 포함하는 프론트엔드 응답용 DTO 정의 및 Builder 적용.
- **Presentation (Scheduler):**
  - `MockOrderBookScheduler.java`: 1초 주기로 가짜 데이터를 생성하여 `/topic/orderbook/{stockCode}` 경로로 전송하는 로직 구현.
- **Test:**
  - `MockOrderBookSchedulerTest.java`: `ArgumentCaptor`를 활용해 스케줄러가 정확한 경로로 규격에 맞는 DTO를 발송하는지 검증하는 테스트 코드 추가.

---
## 📝 리뷰 포인트
- **DTO 필드 타입:** 현재 가격과 잔량 데이터를 프론트엔드에서 가공하기 편하도록 `String` 타입으로 제공하고 있습니다. 프론트엔드 로직상 `Long` 타입 즉, 숫자 타입으로 바꾸는게 좋을지 아니면 `String` 타입으로 유지할지 판단해주세요
- **테스트 격리:** `MockOrderBookSchedulerTest`에서 `SimpMessagingTemplate`을 모킹하여 실제 메시지 브로커를 띄우지 않고도 단위 테스트를 수행하도록 구성했습니다. 검증 로직이 충분한지 리뷰 부탁드립니다.

---
## 📡 프론트엔드 협업 가이드 (WebSocket Spec)
> `develop` 브런치를 `pull` 한 뒤 로컬 환경에서 서버 실행 시 즉시 테스트 가능합니다.

### 1. 연결
- **STOMP Endpoint:** `/ws-stock` (기존과 동일)
- **Subscribe Topic:** `/topic/orderbook/{stockCode}`
  - 예시: `/topic/orderbook/005930` (삼성전자)

### 2. Mock 데이터 전송 주기
- **주기:** 1초 마다 자동 발송

### 3. 응답 구조 (예시)
```json
{
  "stockCode": "005930",
  "marketTime": "153001",
  "totalAskSize": "45200",
  "totalBidSize": "38900",
  "levels": [
    {
      "level": 1,
      "askPrice": "271000",
      "askSize": "1200",
      "bidPrice": "269000",
      "bidSize": "2500"
    },
    ... (level 10까지 포함, 총 10개의 호가 데이터)
  ]
}
```
---
## 연관 이슈
- **Resolves: #409**