### PR TITLE
[Feat] KIS 실시간 호가 데이터(H0STASP0)을 통한 호가 수집 파이프라인 구축 및 테스트

### DIFF
--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/domain/OrderBook.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/domain/OrderBook.java
@@ -1,0 +1,25 @@
+package com.assetmind.server_stock.market_access.domain;
+
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * 호가 데이터 모델
+ */
+public record OrderBook(
+        String stockCode, // 종목 코드
+        LocalTime marketTime, // 호가 수신 시간
+        Long totalAskSize, // 총 매도 호가 잔량
+        Long totalBidSize, // 총 매수 호가 잔량
+        List<Level> levels // 1~10 호가
+) {
+
+    public record Level(
+            int level, // 1~10
+            Float askPrice, // 매도 호가
+            Float askSize, // 매도 잔량
+            Float bidPrice, // 매수 호가
+            Float bidSize // 매수 잔량
+    ) {}
+
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/domain/OrderBook.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/domain/OrderBook.java
@@ -2,10 +2,12 @@ package com.assetmind.server_stock.market_access.domain;
 
 import java.time.LocalTime;
 import java.util.List;
+import lombok.Builder;
 
 /**
  * 호가 데이터 모델
  */
+@Builder
 public record OrderBook(
         String stockCode, // 종목 코드
         LocalTime marketTime, // 호가 수신 시간
@@ -13,7 +15,7 @@ public record OrderBook(
         Long totalBidSize, // 총 매수 호가 잔량
         List<Level> levels // 1~10 호가
 ) {
-
+    @Builder
     public record Level(
             int level, // 1~10
             Float askPrice, // 매도 호가

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/domain/event/OrderBookReceivedEvent.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/domain/event/OrderBookReceivedEvent.java
@@ -1,0 +1,12 @@
+package com.assetmind.server_stock.market_access.domain.event;
+
+import com.assetmind.server_stock.market_access.domain.OrderBook;
+
+/**
+ * 실시간 호가 데이터 파싱 완료되었음을 애플리케이션 내부에 알리는 이벤트
+ */
+public record OrderBookReceivedEvent(
+        OrderBook orderBook
+) {
+}
+

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/dto/KisSubscriptionRequest.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/dto/KisSubscriptionRequest.java
@@ -48,10 +48,10 @@ public record KisSubscriptionRequest(
     ) {}
 
     // 사용 편의를 위한 팩토리 메서드
-    public static KisSubscriptionRequest of(String approvalKey, String stockCode) {
+    public static KisSubscriptionRequest of(String approvalKey, String stockCode, String trId) {
         return new KisSubscriptionRequest(
                 new Header(approvalKey, "P", "1", "utf-8"),
-                new Body(new Input("H0STCNT0", stockCode))
+                new Body(new Input(trId, stockCode))
         );
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisRealTimeStockDataAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisRealTimeStockDataAdapter.java
@@ -7,6 +7,7 @@ import com.assetmind.server_stock.market_access.domain.MarketTokenProvider;
 import com.assetmind.server_stock.market_access.infrastructure.kis.config.KisProperties;
 import com.assetmind.server_stock.market_access.infrastructure.kis.config.KisProperties.Account;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.mapper.KisEventMapper;
+import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisOrderBookParser;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisRealTimeDataParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
@@ -39,6 +40,7 @@ public class KisRealTimeStockDataAdapter implements RealTimeStockDataPort {
     // KisWebSocketHandler 생성을 위한 의존객체들
     private final ObjectMapper objectMapper;
     private final KisRealTimeDataParser dataParser;
+    private final KisOrderBookParser orderBookParser;
     private final KisEventMapper eventMapper;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -163,7 +165,7 @@ public class KisRealTimeStockDataAdapter implements RealTimeStockDataPort {
         // 핸들러 생성
         KisWebSocketHandler handler = new KisWebSocketHandler(
                 approvalKey.value(), account, chunk,
-                objectMapper, dataParser, eventMapper, eventPublisher, taskScheduler
+                objectMapper, dataParser, orderBookParser, eventMapper, eventPublisher, taskScheduler
         );
 
         // 관리 리스트에 추가 및 물리적 연결 실행

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisRealTimeStockDataAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisRealTimeStockDataAdapter.java
@@ -48,7 +48,8 @@ public class KisRealTimeStockDataAdapter implements RealTimeStockDataPort {
     // 활성화된 핸들러(세션)들을 추적 및 관리
     private final List<KisWebSocketHandler> activeHandlers = new CopyOnWriteArrayList<>();
 
-    private static final int MAX_SUBSCRIBE_PER_SESSION = 40;
+    // 1종목당 체결, 호가를 동시에 구독해야하므로, 계좌 앱키 유량한계 때문에 세션당 최대 할당 종목 수는 20개
+    private static final int MAX_SUBSCRIBE_PER_SESSION = 20;
 
     @Override
     public void prepareConnection() {
@@ -69,7 +70,7 @@ public class KisRealTimeStockDataAdapter implements RealTimeStockDataPort {
 
         List<Account> accounts = kisProperties.getAccounts();
 
-        // KIS 웹소켓 요청 한도에 맞춰 40개씩 분할
+        // KIS 웹소켓 요청 한도에 맞춰 20개씩 분할
         List<List<String>> partitionedStocks = partitionList(stockCodes, MAX_SUBSCRIBE_PER_SESSION);
 
         for (int i = 0; i < partitionedStocks.size(); i++) {

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandler.java
@@ -1,10 +1,12 @@
 package com.assetmind.server_stock.market_access.infrastructure.kis.websocket;
 
 import com.assetmind.server_stock.market_access.application.event.KisWebSocketDisconnectedEvent;
+import com.assetmind.server_stock.market_access.domain.OrderBook;
 import com.assetmind.server_stock.market_access.infrastructure.kis.config.KisProperties.Account;
 import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisRealTimeData;
 import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisSubscriptionRequest;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.mapper.KisEventMapper;
+import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisOrderBookParser;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisRealTimeDataParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,6 +41,7 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
 
     private final ObjectMapper objectMapper;
     private final KisRealTimeDataParser dataParser;
+    private final KisOrderBookParser orderBookParser;
     private final KisEventMapper eventMapper;
     private final ApplicationEventPublisher eventPublisher;
     private final TaskScheduler taskScheduler;
@@ -57,12 +60,13 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
     private ScheduledFuture<?> pingTask;
 
     public KisWebSocketHandler(String approveKey, Account account, List<String> chunk, ObjectMapper objectMapper, KisRealTimeDataParser dataParser,
-            KisEventMapper eventMapper, ApplicationEventPublisher eventPublisher, TaskScheduler taskScheduler) {
+            KisOrderBookParser orderBookParser, KisEventMapper eventMapper, ApplicationEventPublisher eventPublisher, TaskScheduler taskScheduler) {
         this.approveKey = approveKey;
         this.account = account;
         this.chunk = chunk;
         this.objectMapper = objectMapper;
         this.dataParser = dataParser;
+        this.orderBookParser = orderBookParser;
         this.eventMapper = eventMapper;
         this.eventPublisher = eventPublisher;
         this.taskScheduler = taskScheduler;
@@ -176,18 +180,34 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
         log.info(">>> [KIS WS Handler] 제어 메시지: {}", payload);
     }
 
-    // 실시간 주식 데이터 처리
+    // 실시간 체결 데이터 처리
     private void handleRealTimeData(String payload) {
-        List<KisRealTimeData> dataList = dataParser.parse(payload);
+        String[] parts = payload.split("\\|");
+        String trId = parts[1];
 
-        dataList.forEach(data -> {
-            try {
-                log.info("[KIS WS Handler] 실시간 체결 데이터 : {}", data.toString());
-                eventPublisher.publishEvent(eventMapper.toEvent(data));
-            } catch (Exception e) {
-                log.error("[KIS WS Handler] 개별 체결 데이터 처리 및 발행 중 에러 발생. Data: {}", data, e);
-            }
-        });
+        if ("H0STCNT0".equals(trId)) {
+            List<KisRealTimeData> dataList = dataParser.parse(payload);
+
+            dataList.forEach(data -> {
+                try {
+                    log.info("[KIS WS Handler] 실시간 체결 데이터 : {}", data.toString());
+                    eventPublisher.publishEvent(eventMapper.toStockTradeEvent(data));
+                } catch (Exception e) {
+                    log.error("[KIS WS Handler] 개별 체결 데이터 처리 및 발행 중 에러 발생. Data: {}", data, e);
+                }
+            });
+        } else if ("H0STASP0".equals(trId)) {
+            List<OrderBook> dataList = orderBookParser.parse(payload);
+
+            dataList.forEach(data -> {
+                try {
+                    log.info("[KIS WS Handler] 실시간 호가 데이터: {}", data.toString());
+                    eventPublisher.publishEvent(eventMapper.toOrderBookEvent(data));
+                } catch (Exception e) {
+                    log.error("[KIS WS Handler] 호가 데이터 처리 및 발행 중 에러 발생. Data: {}", data, e);
+                }
+            });
+        }
     }
 
     @Override
@@ -214,22 +234,27 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
         if (subscribedStock.contains(stockCode)) return;
 
         try {
-            KisSubscriptionRequest request = KisSubscriptionRequest.of(approveKey, stockCode);
-            String jsonPayload = objectMapper.writeValueAsString(request);
-
             if (currentSession != null && currentSession.isOpen()) {
-                currentSession.sendMessage(new TextMessage(jsonPayload));
+                // 체결 데이터 (H0STCNT0) 구독 요청
+                KisSubscriptionRequest executionRequest = KisSubscriptionRequest.of(approveKey, stockCode, "H0STCNT0");
+                currentSession.sendMessage(new TextMessage(objectMapper.writeValueAsString(executionRequest)));
+
+                Thread.sleep(20);
+
+                KisSubscriptionRequest orderBookRequest = KisSubscriptionRequest.of(approveKey, stockCode, "H0STASP0");
+                currentSession.sendMessage(new TextMessage(objectMapper.writeValueAsString(orderBookRequest)));
 
                 subscribedStock.add(stockCode);
+
+                log.info("[KIS WS] 구독 요청 전송 완료 (체결/호가): {}", stockCode);
             }
-            log.info("[KIS WS] 구독 요청 전송 완료: {}", stockCode);
 
         } catch (JsonProcessingException e) {
             log.error("[KIS WS] JSON 변환 오류. 종목코드: {} (구독 건너뜀)", stockCode, e);
         } catch (IOException e) {
             log.error("[KIS WS] 메시지 전송 실패 (I/O Error). 종목코드: {}", stockCode, e);
         } catch (Exception e) {
-            log.error("[KIS WS] 알 수 없는 오류 발생. 종목코드: {}", stockCode, e);
+            log.error("[KIS WS] 구독 요청 중 알 수 없는 오류 발생. 종목코드: {}", stockCode, e);
         }
     }
 

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/mapper/KisEventMapper.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/mapper/KisEventMapper.java
@@ -1,5 +1,7 @@
 package com.assetmind.server_stock.market_access.infrastructure.kis.websocket.mapper;
 
+import com.assetmind.server_stock.market_access.domain.OrderBook;
+import com.assetmind.server_stock.market_access.domain.event.OrderBookReceivedEvent;
 import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisRealTimeData;
 import com.assetmind.server_stock.stock.application.listener.dto.RealTimeStockTradeEvent;
 import java.time.LocalDateTime;
@@ -8,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class KisEventMapper {
 
-    public RealTimeStockTradeEvent toEvent(KisRealTimeData data) {
+    public RealTimeStockTradeEvent toStockTradeEvent(KisRealTimeData data) {
         return RealTimeStockTradeEvent.builder()
                 .stockCode(data.stockCode())
                 .time(data.executionTime())
@@ -30,4 +32,10 @@ public class KisEventMapper {
                 .eventTimeStamp(LocalDateTime.now())
                 .build();
     }
+
+    public OrderBookReceivedEvent toOrderBookEvent(OrderBook data) {
+        return new OrderBookReceivedEvent(data);
+    }
+
+
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisOrderBookParser.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisOrderBookParser.java
@@ -3,6 +3,7 @@ package com.assetmind.server_stock.market_access.infrastructure.kis.websocket.pa
 import com.assetmind.server_stock.market_access.domain.OrderBook;
 import com.assetmind.server_stock.market_access.domain.OrderBook.Level;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,8 @@ public class KisOrderBookParser {
 
     private static final String FIRST_DELIMITER = "\\|";
     private static final String SECOND_DELIMITER = "\\^";
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmmss");
 
     public List<OrderBook> parse(String payload) {
         List<OrderBook> resultList = new ArrayList<>();
@@ -86,9 +89,10 @@ public class KisOrderBookParser {
 
         return OrderBook.builder()
                 .stockCode(stockCode)
-                .marketTime(LocalTime.parse(timeStr))
+                .marketTime(LocalTime.parse(timeStr, TIME_FORMATTER))
                 .totalAskSize(totalAskSize)
                 .totalBidSize(totalBidSize)
+                .levels(levels)
                 .build();
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisOrderBookParser.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisOrderBookParser.java
@@ -1,0 +1,94 @@
+package com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser;
+
+import com.assetmind.server_stock.market_access.domain.OrderBook;
+import com.assetmind.server_stock.market_access.domain.OrderBook.Level;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * KIS 실시간 호가 데이터 (H0STASP0)의 응답을
+ * OrderBook 순수 도메인 객체로 파싱
+ */
+@Slf4j
+@Component
+public class KisOrderBookParser {
+
+    private static final String FIRST_DELIMITER = "\\|";
+    private static final String SECOND_DELIMITER = "\\^";
+
+    public List<OrderBook> parse(String payload) {
+        List<OrderBook> resultList = new ArrayList<>();
+
+        try {
+            String[] parts = payload.split(FIRST_DELIMITER);
+            if (parts.length < 3) return resultList;
+
+            // 호가 데이터의 개수 파악 및 Raw 데이터 추출
+            int dataCount;
+            String rawData;
+
+            if (parts[2].matches("\\d+")) {
+                dataCount = Integer.parseInt(parts[2]);
+                rawData = parts[3];
+            } else {
+                dataCount = 1;
+                rawData = parts[2];
+            }
+
+            if (rawData == null || rawData.isEmpty()) return resultList;
+
+            String[] details = rawData.split(SECOND_DELIMITER, -1);
+
+            // 데이터 1건당 차지하는 필드 개수 계산
+            // KIS 호가 데이터는 보통 1건당 54~55개의 필드를 가짐
+            int fieldCountPerData = details.length / dataCount;
+
+            for (int i = 0; i < dataCount; i++) {
+                int offset = i * fieldCountPerData;
+                resultList.add(mapToDomain(details, offset));
+            }
+        } catch (Exception e) {
+            log.error("KIS 실시간 호가 데이터 파싱 중 오류 발생. Payload: {}, Error: {}", payload, e.getMessage());
+        }
+
+        return resultList;
+    }
+
+    private OrderBook mapToDomain(String[] details, int offset) {
+        String stockCode = details[offset];          // [0] 종목코드
+        String timeStr = details[offset + 1];        // [1] 영업시간 (HHmmss)
+
+        Long totalAskSize = Long.valueOf(details[offset + 43]); // [43] 총 매도호가 잔량
+        Long totalBidSize = Long.valueOf(details[offset + 44]); // [44] 총 매수호가 잔량
+
+        List<Level> levels = new ArrayList<>(10);
+
+        // 1호가 ~ 10호가 루프 파싱
+        for (int i = 0; i < 10; i++) {
+            int levelNum = i + 1;
+            Float askPrice = Float.valueOf(details[offset + 3 + i]);  // [3~12] 매도호가
+            Float bidPrice = Float.valueOf(details[offset + 13 + i]); // [13~22] 매수호가
+            Float askSize = Float.valueOf(details[offset + 23 + i]);  // [23~32] 매도호가 잔량
+            Float bidSize = Float.valueOf(details[offset + 33 + i]);  // [33~42] 매수호가 잔량
+
+            levels.add(Level.builder()
+                    .level(levelNum)
+                    .askPrice(askPrice)
+                    .askSize(askSize)
+                    .bidPrice(bidPrice)
+                    .bidSize(bidSize)
+                    .build()
+            );
+        }
+
+        return OrderBook.builder()
+                .stockCode(stockCode)
+                .marketTime(LocalTime.parse(timeStr))
+                .totalAskSize(totalAskSize)
+                .totalBidSize(totalBidSize)
+                .build();
+    }
+}

--- a/apps/server-stock/src/main/resources/application.yml
+++ b/apps/server-stock/src/main/resources/application.yml
@@ -75,9 +75,11 @@ management:
 kis:
   token-expiration: 86400
   base-url: "https://openapivts.koreainvestment.com:29443"
-  websocket-url: "ws://ops.koreainvestment.com:31000"
+  websocket-url: "ws://ops.koreainvestment.com:21000"
   accounts:
     - app-key: ${KIS_APP_KEY_1}
       app-secret: ${KIS_APP_SECRET_KEY_1}
     - app-key: ${KIS_APP_KEY_2}
       app-secret: ${KIS_APP_SECRET_KEY_2}
+    - app-key: ${KIS_APP_KEY_3}
+      app-secret: ${KIS_APP_SECRET_KEY_3}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandlerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisWebSocketHandlerTest.java
@@ -1,9 +1,12 @@
 package com.assetmind.server_stock.market_access.infrastructure.kis.websocket;
 
 import com.assetmind.server_stock.market_access.application.event.KisWebSocketDisconnectedEvent;
+import com.assetmind.server_stock.market_access.domain.OrderBook;
+import com.assetmind.server_stock.market_access.domain.event.OrderBookReceivedEvent;
 import com.assetmind.server_stock.market_access.infrastructure.kis.config.KisProperties.Account;
 import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisRealTimeData;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.mapper.KisEventMapper;
+import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisOrderBookParser;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisRealTimeDataParser;
 import com.assetmind.server_stock.stock.application.listener.dto.RealTimeStockTradeEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -54,6 +57,9 @@ class KisWebSocketHandlerTest {
     private KisRealTimeDataParser dataParser;
 
     @Mock
+    private KisOrderBookParser orderBookParser;
+
+    @Mock
     private KisEventMapper eventMapper;
 
     @Mock
@@ -78,6 +84,7 @@ class KisWebSocketHandlerTest {
                 TEST_CHUNK,
                 objectMapper,
                 dataParser,
+                orderBookParser,
                 eventMapper,
                 eventPublisher,
                 taskScheduler
@@ -115,8 +122,9 @@ class KisWebSocketHandlerTest {
             when(session.isOpen()).thenReturn(true);
             runnableCaptor.getAllValues().forEach(Runnable::run);
 
-            // Then 3: 최종적으로 메시지가 2번 전송되었는지 확인하고 대기열 비워짐 확인
-            verify(session, times(2)).sendMessage(any(TextMessage.class));
+            // Then 3: 최종적으로 메시지가 4번 전송되었는지 확인하고 대기열 비워짐 확인
+            // 2종목에 대한 체결가, 호가 메세지를 전송해야하므로 4개
+            verify(session, times(4)).sendMessage(any(TextMessage.class));
             assertThat(pendingList).isEmpty();
         }
 
@@ -131,7 +139,7 @@ class KisWebSocketHandlerTest {
             handler.subscribeNewStock(List.of("035420"));
 
             // Then: 즉시 전송 확인
-            verify(session, times(1)).sendMessage(any(TextMessage.class));
+            verify(session, times(2)).sendMessage(any(TextMessage.class));
         }
     }
 
@@ -154,6 +162,25 @@ class KisWebSocketHandlerTest {
 
             // Then
             verify(dataParser, times(1)).parse(payload);
+        }
+
+        @Test
+        @DisplayName("성공: 실시간 호가 데이터 수신 시 호가 파서를 호출하고 이벤트를 발행해야 한다.")
+        void givenOrderBookPayload_whenHandleMessage_thenInvokeOrderBookParser() throws Exception {
+            // Given
+            String payload = "0|H0STASP0|001|005930^093015^0^81000...";
+            OrderBook mockOrderBook = new OrderBook("005930", java.time.LocalTime.now(), 100L, 200L, java.util.List.of());
+            when(orderBookParser.parse(payload)).thenReturn(java.util.List.of(mockOrderBook));
+
+            OrderBookReceivedEvent mockEvent = new OrderBookReceivedEvent(mockOrderBook);
+            when(eventMapper.toOrderBookEvent(mockOrderBook)).thenReturn(mockEvent);
+
+            // When
+            handler.handleMessage(session, new TextMessage(payload));
+
+            // Then
+            verify(orderBookParser, times(1)).parse(payload);
+            verify(eventPublisher, times(1)).publishEvent(mockEvent);
         }
     }
 
@@ -191,7 +218,7 @@ class KisWebSocketHandlerTest {
             handler.subscribeNewStock(List.of("FAIL_STOCK", "SUCCESS_STOCK"));
 
             // Then
-            verify(session, times(2)).sendMessage(any(TextMessage.class));
+            verify(session, times(3)).sendMessage(any(TextMessage.class));
         }
 
         @Test
@@ -207,8 +234,8 @@ class KisWebSocketHandlerTest {
             when(dataParser.parse(payload)).thenReturn(List.of(failData, successData));
 
             RealTimeStockTradeEvent dummyEvent = RealTimeStockTradeEvent.builder().stockCode("005930").build();
-            when(eventMapper.toEvent(failData)).thenThrow(new RuntimeException("매핑 도중 에러 발생"));
-            when(eventMapper.toEvent(successData)).thenReturn(dummyEvent);
+            when(eventMapper.toStockTradeEvent(failData)).thenThrow(new RuntimeException("매핑 도중 에러 발생"));
+            when(eventMapper.toStockTradeEvent(successData)).thenReturn(dummyEvent);
 
             // When
             assertDoesNotThrow(() -> handler.handleMessage(session, new TextMessage(payload)));
@@ -222,7 +249,7 @@ class KisWebSocketHandlerTest {
         @DisplayName("실패: 수신 메시지 파싱 중 치명적 에러가 발생해도 세션이 죽지 않아야 한다")
         void givenFatalError_whenHandleMessage_thenCatchAndLog(CapturedOutput output) throws Exception {
             // Given
-            String badPayload = "CRITICAL_BAD_PAYLOAD";
+            String badPayload = "0|H0STCNT0|001|DummyData...";
             when(dataParser.parse(badPayload)).thenThrow(new NullPointerException("Parser Crashed!"));
 
             // When

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisOrderBookParserTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/parser/KisOrderBookParserTest.java
@@ -1,0 +1,109 @@
+package com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.assetmind.server_stock.market_access.domain.OrderBook;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith(OutputCaptureExtension.class)
+class KisOrderBookParserTest {
+
+    private final KisOrderBookParser parser = new KisOrderBookParser();
+
+    @Test
+    @DisplayName("성공: KIS 호가 원본 데이터(H0STASP0)를 OrderBook 도메인 객체로 정확히 파싱해야 한다.")
+    void givenOrderBookData_whenParse_thenReturnParsedOrderBook() {
+        // given
+        String stockCode = "005930";
+        String marketTime = "093015";
+
+        // KIS 호가 데이터의 일반적인 필드 길이(약 55개)를 가진 가짜 배열 생성 및 "0"으로 초기화
+        String[] details = new String[55];
+        Arrays.fill(details, "0");
+        details[0] = stockCode; // [0] 종목코드
+        details[1] = marketTime; // [1] 영업시간
+
+        // 1호가 데이터 세팅 (인덱스 규칙: 매도 3, 매수 13, 매도잔량 23, 매수잔량 33)
+        details[3] = "81000";  // 1호가 매도 가격
+        details[13] = "80900"; // 1호가 매수 가격
+        details[23] = "1500";  // 1호가 매도 잔량
+        details[33] = "2000";  // 1호가 매수 잔량
+
+        details[43] = "45000"; // [43] 총 매도 잔량
+        details[44] = "38000"; // [44] 총 매수 잔량
+
+        // "^" 기호로 묶어서 진짜 KIS에서 날아오는 형태의 본문 생성
+        String rawData = String.join("^", details);
+        String payload = "0|H0STASP0|001|" + rawData;
+
+        // when
+        List<OrderBook> result = parser.parse(payload);
+
+        // then
+        assertThat(result).hasSize(1);
+        OrderBook orderBook = result.get(0);
+
+        // 기본 메타데이터 검증
+        assertThat(orderBook.stockCode()).isEqualTo("005930");
+        assertThat(orderBook.marketTime()).isEqualTo(LocalTime.of(9, 30, 15));
+        assertThat(orderBook.totalAskSize()).isEqualTo(45000L);
+        assertThat(orderBook.totalBidSize()).isEqualTo(38000L);
+
+        // 10호가 리스트 생성 여부 검증
+        assertThat(orderBook.levels()).hasSize(10);
+
+        // 1호가 상세 데이터 맵핑 검증
+        OrderBook.Level level1 = orderBook.levels().get(0);
+        assertThat(level1.level()).isEqualTo(1);
+        assertThat(level1.askPrice()).isEqualTo(81000L);
+        assertThat(level1.bidPrice()).isEqualTo(80900L);
+        assertThat(level1.askSize()).isEqualTo(1500L);
+        assertThat(level1.bidSize()).isEqualTo(2000L);
+    }
+
+    @Test
+    @DisplayName("성공: 데이터 건수(dataCount)가 생략된 단건 데이터 형식도 정상적으로 파싱해야 한다.")
+    void givenNoDataCountOrderBook_whenParse_thenHandleOmittedDataCount() {
+        // given (데이터 건수 '001' 자리가 없고 바로 TR_ID 뒤에 본문이 오는 특이 케이스)
+        String[] details = new String[55];
+        Arrays.fill(details, "0");
+        details[0] = "035420";
+        details[1] = "153000";
+        details[43] = "100";
+        details[44] = "200";
+
+        // payload: 0|H0STASP0|035420^153000^...
+        String payload = "0|H0STASP0|" + String.join("^", details);
+
+        // when
+        List<OrderBook> result = parser.parse(payload);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).stockCode()).isEqualTo("035420");
+        assertThat(result.get(0).marketTime()).isEqualTo(LocalTime.of(15, 30, 0));
+    }
+
+    @Test
+    @DisplayName("실패: 포맷이 어긋나거나 타입 변환이 불가능한 경우, 에러를 로깅하고 빈 리스트를 반환해야 한다.")
+    void givenInvalidOrderBook_whenParse_thenShouldCatchExceptionAndLogging(CapturedOutput output) {
+        // given: 시간(HHmmss)이 들어가야 할 자리에 문자열이 섞인 악의적인 데이터
+        String payload = "0|H0STASP0|001|005930^WRONG_TIME^0^81000";
+
+        // when
+        List<OrderBook> result = parser.parse(payload);
+
+        // then: 시스템이 죽지 않고 빈 리스트를 반환
+        assertThat(result).isEmpty();
+
+        // 로그에 에러 메시지가 정상적으로 찍혔는지 확인
+        assertThat(output.getOut()).contains("KIS 실시간 호가 데이터 파싱 중 오류 발생");
+    }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/RealTimeStockEventLightTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/RealTimeStockEventLightTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.*;
 import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisRealTimeData;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.KisWebSocketHandler;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.mapper.KisEventMapper;
+import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisOrderBookParser;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisRealTimeDataParser;
 import com.assetmind.server_stock.stock.application.StockService;
 import com.assetmind.server_stock.stock.application.listener.StockTradeEventListener;
@@ -51,6 +52,9 @@ public class RealTimeStockEventLightTest {
     private KisRealTimeDataParser parser;
 
     @MockitoBean
+    private KisOrderBookParser orderBookParser;
+
+    @MockitoBean
     private StockService stockService;
 
     @BeforeEach
@@ -62,6 +66,7 @@ public class RealTimeStockEventLightTest {
                 List.of(),
                 null, // objectMapper (이 테스트에선 안 쓰임)
                 parser, // Mock 객체
+                orderBookParser, // Mock 객체
                 eventMapper, // 실제 빈
                 eventPublisher, // 실제 빈 (핵심!)
                 null // taskScheduler (이 테스트에선 안 쓰임)
@@ -87,7 +92,7 @@ public class RealTimeStockEventLightTest {
         given(parser.parse(anyString())).willReturn(List.of(mockData));
 
         // when: Kis에서 실시간 주가 데이터 수신 상황 구성
-        webSocketHandler.handleMessage(null, new TextMessage("Payload From KIS"));
+        webSocketHandler.handleMessage(null, new TextMessage("0|H0STCNT0|001|DummyData..."));
 
         // then: 리스너 수신 확인
         ArgumentCaptor<RealTimeStockTradeEvent> captor = ArgumentCaptor.forClass(RealTimeStockTradeEvent.class);

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/StockWebSocketIntegrationTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/StockWebSocketIntegrationTest.java
@@ -2,8 +2,10 @@ package com.assetmind.server_stock.stock.integration;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.assetmind.server_stock.market_access.infrastructure.kis.dto.KisRealTimeData;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.KisWebSocketHandler;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.mapper.KisEventMapper;
+import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisOrderBookParser;
 import com.assetmind.server_stock.market_access.infrastructure.kis.websocket.parser.KisRealTimeDataParser;
 import com.assetmind.server_stock.support.IntegrationTestSupport;
 import com.assetmind.server_stock.support.MockKisDataFeeder;
@@ -55,6 +57,9 @@ class StockWebSocketIntegrationTest extends IntegrationTestSupport {
     private KisRealTimeDataParser dataParser;
 
     @Autowired
+    private KisOrderBookParser orderBookParser;
+
+    @Autowired
     private KisEventMapper eventMapper;
 
     @Autowired
@@ -87,6 +92,7 @@ class StockWebSocketIntegrationTest extends IntegrationTestSupport {
                 List.of("035420", "005930"),
                 objectMapper,
                 dataParser,
+                orderBookParser,
                 eventMapper,
                 eventPublisher,
                 taskScheduler


### PR DESCRIPTION
## 📌 작업 내용
- **KIS 실시간 호가 파이프라인 구축:** KIS 웹소켓에서 1초에 수십 번씩 날아오는 실시간 호가 데이터(H0STASP0)를 수신하고, 순수 도메인 객체(`OrderBook`)로 파싱하여 내부 시스템에 전파하는 파이프라인을 완성했습니다.
- **체결/호가 웹소켓 멀티플렉싱(Multiplexing) 환경 구성:** 기존 체결 데이터용 파이프라인과 신규 호가 데이터 파이프라인을 별도의 커넥션으로 나누지 않고, 단일 웹소켓 세션에서 동시에 처리하도록 인프라 자원을 최적화했습니다.

---

## 🏗 기술적 의사결정 및 설계

### 1. 웹소켓 세션 멀티플렉싱 및 계좌 한계를 고려한 타겟 축소 (KOSPI 80 -> 60)
- **문제:** KIS 웹소켓 연결에 대한 유량 제한은 1세션(AppKey) 당 최대 40건의 TR_ID 구독만 허용합니다. 1개 종목을 온전히 모니터링하려면 체결과 호가, 총 2건의 구독이 필요하므로 1세션이 감당할 수 있는 최대 종목 수는 20(체결20 + 호가20)개입니다. 기존 목표였던 KOSPI 80종목을 감당하기에는 현재 가용 가능한 3개의 계좌(최대 60종목)로는 물리적인 API Key 한도가 존재했습니다.
- **해결:** 모니터링 대상을 KOSPI 80에서 KOSPI 60으로 전략적으로 축소 조정했습니다. 또한, 하나의 세션에서 체결과 호가 데이터를 섞어서 수신(멀티플렉싱)하도록 어댑터를 병합하고, `KisRealTimeStockDataAdapter`에서 계좌당 할당 종목 수를 20개로 고정하여 3개의 계좌로 KOSPI 60종목을 빈틈없이 커버할 수 있도록 설계하였습니다.

### 2. 라우터(Router) 패턴을 통한 파서 단일 책임 원칙(SRP) 준수
- **문제:** KIS의 괴상한 텍스트 포맷(`^` 및 `|` 구분자)을 풀기 위해 핸들러 내부에서 체결과 호가 파싱 로직을 섞어 쓰면, 향후 KIS 명세 변경 시 치명적인 유지보수 지옥이 예상되었습니다.
- **해결:** `KisWebSocketHandler`는 웹소켓 메시지의 `TR_ID`을 확인하여 알맞은 파서(`KisRealTimeDataParser`, `KisOrderBookParser`)로 데이터를 던져주는 라우터 역할만 담당하도록 책임을 명확히 분리했습니다.

### 3. 도메인 이벤트(Domain Event)를 통한 단방향 의존성 구축
- **문제:** 파싱된 데이터를 `stock` 모듈에 넘겨줄 때, 인프라 계층이 애플리케이션 계층(수신자)을 직접 호출하면 모듈 간 독립성이 훼손됩니다.
- **해결:** `market_access.domain`에 `OrderBookReceivedEvent`를 정의하여 발행(Publish)만 수행합니다. `stock` 모듈은 인프라 기술(KIS)을 전혀 모른 채 순수 이벤트만 리스닝하도록 하여 모듈간의 독립성을 지켰습니다.

---

## ✅ 주요 변경점
- **Domain:**
  - `OrderBookReceivedEvent.java`: 호가 데이터 수신을 애플리케이션 내부에 알리는 도메인 이벤트 추가.
- **Infrastructure:**
  - `KisOrderBookParser.java`: 55개 필드의 `^` 구분자 문자열을 1~10호가 리스트(`List<Level>`)를 포함한 `OrderBook` 객체로 파싱 로직 구현 (`HHmmss` 시간 변환 및 동적 오프셋 적용).
  - `KisWebSocketHandler.java`: 체결/호가 쌍끌이 구독(Dual Subscription) 요청 전송 및 수신 데이터 라우팅(`handleRealTimeData`) 구현.
  - `KisRealTimeStockDataAdapter.java`: `MAX_STOCKS_PER_SESSION` 상수를 20으로 변경하여 1세션 40구독 한도 방어.
- **Test:**
  - `KisOrderBookParserTest.java`: 55개 배열 조립을 통한 동적 파싱 검증 및 데이터 누락/형식 오류 시 빈 리스트 반환(Fail-safe) 단위 테스트 작성.
  - `KisWebSocketHandlerTest.java`: 쌍끌이 구독 시 전송 횟수(종목수 x 2) 검증, 전송 IO 에러 발생 시 중단 없이 다음 종목 처리(Skip) 보장 테스트 반영.

---

## 📝 리뷰 포인트
- **쌍끌이 구독 요청 딜레이:** `KisWebSocketHandler`의 `sendSubscriptionRequest`에서 체결 구독 요청 후 호가 구독 요청을 보낼 때, KIS 서버 부하를 막기 위해 `Thread.sleep(20)`으로 미세 딜레이를 주었습니다. 이 방식이 비동기 웹소켓 환경에서 스레드를 점유하는 데 무리가 없을지 리뷰 부탁드립니다 (필요시 TaskScheduler로 분리 고려).

---

## 🔗 연관 이슈
- **Resolves:** #399