### PR TITLE
[Feat] 초기 로딩용 호가 스냅샷 REST API 구축 및 통합 테스트

### DIFF
--- a/apps/server-stock/src/docs/asciidoc/index.adoc
+++ b/apps/server-stock/src/docs/asciidoc/index.adoc
@@ -60,3 +60,37 @@ include::{snippets}/chart-get-candles/query-parameters.adoc[]
 ==== 응답 (Response)
 include::{snippets}/chart-get-candles/http-response.adoc[]
 include::{snippets}/chart-get-candles/response-fields.adoc[]
+
+== 4. 주식 호가 (OrderBook)
+
+=== 4-1. 실시간 호가 스냅샷 단건 조회
+종목 상세 페이지 최초 진입 시, 화면의 빈 공간(스켈레톤 UI 등)을 즉시 채우기 위해 인메모리 캐시에 저장된 최신 1~10호가 스냅샷을 조회합니다.
+(조회 이후 실시간 데이터 업데이트는 STOMP 웹소켓 채널 구독을 이용해주세요.)
+
+==== [정상] 캐시 데이터 존재 시
+===== 요청 (Request)
+include::{snippets}/orderbook/get-snapshot-success/http-request.adoc[]
+include::{snippets}/orderbook/get-snapshot-success/path-parameters.adoc[]
+
+===== 응답 (Response)
+include::{snippets}/orderbook/get-snapshot-success/http-response.adoc[]
+include::{snippets}/orderbook/get-snapshot-success/response-fields.adoc[]
+
+==== [정상] 데이터 미수집 상태 (장 시작 전 등)
+KIS 서버로부터 아직 호가 데이터를 수신하지 못한 초기 상태에는 `data` 필드가 `null`로 반환됩니다.
+===== 요청 (Request)
+include::{snippets}/orderbook/get-snapshot-success-empty/http-request.adoc[]
+include::{snippets}/orderbook/get-snapshot-success-empty/path-parameters.adoc[]
+
+===== 응답 (Response)
+include::{snippets}/orderbook/get-snapshot-success-empty/http-response.adoc[]
+include::{snippets}/orderbook/get-snapshot-success-empty/response-fields.adoc[]
+
+==== [실패] 지원하지 않는 종목 조회 시
+===== 요청 (Request)
+include::{snippets}/orderbook/get-snapshot-fail-invalid-code/http-request.adoc[]
+include::{snippets}/orderbook/get-snapshot-fail-invalid-code/path-parameters.adoc[]
+
+===== 응답 (Response)
+include::{snippets}/orderbook/get-snapshot-fail-invalid-code/http-response.adoc[]
+include::{snippets}/orderbook/get-snapshot-fail-invalid-code/response-fields.adoc[]

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/global/error/ErrorCode.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/global/error/ErrorCode.java
@@ -13,7 +13,11 @@ public enum ErrorCode {
     NOT_FOUND_STOCK(HttpStatus.NOT_FOUND, "S002", "주식 데이터를 찾을 수 없습니다."),
 
     // Chart 에러
-    INVALID_CHART_PARAMETER(HttpStatus.BAD_REQUEST, "S003", "유효하지 않은 입력값 입니다.");
+    INVALID_CHART_PARAMETER(HttpStatus.BAD_REQUEST, "S003", "유효하지 않은 입력값 입니다."),
+
+    // OrderBook 에러
+    INVALID_ORDER_BOOK_PARAMETER(HttpStatus.BAD_REQUEST, "S004", "유효하지 않는 입력값 입니다."),
+    UNSUPPORTED_ORDER_BOOK(HttpStatus.BAD_REQUEST, "S005", "실시간 호가를 지원하지 않는 종목입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/OrderBookService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/OrderBookService.java
@@ -1,0 +1,22 @@
+package com.assetmind.server_stock.stock.application;
+
+import com.assetmind.server_stock.global.error.ErrorCode;
+import com.assetmind.server_stock.market_access.domain.OrderBook;
+import com.assetmind.server_stock.stock.exception.InvalidStockParameterException;
+import com.assetmind.server_stock.stock.infrastructure.throttling.OrderBookCacheRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderBookService {
+
+    private final OrderBookCacheRepository cacheRepository;
+
+    /**
+     * 특정 종목의 최신 호가 스냅샷을 조회
+     */
+    public OrderBook getOrderBookSnapshot(String stockCode) {
+        return cacheRepository.getSnapshot(stockCode);
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/OrderBookService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/OrderBookService.java
@@ -2,7 +2,8 @@ package com.assetmind.server_stock.stock.application;
 
 import com.assetmind.server_stock.global.error.ErrorCode;
 import com.assetmind.server_stock.market_access.domain.OrderBook;
-import com.assetmind.server_stock.stock.exception.InvalidStockParameterException;
+import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
+import com.assetmind.server_stock.stock.exception.InvalidOrderBookParameterException;
 import com.assetmind.server_stock.stock.infrastructure.throttling.OrderBookCacheRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,11 +13,17 @@ import org.springframework.stereotype.Service;
 public class OrderBookService {
 
     private final OrderBookCacheRepository cacheRepository;
+    private final StockMetadataProvider stockMetadataProvider;
 
     /**
      * 특정 종목의 최신 호가 스냅샷을 조회
      */
     public OrderBook getOrderBookSnapshot(String stockCode) {
+
+        if(!stockMetadataProvider.isExist(stockCode)) {
+            throw new InvalidOrderBookParameterException(ErrorCode.UNSUPPORTED_ORDER_BOOK);
+        }
+
         return cacheRepository.getSnapshot(stockCode);
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/OrderBookService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/application/OrderBookService.java
@@ -5,6 +5,8 @@ import com.assetmind.server_stock.market_access.domain.OrderBook;
 import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
 import com.assetmind.server_stock.stock.exception.InvalidOrderBookParameterException;
 import com.assetmind.server_stock.stock.infrastructure.throttling.OrderBookCacheRepository;
+import com.assetmind.server_stock.stock.presentation.dto.OrderBookResponseDto;
+import com.assetmind.server_stock.stock.presentation.dto.OrderBookResponseDto.OrderBookLevelResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,12 +20,14 @@ public class OrderBookService {
     /**
      * 특정 종목의 최신 호가 스냅샷을 조회
      */
-    public OrderBook getOrderBookSnapshot(String stockCode) {
+    public OrderBookResponseDto getOrderBookSnapshot(String stockCode) {
 
         if(!stockMetadataProvider.isExist(stockCode)) {
             throw new InvalidOrderBookParameterException(ErrorCode.UNSUPPORTED_ORDER_BOOK);
         }
 
-        return cacheRepository.getSnapshot(stockCode);
+        OrderBook snapshot = cacheRepository.getSnapshot(stockCode);
+
+        return OrderBookResponseDto.from(snapshot);
     }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/exception/InvalidOrderBookParameterException.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/exception/InvalidOrderBookParameterException.java
@@ -1,0 +1,15 @@
+package com.assetmind.server_stock.stock.exception;
+
+import com.assetmind.server_stock.global.error.BusinessException;
+import com.assetmind.server_stock.global.error.ErrorCode;
+
+public class InvalidOrderBookParameterException extends BusinessException {
+
+    public InvalidOrderBookParameterException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public InvalidOrderBookParameterException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/throttling/CachedOrderBook.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/throttling/CachedOrderBook.java
@@ -2,12 +2,14 @@ package com.assetmind.server_stock.stock.infrastructure.throttling;
 
 import com.assetmind.server_stock.market_access.domain.OrderBook;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.Getter;
 
 /**
  * L1(Lever1, 인메모리 캐시) 캐시 내부에 저장될 객체
  * 멀티스레드 환경에서 안전한 상태 관리를 보장
  */
 public class CachedOrderBook {
+    @Getter
     private OrderBook orderBook;
 
     // 멀티스레드 환경에서 OrderBook 상태의 원자성을 지키기 위해 CAS 사용하는 AtomicBoolean 이용
@@ -46,4 +48,5 @@ public class CachedOrderBook {
 
         return null;
     }
+
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/throttling/OrderBookCacheRepository.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/infrastructure/throttling/OrderBookCacheRepository.java
@@ -47,4 +47,13 @@ public class OrderBookCacheRepository {
         }
         return null;
     }
+
+    /**
+     * 최신 스냅샷 단건 조회
+     * 종목 상세 페이지에 최초 진입시 초기 데이터 렌더링을 위한 메서드
+     */
+    public OrderBook getSnapshot(String stockCode) {
+        CachedOrderBook cached = cacheMap.get(stockCode);
+        return (cached != null) ? cached.getOrderBook() : null;
+    }
 }

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/OrderBookController.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/OrderBookController.java
@@ -1,0 +1,31 @@
+package com.assetmind.server_stock.stock.presentation;
+
+import com.assetmind.server_stock.global.common.ApiResponse;
+import com.assetmind.server_stock.market_access.domain.OrderBook;
+import com.assetmind.server_stock.stock.application.OrderBookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stocks")
+public class OrderBookController {
+    private final OrderBookService orderBookService;
+
+    /**
+     * 종목 상세 페이지 최초 진입 시 사용할 호가 스냅샷 조회 API
+     */
+    @GetMapping("/{stockCode}/orderbook")
+    public ApiResponse<OrderBook> getOrderBookSnapshot(@PathVariable String stockCode) {
+        OrderBook snapshot = orderBookService.getOrderBookSnapshot(stockCode);
+
+        if (snapshot == null) {
+            return ApiResponse.success("해당 종목의 호가 스냅샷이 존재하지 않습니다.");
+        }
+
+        return ApiResponse.success(snapshot);
+    }
+}

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/OrderBookController.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/OrderBookController.java
@@ -3,6 +3,7 @@ package com.assetmind.server_stock.stock.presentation;
 import com.assetmind.server_stock.global.common.ApiResponse;
 import com.assetmind.server_stock.market_access.domain.OrderBook;
 import com.assetmind.server_stock.stock.application.OrderBookService;
+import com.assetmind.server_stock.stock.presentation.dto.OrderBookResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,8 +20,8 @@ public class OrderBookController {
      * 종목 상세 페이지 최초 진입 시 사용할 호가 스냅샷 조회 API
      */
     @GetMapping("/{stockCode}/orderbook")
-    public ApiResponse<OrderBook> getOrderBookSnapshot(@PathVariable String stockCode) {
-        OrderBook snapshot = orderBookService.getOrderBookSnapshot(stockCode);
+    public ApiResponse<OrderBookResponseDto> getOrderBookSnapshot(@PathVariable String stockCode) {
+        OrderBookResponseDto snapshot = orderBookService.getOrderBookSnapshot(stockCode);
 
         if (snapshot == null) {
             return ApiResponse.success("해당 종목의 호가 스냅샷이 존재하지 않습니다.");

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/OrderBookResponseDto.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/stock/presentation/dto/OrderBookResponseDto.java
@@ -1,5 +1,7 @@
 package com.assetmind.server_stock.stock.presentation.dto;
 
+import com.assetmind.server_stock.market_access.domain.OrderBook;
+import com.assetmind.server_stock.market_access.domain.OrderBook.Level;
 import java.util.List;
 import lombok.Builder;
 
@@ -15,6 +17,22 @@ public record OrderBookResponseDto(
         List<OrderBookLevelResponse> levels // 10개의 호가
 ) {
 
+    public static OrderBookResponseDto from(OrderBook orderBook) {
+        if (orderBook == null) {
+            return null; // 방어 로직: 캐시가 비어있을 경우 null 반환
+        }
+
+        return OrderBookResponseDto.builder()
+                .stockCode(orderBook.stockCode())
+                .marketTime(String.valueOf(orderBook.marketTime()))
+                .totalBidSize(String.valueOf(orderBook.totalBidSize()))
+                .totalAskSize(String.valueOf(orderBook.totalAskSize()))
+                .levels(orderBook.levels().stream()
+                        .map(OrderBookLevelResponse::from)
+                        .toList())
+                .build();
+    }
+
     /**
      * 단일 호가 레벨 데이터
      */
@@ -25,5 +43,14 @@ public record OrderBookResponseDto(
             String askSize, // 매도 잔량
             String bidPrice,// 매수 호가
             String bidSize // 매수 잔량
-    ) {}
+    ) {
+        public static OrderBookLevelResponse from(Level domainLevel) {
+            return OrderBookLevelResponse.builder()
+                    .askPrice(String.valueOf(domainLevel.askPrice()))
+                    .askSize(String.valueOf(domainLevel.askSize()))
+                    .bidPrice(String.valueOf(domainLevel.bidPrice()))
+                    .bidSize(String.valueOf(domainLevel.bidSize()))
+                    .build();
+        }
+    }
 }

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/OrderBookServiceTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/OrderBookServiceTest.java
@@ -1,0 +1,99 @@
+package com.assetmind.server_stock.stock.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.assetmind.server_stock.global.error.ErrorCode;
+import com.assetmind.server_stock.market_access.domain.OrderBook;
+import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
+import com.assetmind.server_stock.stock.exception.InvalidOrderBookParameterException;
+import com.assetmind.server_stock.stock.infrastructure.throttling.OrderBookCacheRepository;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderBookServiceTest {
+
+    @InjectMocks
+    private OrderBookService orderBookService;
+
+    @Mock
+    private OrderBookCacheRepository cacheRepository;
+
+    @Mock
+    private StockMetadataProvider stockMetadataProvider;
+
+    @Test
+    @DisplayName("지원하는 종목 코드로 조회 시, 캐시에 데이터가 있으면 호가 스냅샷을 반환한다.")
+    void givenSupportedStockCode_whenGetSnapshot_thenReturnOrderBook() {
+        // given
+        String validStockCode = "005930";
+        OrderBook dummyOrderBook = OrderBook.builder()
+                .stockCode(validStockCode)
+                .marketTime(LocalTime.now())
+                .totalBidSize(100L)
+                .totalAskSize(200L)
+                .levels(List.of())
+                .build();
+
+        given(stockMetadataProvider.isExist(validStockCode)).willReturn(true);
+        given(cacheRepository.getSnapshot(validStockCode)).willReturn(dummyOrderBook);
+
+        // when
+        OrderBook result = orderBookService.getOrderBookSnapshot(validStockCode);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.stockCode()).isEqualTo(validStockCode);
+
+        // 의존성 호출 검증
+        verify(stockMetadataProvider).isExist(validStockCode);
+        verify(cacheRepository).getSnapshot(validStockCode);
+    }
+
+    @Test
+    @DisplayName("지원하는 종목 코드이지만 캐시가 비어있을 경우, null을 반환한다.")
+    void givenSupportedStockCode_whenCacheIsEmpty_thenReturnNull() {
+        // given
+        String validStockCode = "005930";
+
+        given(stockMetadataProvider.isExist(validStockCode)).willReturn(true);
+        given(cacheRepository.getSnapshot(validStockCode)).willReturn(null);
+
+        // when
+        OrderBook result = orderBookService.getOrderBookSnapshot(validStockCode);
+
+        // then
+        assertThat(result).isNull();
+        verify(stockMetadataProvider).isExist(validStockCode);
+        verify(cacheRepository).getSnapshot(validStockCode);
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 종목 코드로 조회 시, InvalidOrderBookParameterException 예외가 발생한다.")
+    void givenUnsupportedStockCode_whenGetSnapshot_thenThrowException() {
+        // given
+        String invalidStockCode = "999999";
+
+        // 메타데이터 프로바이더가 false를 반환하도록 설정
+        given(stockMetadataProvider.isExist(invalidStockCode)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> orderBookService.getOrderBookSnapshot(invalidStockCode))
+                .isInstanceOf(InvalidOrderBookParameterException.class)
+                // 예외 내부에 정의된 ErrorCode가 맞는지 검증
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_ORDER_BOOK);
+
+        // 검증: 예외가 터졌으므로 캐시 저장소는 절대 호출되지 않아야 함
+        verify(cacheRepository, never()).getSnapshot(invalidStockCode);
+    }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/OrderBookServiceTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/application/OrderBookServiceTest.java
@@ -11,6 +11,7 @@ import com.assetmind.server_stock.market_access.domain.OrderBook;
 import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
 import com.assetmind.server_stock.stock.exception.InvalidOrderBookParameterException;
 import com.assetmind.server_stock.stock.infrastructure.throttling.OrderBookCacheRepository;
+import com.assetmind.server_stock.stock.presentation.dto.OrderBookResponseDto;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -49,7 +50,7 @@ class OrderBookServiceTest {
         given(cacheRepository.getSnapshot(validStockCode)).willReturn(dummyOrderBook);
 
         // when
-        OrderBook result = orderBookService.getOrderBookSnapshot(validStockCode);
+        OrderBookResponseDto result = orderBookService.getOrderBookSnapshot(validStockCode);
 
         // then
         assertThat(result).isNotNull();
@@ -70,7 +71,7 @@ class OrderBookServiceTest {
         given(cacheRepository.getSnapshot(validStockCode)).willReturn(null);
 
         // when
-        OrderBook result = orderBookService.getOrderBookSnapshot(validStockCode);
+        OrderBookResponseDto result = orderBookService.getOrderBookSnapshot(validStockCode);
 
         // then
         assertThat(result).isNull();

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/OrderBookPipelineIntegrationTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/integration/OrderBookPipelineIntegrationTest.java
@@ -1,0 +1,86 @@
+package com.assetmind.server_stock.stock.integration;
+
+import com.assetmind.server_stock.stock.application.provider.StockMetadataProvider;
+import com.assetmind.server_stock.support.IntegrationTestSupport;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.assetmind.server_stock.market_access.domain.OrderBook;
+import com.assetmind.server_stock.market_access.domain.event.OrderBookReceivedEvent;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class OrderBookPipelineIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    // KIS 어댑터를 대신하여 이벤트를 허공에 쏴줄 퍼블리셔
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @MockitoBean
+    private StockMetadataProvider stockMetadataProvider;
+
+    @Test
+    @DisplayName("KIS 호가 수신 -> 이벤트 리스너 -> 캐시 저장 -> REST API 즉시 조회 성공")
+    void givenKisFileEvent_whenGetOrderBook_thenServeLatestSnapshot() throws Exception {
+        // given
+        String stockCode = "005930"; // 삼성전자
+        OrderBook incomingOrderBook = OrderBook.builder()
+                .stockCode(stockCode)
+                .marketTime(LocalTime.of(9, 1, 30))
+                .totalBidSize(10000L)
+                .totalAskSize(20000L)
+                .levels(List.of()) // 실제로는 호가 리스트가 들어가야 함
+                .build();
+
+        BDDMockito.given(stockMetadataProvider.isExist(stockCode)).willReturn(true);
+
+        // ==========================================
+        // 수집: KIS에서 데이터가 들어왔다고 가정하고 이벤트를 강제 발행!
+        // ==========================================
+        eventPublisher.publishEvent(new OrderBookReceivedEvent(incomingOrderBook));
+
+        // (내부 동작: 리스너가 동기로 캐치 -> ConcurrentHashMap 에 save)
+
+        // ==========================================
+        // 서빙: 프론트엔드가 진입해서 API 단건 조회
+        // ==========================================
+        mockMvc.perform(get("/api/stocks/{stockCode}/orderbook", stockCode)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                // 검증: 발행했던 데이터가 그대로 나오는지 확인
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.stockCode").value(stockCode))
+                .andExpect(jsonPath("$.data.totalBidSize").value(10000L))
+                .andExpect(jsonPath("$.data.totalAskSize").value(20000L));
+    }
+
+    @Test
+    @DisplayName("KIS 호가가 한 번도 수신되지 않은 장 시작 전 상태에서의 API 조회")
+    void givenNoEventPublished_whenGetOrderBook_thenReturnEmptyData() throws Exception {
+        // given
+        String newStockCode = "000660";
+
+        BDDMockito.given(stockMetadataProvider.isExist(newStockCode)).willReturn(true);
+
+        // when & then
+        mockMvc.perform(get("/api/stocks/{stockCode}/orderbook", newStockCode)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("해당 종목의 호가 스냅샷이 존재하지 않습니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/OrderBookControllerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/OrderBookControllerTest.java
@@ -1,0 +1,90 @@
+package com.assetmind.server_stock.stock.presentation;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.assetmind.server_stock.global.error.ErrorCode;
+import com.assetmind.server_stock.market_access.domain.OrderBook;
+import com.assetmind.server_stock.stock.application.OrderBookService;
+import com.assetmind.server_stock.stock.exception.InvalidStockParameterException;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OrderBookController.class)
+@AutoConfigureRestDocs
+public class OrderBookControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OrderBookService orderBookService;
+
+    @Test
+    @DisplayName("종목 코드로 해당 종목의 호가 조회 시, 데이터가 존재하면 데이터를 담아 응답한다.")
+    void givenValidStockCode_whenGetOrderBookSnapshot_thenSuccess200AndData() throws Exception {
+        // given
+        String stockCode = "005930";
+        OrderBook dummyOrderBook = OrderBook.builder()
+                .stockCode(stockCode)
+                .marketTime(LocalTime.of(15, 30, 0))
+                .totalBidSize(1500L)
+                .totalAskSize(2000L)
+                .levels(List.of())
+                .build();
+
+        given(orderBookService.getOrderBookSnapshot(stockCode)).willReturn(dummyOrderBook);
+
+        // when & then
+        mockMvc.perform(get("/api/stocks/{stockCode}/orderbook", stockCode))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.stockCode").value(stockCode))
+                .andExpect(jsonPath("$.data.totalBidSize").value(1500L));
+
+    }
+
+    @Test
+    @DisplayName("종목 코드로 해당 종목의 호가 조회 시, 데이터가 존재하지 않으면 빈 데이터를 응답한다.")
+    void givenValidStockCode_whenGetOrderBookSnapshotIfNonData_thenSuccess200AndNull()
+            throws Exception {
+        // given
+        String stockCode = "005930";
+        given(orderBookService.getOrderBookSnapshot(stockCode)).willReturn(null);
+
+        // when & then
+        mockMvc.perform(get("/api/stocks/{stockCode}/orderbook", stockCode)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("해당 종목의 호가 스냅샷이 존재하지 않습니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 종목 코드로 해당 종목의 호가 조회 시, 400 에러를 응답한다.")
+    void givenInvalidStockCOde_whenGetOrderBookSnapshot_thenBadRequest400() throws Exception {
+        // given
+        String invalidStockCode = "123";
+        // 서비스 계층에서 예외를 던지도록 스터빙
+        given(orderBookService.getOrderBookSnapshot(invalidStockCode))
+                .willThrow(new InvalidStockParameterException("유효하지 않은 종목 코드입니다.", ErrorCode.INVALID_STOCK_PARAMETER));
+
+        // when & then
+        mockMvc.perform(get("/api/stocks/{stockCode}/orderbook", invalidStockCode)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_STOCK_PARAMETER.getMessage()));
+    }
+}

--- a/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/OrderBookControllerTest.java
+++ b/apps/server-stock/src/test/java/com/assetmind/server_stock/stock/presentation/OrderBookControllerTest.java
@@ -1,7 +1,11 @@
 package com.assetmind.server_stock.stock.presentation;
 
 import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -9,6 +13,7 @@ import com.assetmind.server_stock.global.error.ErrorCode;
 import com.assetmind.server_stock.market_access.domain.OrderBook;
 import com.assetmind.server_stock.stock.application.OrderBookService;
 import com.assetmind.server_stock.stock.exception.InvalidStockParameterException;
+import com.assetmind.server_stock.stock.presentation.dto.OrderBookResponseDto;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -35,11 +41,11 @@ public class OrderBookControllerTest {
     void givenValidStockCode_whenGetOrderBookSnapshot_thenSuccess200AndData() throws Exception {
         // given
         String stockCode = "005930";
-        OrderBook dummyOrderBook = OrderBook.builder()
+        OrderBookResponseDto dummyOrderBook = OrderBookResponseDto.builder()
                 .stockCode(stockCode)
-                .marketTime(LocalTime.of(15, 30, 0))
-                .totalBidSize(1500L)
-                .totalAskSize(2000L)
+                .marketTime(String.valueOf(LocalTime.of(15, 30, 0)))
+                .totalBidSize("1500")
+                .totalAskSize("2000")
                 .levels(List.of())
                 .build();
 
@@ -50,7 +56,34 @@ public class OrderBookControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.stockCode").value(stockCode))
-                .andExpect(jsonPath("$.data.totalBidSize").value(1500L));
+                .andExpect(jsonPath("$.data.totalBidSize").value("1500"))
+
+                // 문서화 로직 추가
+                .andDo(document("orderbook/get-snapshot-success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("stockCode").description("조회할 주식 종목 코드 (6자리 숫자)")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("API 호출 성공 여부").optional(),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지 (성공 시 null)").optional(),
+
+                                fieldWithPath("data").type(JsonFieldType.OBJECT).description("호가 스냅샷 데이터"),
+                                fieldWithPath("data.stockCode").type(JsonFieldType.STRING).description("종목 코드"),
+                                fieldWithPath("data.marketTime").type(JsonFieldType.STRING).description("호가 수신 시간 (HHmmss 등)"),
+
+                                fieldWithPath("data.totalAskSize").type(JsonFieldType.STRING).description("총 매도 호가 잔량"),
+                                fieldWithPath("data.totalBidSize").type(JsonFieldType.STRING).description("총 매수 호가 잔량"),
+
+                                fieldWithPath("data.levels[]").type(JsonFieldType.ARRAY).description("1~10단계 호가 리스트").optional(),
+                                fieldWithPath("data.levels[].level").type(JsonFieldType.NUMBER).description("호가 단계 (1~10)").optional(),
+                                fieldWithPath("data.levels[].askPrice").type(JsonFieldType.STRING).description("매도 호가").optional(),
+                                fieldWithPath("data.levels[].askSize").type(JsonFieldType.STRING).description("매도 잔량").optional(),
+                                fieldWithPath("data.levels[].bidPrice").type(JsonFieldType.STRING).description("매수 호가").optional(),
+                                fieldWithPath("data.levels[].bidSize").type(JsonFieldType.STRING).description("매수 잔량").optional()
+                        )
+                ));
 
     }
 
@@ -68,7 +101,20 @@ public class OrderBookControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("해당 종목의 호가 스냅샷이 존재하지 않습니다."))
-                .andExpect(jsonPath("$.data").isEmpty());
+                .andExpect(jsonPath("$.data").isEmpty())
+
+                .andDo(document("orderbook/get-snapshot-success-empty",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("stockCode").description("조회할 주식 종목 코드 (6자리 숫자)")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("API 호출 성공 여부").optional(),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지 (데이터 없음 알림)"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("데이터 (캐시가 비어있을 경우 null)")
+                        )
+                ));
     }
 
     @Test
@@ -85,6 +131,20 @@ public class OrderBookControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_STOCK_PARAMETER.getMessage()));
+                .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_STOCK_PARAMETER.getMessage()))
+
+                // 문서화 로직 추가
+                .andDo(document("orderbook/get-snapshot-fail-invalid-code",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("stockCode").description("조회할 주식 종목 코드 (잘못된 요청)")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("API 호출 실패 (false)").optional(),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("에러 상세 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("데이터 (null)").optional()
+                        )
+                ));
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
- **최초 진입용 실시간 호가 스냅샷 API 구축:** 종목 상세 페이지 진입 시 화면의 빈 공간을 채우기 위해, 인메모리 캐시에서 가장 최신 호가를 즉시 서빙하는 단건 조회 REST API를 구현했습니다. (이후 실시간 업데이트는 웹소켓으로 이관)
- **수집 ➔ 가공 ➔ 서빙 파이프라인 E2E 검증:** 외부 인프라(KIS) 의존성 없이 동작 모킹하듯이 `ApplicationEventPublisher`를 활용해 파이프라인 전체가 정상 동작하는지 검증하는 통합 테스트를 완성했습니다.
- **REST Docs 기반 API 명세서 통합:** 성공/실패/데이터없음 3가지 상황에 대한 스니펫을 추출하여 기존 `index.adoc`에 완벽하게 통합했습니다.

---

## 🏗 기술적 의사결정 및 테스트 설계 (Core Design)

### 1. L1 캐시 순수 스냅샷 조회
- **문제:** 스케줄러가 STOMP로 쏘기 위해 사용하는 기존 `getIfDirtyAndClean()` 메서드를 API 조회 시 재사용할 경우, `isDirty` 플래그가 풀려버려 정작 스케줄러가 변경분을 인지하지 못하고 브로드캐스팅을 누락하는 치명적인 버그 발생 위험이 존재했습니다.
- **해결:** 캐시의 상태(Flag)를 전혀 건드리지 않고 순수하게 내부 데이터만 읽어오는 `getSnapshot()` 메서드를 인프라 계층에 별도로 분리하여 스레드 세이프(Thread-safe)한 순수 조회를 구현했습니다.

### 2. 프론트엔드 위한 DTO 문자열 매핑 및 팩토리 패턴
- **문제:** 대용량 호가 잔량이나 가격 데이터가 Number 타입으로 내려갈 경우 자바스크립트의 정밀도 한계로 데이터가 유실될 우려가 있으며, 도메인 객체가 컨트롤러 밖으로 노출되면 계층 간 결합도가 상승합니다.
- **해결:** API 응답용 `OrderBookResponseDto`를 생성하고 내부의 모든 숫자 필드를 `String`으로 변환하도록 설계했습니다. 특히, 이 변환 로직(`from()`)을 서비스 계층이 아닌 DTO 내부의 정적 팩토리 메서드로 위임하여 서비스 로직의 가독성과 단일 책임 원칙(SRP)을 지켰습니다.

### 3. 모의 이벤트(Mock Event)를 활용한 파이프라인 통합 테스트 설계
- **문제:** KIS 웹소켓 수신부터 REST API 조회까지의 전체 파이프라인을 테스트하려면 외부 인프라에 심하게 의존해야 하는 문제가 있었습니다.
- **해결:** `ApplicationEventPublisher`를 주입받아, 테스트 환경에서 강제로 KIS 수신 이벤트(`OrderBookReceivedEvent`)를 발행하는 방식으로 인프라 단절을 극복했습니다. 이를 통해 이벤트 리스너 ➔ 캐시 저장 ➔ 컨트롤러 조회로 이어지는 E2E 흐름을 100% 독립적이고 결정론적인 환경에서 검증해냈습니다.

---

## ✅ 주요 변경점
- **Presentation:**
  - `OrderBookController.java`: 스냅샷 조회 엔드포인트(`GET /api/stocks/{stockCode}/orderbook`) 추가
  - `OrderBookResponseDto.java`: 프론트엔드 규격에 맞춘 String 타입 응답 DTO 및 팩토리 메서드 구현
- **Application:**
  - `OrderBookService.java`: 지원 종목 검증(`StockMetadataProvider`) 및 데이터 없을 시 방어 로직(`null` 반환) 추가
- **Infrastructure:**
  - `OrderBookCacheRepository.java` & `CachedOrderBook.java`: 상태 변경 없는 순수 읽기 전용 `getSnapshot()` 구현
- **Test:**
  - `OrderBookControllerTest.java`: MockMvc + REST Docs 스니펫 추출 단위 테스트 (성공/빈 데이터/400에러)
  - `OrderBookServiceTest.java`: 비즈니스 로직 및 예외 발생 검증 단위 테스트
  - `OrderBookPipelineIntegrationTest.java`: `IntegrationTestSupport` 기반 파이프라인 통합 테스트
- **Docs:**
  - `index.adoc`: 주식 호가(OrderBook) 섹션 4번 항목 추가 및 문서화 완료

---

## 📝 리뷰 포인트
- **데이터 없을 때의 응답 규격:** 서버 재시작 직후나 장 시작 전(09:00 정각 이전)에는 KIS 웹소켓 데이터가 없어 인메모리 캐시가 비어있을 수 있습니다. 이때 API는 `200 OK`와 함께 `data: null`을 반환하도록 설계했습니다. 