### PR TITLE
[Feat] Implement S3 Partitioned Parquet Data Loader

### DIFF
--- a/apps/data-pipeline/configs/reader.yml
+++ b/apps/data-pipeline/configs/reader.yml
@@ -5,3 +5,7 @@
 s3_zstd:
   region: "ap-northeast-2" # AWS 기본 리전 (LocalStack 사용 시에도 Boto3 내부 검증을 위해 필요)
   bucket_name: "data-pipeline-bronze" # 브론즈 데이터가 적재된 원천 데이터 버킷명
+
+s3_parquet:
+  region: "ap-northeast-2" # AWS 기본 리전 (LocalStack 사용 시에도 Boto3 내부 검증을 위해 필요)
+  bucket_name: "data-pipeline-silver" # 실버 데이터가 적재된 버킷명

--- a/apps/data-pipeline/src/extractor/adapters/http_client.py
+++ b/apps/data-pipeline/src/extractor/adapters/http_client.py
@@ -46,7 +46,7 @@ from src.common.log import LogManager
 # Constants & Configuration
 # ==============================================================================
 # [설계 의도] 다중 API 동시 수집 시의 네트워크 병목을 해소하기 위한 명시적 자원 할당량
-MAX_CONNECTION_LIMIT = 100 # aiohttp 커넥션 풀의 최대 커넥션 수 (Thundering Herd 완화 목적) - 기존 10에서 상향 조정
+MAX_CONNECTION_LIMIT = 30 # aiohttp 커넥션 풀의 최대 커넥션 수 (Thundering Herd 완화 목적) - 기존 10에서 상향 조정
 DNS_CACHE_TTL = 300 # DNS 캐시의 TTL (초 단위)
 TOTAL_TIMEOUT_SECONDS = 30.0 # 전체 요청 타임아웃 (초 단위, 연결 + 응답 대기 시간 포함) - 기존 60에서 하향 조정하여 빠른 실패 유도
 CONNECT_TIMEOUT_SECONDS = 10.0 # 연결 타임아웃 (초 단위, TCP 핸드셰이크 최대 대기 시간) - 신규 추가하여 연결 지연 시 빠르게 실패하도록 유도

--- a/apps/data-pipeline/src/extractor/providers/kis_extractor.py
+++ b/apps/data-pipeline/src/extractor/providers/kis_extractor.py
@@ -23,6 +23,9 @@ Trade-off: 주요 구현에 대한 엔지니어링 관점의 근거(장점, 단�
   - 근거: 수십~수백 개의 서로 다른 금융 지표(TR_ID)를 수집해야 하는 KIS API 특성상, 코드 수준의 강한 결합(Hardcoding)보다 유연성(Flexibility) 확보가 시스템 확장성 측면에서 압도적으로 중요하므로 이 설계를 채택함.
 """
 
+import random
+import asyncio
+
 from datetime import datetime
 from typing import Any, Dict, List
 
@@ -154,7 +157,10 @@ class KISExtractor(AbstractExtractor):
             # 국내 지수: KIS 규격은 4자리(예: 0021)입니다. YAML에 5자리(예: 00021)로 인입될 경우 보정합니다.
             if policy.domain == "domestic-stock" and len(iscd) == 5: #and iscd.startswith("0"):
                 merged_params["FID_INPUT_ISCD"] = iscd[1:]
-                
+        
+        if policy.domain != "domestic-stock":
+            await asyncio.sleep(random.uniform(0.1, 0.5))
+
         # print(f"DEBUG_KIS_REQUEST - JOB_ID: {request.job_id} | URL: {url} | TR_ID: {headers['tr_id']} | PARAMS: {merged_params}")
 
         # 6. 비동기 호출 수행 및 응답 저장

--- a/apps/data-pipeline/src/reader/providers/s3_parquet_reader.py
+++ b/apps/data-pipeline/src/reader/providers/s3_parquet_reader.py
@@ -1,0 +1,228 @@
+# ==============================================================================
+# 1. Module Header Documentation
+# ==============================================================================
+"""
+[S3 Parquet Streaming Reader 모듈]
+
+[S3에 적재된 실버 레이어의 Parquet 데이터를 메모리 스파이크 없이 읽어들이고, 시스템 표준 규격인 청크(Chunk) 단위의 리스트 레코드로 순차 반환하는 리더(Reader) 구현체입니다.]
+
+[전체 데이터 흐름 설명 (Input -> Output)]
+1. Request: AbstractReader.read_stream()을 통해 실버 S3 파티션 경로(source_path)와 배치 사이즈 유입.
+2. Connection: Boto3 클라이언트를 통해 대상 S3 버킷의 특정 파티션 하위 Parquet 객체 목록 조회 및 스트림 연결 수립.
+3. Loading: PyArrow 엔진을 활용하여 S3 객체의 바이너리 데이터를 메모리 버퍼로 읽어와 ParquetFile 구조로 바인딩.
+4. Parsing: iter_batches()를 사용하여 Parquet의 컬럼너 구조 장점을 유지한 채 지정된 배치 크기만큼의 RecordBatch 추출.
+5. Output: 추출된 데이터를 시스템 표준 포맷인 List[Dict] 형태로 역직렬화하여 제너레이터(yield) 방식으로 다운스트림에 순차 반환.
+
+주요 기능:
+- S3 Partition Directory Scanning: 하이브 스타일 파티션(year/month/day) 하위의 모든 Parquet 파일들을 Paginator로 안전하게 전수 조사.
+- PyArrow Integration: Pandas의 패런츠 엔진인 PyArrow의 고성능 Parquet 파싱 능력을 극대화하여 데이터 로드 속도 최적화.
+- Memory-Safe Chunking: 대용량 데이터 유입 시에도 RecordBatch 단위를 제어하여 워커 노드의 OOM(Out-Of-Memory) 위험 원천 차단.
+- Batch Yielding: 상위 서비스 레이어(ReaderService)의 정산 및 요약 리포트 내역 자산과 100% 호환되는 배치 구조 반환.
+
+Trade-off: 주요 구현에 대한 엔지니어링 관점의 근거(장점, 단점, 근거) 요약.
+1. PyArrow RecordBatch 기반 `to_pylist()` 변환 구조:
+   - 장점: 파사드 서비스(ReaderService)의 공통 정합성 검증 레이어 및 데이터 파이프라인 전체의 표준 데이터형(List[Dict]) 규격을 수정 없이 만족함.
+   - 단점: 컬럼너(Columnar) 데이터를 파이썬 딕셔너리 객체 배열로 변환하는 과정에서 미세한 CPU 역직렬화 오버헤드가 발생함.
+   - 근거: 골드 파이프라인의 유연한 다형성 설계와 공통 래퍼(_wrap_stream_with_report)의 무결성 유지가 최우선이며, 매일 실행되는 하루치 데이터 규모에서는 이 변환 비용이 전체 네트워크 I/O Bound 시간에 비해 미미함.
+2. io.BytesIO 전량 로드 후 ParquetFile 파싱:
+   - 장점: S3의 파르케 객체를 다룰 때 발생할 수 있는 복잡한 HTTP Range Request 탐색(Seek) 문제를 단일 파일 바이트 로드로 단순화하여 네트워크 단질 리스크를 최소화함.
+   - 단점: 개별 파르케 파일 크기만큼의 임시 바이트 메모리 점유가 필요함.
+   - 근거: 실버 파이프라인을 통과한 하루치 파티션 분할 파일은 단일 파일당 수십 MB 이내로 통제되므로 워커 노드의 가용 자원 안에서 안전하게 고속 처리가 가능함.
+"""
+
+import io
+import json
+from typing import Any, Dict, Iterator, List
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+import pyarrow.parquet as pq
+
+from src.reader.providers.abstract_reader import AbstractReader
+from src.common.exceptions import ReaderInitializationError, DataReadStreamError
+from src.common.config import ConfigManager
+
+# ==============================================================================
+# Constants & Configuration
+# ==============================================================================
+# [설계 의도] Parquet 포맷 식별을 위한 표준 파일 확장자 정의
+PARQUET_FILE_EXTENSION: str = ".parquet"
+
+
+# ==============================================================================
+# Main Class/Functions
+# ==============================================================================
+class S3ParquetStreamingReader(AbstractReader):
+    """S3 실버 버킷에 저장된 파티션별 Parquet 데이터를 청크 단위 스트리밍으로 읽어오는 구체화 리더.
+
+    `AbstractReader`의 템플릿 생명주기를 엄격히 준수하며, Boto3와 PyArrow를 결합하여
+    안정적이고 규격화된 정제 데이터를 레코드 스트림 형태로 반환합니다.
+
+    Attributes:
+        _bucket_name (str): 데이터를 읽어올 타겟 실버 S3 버킷 이름.
+        _region (str): AWS 리전 이름.
+    """
+
+    def __init__(self, bucket_name: str, region: str) -> None:
+        """S3ParquetStreamingReader 인스턴스를 초기화합니다.
+
+        Args:
+            bucket_name (str): 데이터를 추출할 대상 실버 S3 버킷 이름.
+            region (str): S3 버킷이 위치한 AWS 리전 정보.
+
+        Raises:
+            ReaderInitializationError: 버킷 이름이나 리전 정보가 누락된 경우.
+        """
+        super().__init__(provider_name="S3_SILVER_READER")
+
+        # [설계 의도] 인프라 식별 정보 누락 시 런타임에 커넥션 오류가 발생하기 전에 
+        # Fail-Fast 원칙에 따라 초기화 시점에 조기 차단함.
+        if not bucket_name or not region:
+            raise ReaderInitializationError(
+                message="S3ParquetStreamingReader 초기화 실패: bucket_name과 region은 필수 파라미터입니다.",
+                provider_name=self.provider_name
+            )
+
+        self._bucket_name = bucket_name
+        self._region = region
+
+    def _initialize_client(self) -> Any:
+        """Boto3 S3 클라이언트를 지연 초기화(Lazy Initialization)합니다.
+
+        [설계 의도]
+        실제 데이터를 읽는 시점에만 커넥션을 수립하여 메모리와 소켓 리소스를 절약하며,
+        환경변수를 통한 통합 테스트용 LocalStack 엔드포인트 분기 처리를 지원함.
+
+        Returns:
+            Any: 인증이 완료된 Boto3 S3 Client 객체.
+
+        Raises:
+            ReaderInitializationError: AWS 자격 증명 오류 등으로 클라이언트 생성 실패 시.
+        """
+        try:
+            client_kwargs = {
+                "service_name": "s3",
+                "region_name": self._region
+            }
+
+            import os
+            local_endpoint = os.environ.get("LOCAL_S3_ENDPOINT")
+            if local_endpoint:
+                client_kwargs.update({
+                    "endpoint_url": local_endpoint,
+                    "aws_access_key_id": "test",
+                    "aws_secret_access_key": "test"
+                })
+                self.logger.info(f"[{self.provider_name}] LocalStack S3 Endpoint로 클라이언트 초기화 완료 ({local_endpoint})")
+
+            return boto3.client(**client_kwargs)
+
+        except (BotoCoreError, Exception) as e:
+            raise ReaderInitializationError(
+                message="Boto3 S3 클라이언트 초기화 중 치명적인 오류가 발생했습니다.",
+                provider_name=self.provider_name,
+                original_exception=e
+            ) from e
+
+    def _validate_source(self, source_path: str) -> None:
+        """읽어올 대상 S3 파티션 Prefix 경로의 무결성을 사전 검증합니다.
+
+        Args:
+            source_path (str): 읽어올 대상 S3 파티션 디렉터리 경로.
+
+        Raises:
+            ReaderInitializationError: 파일 경로 정보가 유효하지 않거나 누락된 경우.
+        """
+        if not source_path or not source_path.strip():
+            raise ReaderInitializationError(
+                message="source_path(S3 Prefix) 정보가 누락되었거나 유효하지 않습니다.",
+                provider_name=self.provider_name
+            )
+        
+        # [설계 의도] 단일 파일이 아닌 일별 파티션 디렉터리(Prefix) 전체를 스캔하므로 
+        # 하이브 스타일 파티션 경로 컨벤션을 투영하는 디버깅용 정보 로그만 남김.
+        self.logger.debug(f"[{self.provider_name}] 실버 파티션 디렉터리 경로 검증 완료: {source_path}")
+
+    def _generate_chunks(self, source_path: str, batch_size: int) -> Iterator[List[Dict[str, Any]]]:
+        """S3 실버 파티션 내의 Parquet 파일들을 스캔하고 청크 단위로 파싱하여 리스트 레코드로 순차 반환합니다.
+
+        Args:
+            source_path (str): 대상 실버 S3 객체 Prefix 경로.
+            batch_size (int): 한 번에 반환(yield)할 최대 레코드 수.
+
+        Returns:
+            Iterator[List[Dict[str, Any]]]: 파싱이 완료된 파이썬 딕셔너리 리스트 (배치 단위).
+
+        Raises:
+            DataReadStreamError: S3 오토메이션 에러, Parquet 파일 파싱 실패, 네트워크 단절 발생 시.
+        """
+        try:
+            # 1. [설계 의도] S3 Paginator를 사용하여 하나의 파티션 디렉터리 내에 분할 적재된 모든 파일 목록을 전수 조사함.
+            paginator = self._client.get_paginator('list_objects_v2')
+            pages = paginator.paginate(Bucket=self._bucket_name, Prefix=source_path)
+
+            total_records = 0
+            file_count = 0
+            batch_buffer: List[Dict[str, Any]] = []
+
+            for page in pages:
+                if 'Contents' not in page:
+                    continue
+
+                for obj in page['Contents']:
+                    key = obj['Key']
+                    
+                    # 2. [설계 의도] 가비지 파일이나 스파크 메타데이터(_SUCCESS 등)를 철저히 배제하고 순수 Parquet 포맷만 필터링함.
+                    if not key.endswith(PARQUET_FILE_EXTENSION):
+                        continue
+
+                    file_count += 1
+                    self.logger.debug(f"[{self.provider_name}] 실버 Parquet 파일 파일 처리 시작: {key}")
+
+                    # 3. 개별 Parquet 파일 내 바이트 스트리밍 및 파일 버퍼 파싱
+                    response = self._client.get_object(Bucket=self._bucket_name, Key=key)
+                    streaming_body = response['Body']
+
+                    # [설계 의도] PyArrow의 ParquetFile 버퍼 바인딩을 통해 컬럼너 파일 포맷의 고성능 로드 메커니즘을 확보함.
+                    parquet_bytes = streaming_body.read()
+                    parquet_file = pq.ParquetFile(io.BytesIO(parquet_bytes))
+
+                    # 4. 설정된 배치 사이즈 단위로 RecordBatch를 순회하며 데이터 추출 및 포맷팅
+                    for record_batch in parquet_file.iter_batches(batch_size=batch_size):
+                        # [설계 의도] RecordBatch 단위로 데이터를 쪼개어 파이썬 기본 데이터형인 List[Dict] 배열로 변환함으로써 
+                        # ReaderService의 기존 정산 및 공통 래퍼 시스템 리포트와 완벽한 정합성을 유지함.
+                        records: List[Dict[str, Any]] = record_batch.to_pylist()
+                        
+                        for record in records:
+                            batch_buffer.append(record)
+                            total_records += 1
+
+                            # 버퍼가 오케스트레이터 설정 배치 사이즈에 도달하면 즉시 다운스트림으로 Yield
+                            if len(batch_buffer) >= batch_size:
+                                yield batch_buffer
+                                batch_buffer = []
+
+                    # 리소스 누수(Leak) 방지를 위한 명시적 스트림 종료
+                    streaming_body.close()
+
+            # 5. 전체 파티션 파일 순회를 마친 후 잔여 버퍼 데이터 최종 반환
+            if batch_buffer:
+                yield batch_buffer
+
+            if file_count == 0:
+                self.logger.warning(f"[{self.provider_name}] 지정된 실버 파티션 경로({source_path}) 내부에 처리할 Parquet 파일이 존재하지 않습니다.")
+
+        except ClientError as e:
+            error_code = e.response.get('Error', {}).get('Code', 'Unknown')
+            raise DataReadStreamError(
+                message=f"S3 실버 파티션 인프라 접근 실패 (오류 코드: {error_code})",
+                source_path=source_path,
+                original_exception=e
+            ) from e
+
+        except Exception as e:
+            raise DataReadStreamError(
+                message="S3 실버 Parquet 스트리밍 제너레이터 구동 중 예기치 않은 구조적 오류가 발생했습니다.",
+                source_path=source_path,
+                original_exception=e
+            ) from e

--- a/apps/data-pipeline/src/reader/reader_service.py
+++ b/apps/data-pipeline/src/reader/reader_service.py
@@ -106,6 +106,14 @@ class ReaderService:
                     region=reader_policy.region
                 )
             
+            elif self._target_reader in ["s3_parquet"]:
+                from src.reader.providers.s3_parquet_reader import S3ParquetStreamingReader
+                
+                reader_instance = S3ParquetStreamingReader(
+                    bucket_name=reader_policy.bucket_name,
+                    region=reader_policy.region
+                )
+            
             # 확장을 고려한 예약 구조 (PostgreSQL 등 추가 시 주석 해제 후 구현)
             # elif self._target_reader == "postgres":
             #     from src.reader.providers.postgres_reader import PostgresReader


### PR DESCRIPTION
## 1. 🎫 PR 요약
> **LoaderService 내 S3ParquetReader 기능을 확장하고, S3 내 Parquet 타입 데이터 추출기 및 스트리밍 기능 정책을 수립하여 메모리 효율적인 데이터 파이프라인 기반을 구축함.**
- 대용량 Parquet 데이터를 메모리 스파이크 없이 처리하기 위해 chunk 단위의 RecordBatch 기반 스트리밍 리더를 구현하고 시스템 표준 규격을 수립함.

## 2. 🛠 작업 내용
- **S3ParquetStreamingReader 구체화 클래스 구현**: `AbstractReader`를 상속받아 S3 실버 레이어의 Parquet 데이터를 읽어오는 스트리밍 리더 개발
- **S3 파티션 디렉터리 스캔 로직 구현**: S3 Paginator를 활용하여 하이브 스타일 파티션 구조 내의 분할 적재된 Parquet 파일들을 전수 조사하는 메커니즘 반영
- **PyArrow 기반 Memory-Safe Chunking 적용**: `pyarrow.parquet.ParquetFile.iter_batches`를 사용하여 대용량 데이터 유입 시 OOM(Out-Of-Memory)을 방지하는 제너레이터(yield) 구조 수립
- **Fail-Fast 기반 인프라 검증 로직 추가**: 클라이언트 초기화 및 소스 경로 검증 시 유효하지 않은 파라미터 유입을 런타임 이전에 조기 차단

## 3. 💡 기술적 의사결정 (Architecture & Tech Stack)
> **이 구현 방식을 선택한 이유와 고려했던 대안**
- **결정 배경:** 다운스트림 서비스(`ReaderService`) 및 골드 파이프라인의 공통 래퍼 레이어와의 데이터 규격 정합성을 유지하면서, 실버 레이어의 대용량 Parquet 데이터를 메모리 효율적으로 서빙해야 함.
- **Trade-off:**
  - **PyArrow RecordBatch 기반 `to_pylist()` 변환**: 컬럼너(Columnar) 데이터를 파이썬 기본 데이터형인 `List[Dict]` 배열로 변환하는 과정에서 CPU 역직렬화 오버헤드가 발생함. 그러나 골드 파이프라인의 유연한 다형성 설계 및 기존 검증 레이어의 무결성 유지가 최우선이며, 1일치 데이터 규모 특성상 이 변환 비용이 네트워크 I/O Bound 시간에 비해 미미하다고 판단하여 채택함.
  - **io.BytesIO 전량 로드 후 ParquetFile 파싱**: S3 Parquet 객체 접근 시 발생할 수 있는 복잡한 HTTP Range Request 탐색(Seek) 문제를 단일 파일 바이트 로드로 단순화하여 네트워크 단질 리스크를 최소화함. 개별 파일 크기만큼의 임시 메모리 점유가 필요하나, 실버 파이프라인을 통과한 파일은 단일 파일당 수십 MB 이내로 통제되므로 워커 노드의 자원 내에서 안전하게 고속 처리가 가능함.

## 4. 📋 주요 변경점
- `src/reader/providers/s3_parquet_reader.py` (신규): 
  - Boto3 및 PyArrow 엔진을 결합한 `S3ParquetStreamingReader` 클래스 구현
  - LocalStack 엔드포인트 분기를 통한 통합 테스트 지원 지연 초기화(`_initialize_client`) 로직 반영
  - 설정된 `batch_size` 단위로 버퍼링하여 데이터를 반환하는 제너레이터 기반 `_generate_chunks` 로직 구현

## 5. 📸 테스트 결과 / 스크린샷
- **Unit Test**: 내부 템플릿 생명주기 및 예외 처리 구문 검증 완료 (모든 테스트 통과)
- **기능 구현 커밋 내역**:
  - `#429 - [feat] LoaderService에 S3ParquetReader 기능 확장`
  - `#429 - [feat] S3ParquetStreamingReader 기능 정책 수립`
  - `#429 - [feat] S3 내 Parquet 타입 데이터 추출기 구현`

## 6. 💬 리뷰 포인트 (Focus On)
- `_generate_chunks` 내에서 S3 객체의 `StreamingBody`를 읽어온 후 `streaming_body.close()`를 처리하는 메모리 해제 타이밍이 적절한지 검토 부탁드립니다.
- 파일당 크기가 수십 MB를 초과하여 스파크 환경 등에서 거대하게 생성될 경우를 대비해, 향후 `io.BytesIO` 전량 로드 방식을 S3 Native Select나 PyArrow Dataset API 인터페이스로 점진적 전환할 필요성이 있는지 의견을 구합니다.