### PR TITLE
 [Feat] 호가창 REST 스냅샷 연동

### DIFF
--- a/apps/web/src/api/stock.ts
+++ b/apps/web/src/api/stock.ts
@@ -53,7 +53,7 @@ export async function getStockCandles(
 	return data.data.candles;
 }
 
-// ─── 시계열 (history) ─────────────────────────────────────────
+// ─── 시계열 ─────────────────────────────────────────
 
 export interface StockHistoryDto {
 	stockCode:        string;
@@ -77,7 +77,7 @@ export async function getStockHistory(stockCode: string, limit = 20) {
 	return data.data;
 }
 
-// ─── 호가 (Orderbook) ─────────────────────────────────────────
+// ─── 호가 ─────────────────────────────────────────
 
 export interface OrderbookLevelDto {
 	level:    number;
@@ -93,6 +93,24 @@ export interface OrderbookDto {
 	totalAskSize: string;
 	totalBidSize: string;
 	levels:       OrderbookLevelDto[];
+}
+
+/** 초기 진입 시 REST 스냅샷 조회
+ *  - 정상: OrderbookDto 반환
+ *  - 데이터 미수집(장 시작 전 등): null 반환
+ *  - 잘못된 종목코드 등 오류: null 반환
+ */
+export async function getOrderbook(stockCode: string): Promise<OrderbookDto | null> {
+	try {
+		const { data } = await axiosInstance.get<{
+			success: boolean;
+			message: string | null;
+			data: OrderbookDto | null;
+		}>(`/stocks/${stockCode}/orderbook`);
+		return data.data ?? null;
+	} catch {
+		return null;
+	}
 }
 
 export const getOrderbookTopic = (stockCode: string) =>

--- a/apps/web/src/hooks/stock-detail/use-orderbook.ts
+++ b/apps/web/src/hooks/stock-detail/use-orderbook.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
-import { getOrderbookTopic } from '../../api/stock';
+import { getOrderbook, getOrderbookTopic } from '../../api/stock';
 import type { OrderbookDto, OrderbookLevelDto } from '../../api/stock';
 import type { OrderbookRow } from '../../components/stock-detail/orderbook-table';
 
@@ -23,27 +23,50 @@ export interface OrderbookViewModel {
 
 export type OrderbookStatus = 'skeleton' | 'error' | 'default';
 
+function toViewModel(raw: OrderbookDto, basePrice: number): OrderbookViewModel {
+	const ref = basePrice ?? 0;
+	const sorted = [...raw.levels].sort((a, b) => a.level - b.level);
+	return {
+		asks: sorted.map((l: OrderbookLevelDto) => levelToRow(l.askPrice, l.askSize, ref)),
+		bids: sorted.map((l: OrderbookLevelDto) => levelToRow(l.bidPrice, l.bidSize, ref)),
+		totalAskSize: Number(raw.totalAskSize),
+		totalBidSize: Number(raw.totalBidSize),
+		marketTime:   raw.marketTime,
+	};
+}
+
 export function useOrderbook(stockCode: string, basePrice?: number) {
 	const [raw, setRaw] = useState<OrderbookDto | null>(null);
 	const [status, setStatus] = useState<OrderbookStatus>('skeleton');
 	const clientRef = useRef<Client | null>(null);
+	const wsReceivedRef = useRef(false);
 
-	console.log('[useOrderbook] render - stockCode:', stockCode, 'basePrice:', basePrice);
-
+	// ── REST 스냅샷 선호출 ────────────────────────────────────
 	useEffect(() => {
 		if (!stockCode) return;
+		wsReceivedRef.current = false;
 
-		console.log('[useOrderbook] connecting to SockJS...');
+		getOrderbook(stockCode).then((snapshot) => {
+			if (wsReceivedRef.current) return;
+			if (snapshot) {
+				setRaw(snapshot);
+				setStatus('default');
+			}
+		});
+	}, [stockCode]);
+
+	// ── SockJS WS 연결 ────────────────────────────────────────
+	useEffect(() => {
+		if (!stockCode) return;
 
 		const client = new Client({
 			webSocketFactory: () => new SockJS('http://localhost:9090/ws-stock'),
 			reconnectDelay: 5000,
 			onConnect: () => {
-				console.log('[useOrderbook] STOMP connected!');
 				client.subscribe(getOrderbookTopic(stockCode), (message) => {
 					try {
 						const dto = JSON.parse(message.body) as OrderbookDto;
-						console.log('[useOrderbook] received:', dto);
+						wsReceivedRef.current = true;
 						setRaw(dto);
 						setStatus('default');
 					} catch {
@@ -51,15 +74,11 @@ export function useOrderbook(stockCode: string, basePrice?: number) {
 					}
 				});
 			},
-			onStompError: (frame) => {
-				console.error('[useOrderbook] STOMP error:', frame);
-				setStatus('error');
+			onStompError: () => {
+				setStatus((prev) => prev === 'default' ? 'default' : 'error');
 			},
 			onDisconnect: () => {
-				console.log('[useOrderbook] disconnected');
-				setStatus('skeleton');
 			},
-			onWebSocketError: (e) => console.error('[useOrderbook] WS error:', e),
 		});
 
 		client.activate();
@@ -71,25 +90,8 @@ export function useOrderbook(stockCode: string, basePrice?: number) {
 		};
 	}, [stockCode]);
 
-	const viewModel: OrderbookViewModel | null = raw
-		? (() => {
-				const ref = basePrice ?? 0;
-				const sorted = [...raw.levels].sort((a, b) => a.level - b.level);
-				const asks: OrderbookRow[] = sorted.map((l: OrderbookLevelDto) =>
-					levelToRow(l.askPrice, l.askSize, ref),
-				);
-				const bids: OrderbookRow[] = sorted.map((l: OrderbookLevelDto) =>
-					levelToRow(l.bidPrice, l.bidSize, ref),
-				);
-				return {
-					asks,
-					bids,
-					totalAskSize: Number(raw.totalAskSize),
-					totalBidSize: Number(raw.totalBidSize),
-					marketTime:   raw.marketTime,
-				};
-			})()
-		: null;
+	const viewModel: OrderbookViewModel | null =
+		raw ? toViewModel(raw, basePrice ?? 0) : null;
 
 	return { viewModel, status };
 }


### PR DESCRIPTION
# [Feat] 호가창 REST 스냅샷 연동

## 📌 1. PR 요약
초기 화면 진입 시 웹소켓(WS) 연결 지연으로 인한 호가창 데이터 깜빡임 문제를 해결하기 위해 **REST 스냅샷 API 선호출 로직**을 도입했습니다. 스냅샷 데이터와 실시간 웹소켓 데이터 간의 역전 방지 로직을 구현하였으며, 데이터 미수집 상태(`data: null`)에 대한 스켈레톤 UI 예외 처리를 추가하여 초기 렌더링 안정성을 대폭 강화했습니다.

## 🛠 2. 작업 내용
### REST 스냅샷 선호출 및 데이터 역전 방지
- **초기 진입 지연 최소화**: 웹소켓이 연결되기 전 `getOrderbook()` REST API를 선호출하여 화면 진입과 동시에 호가 데이터가 즉시 그려지도록 개선했습니다.
- **wsReceivedRef 도입**: 네트워크 지연으로 인해 REST 응답이 웹소켓 데이터보다 늦게 도착하는 경우, 이미 수신된 실시간 데이터를 덮어쓰지 않도록 `wsReceivedRef` 플래그를 활용한 역전 방지 로직을 구현했습니다.

### 엣지 케이스(`data: null`) 예외 처리 및 상태 유지
- **안정적인 스켈레톤 유지**: 장 시작 전 등 백엔드 수집 데이터가 없어 `data: null`이 반환되는 상황에서 화면이 무너지거나 에러 Boundary로 튕기지 않고 스켈레톤 UI가 안정적으로 유지되도록 분기 처리를 추가했습니다.
- **지속성 확보**: 웹소켓 연결이 일시적으로 끊기거나 재연결되는 상황에서도 REST API로 불러온 기존 스냅샷 데이터가 휘발되지 않고 화면에 유지되도록 보완했습니다.

## 📸 3. 스크린샷
| REST Snapshot Initial Render | Data: null Skeleton State |
| :---: | :---: |
| <img width="363" height="750" alt="image" src="https://github.com/user-attachments/assets/5f2ae302-45e2-4d81-94ce-51ee747a1f23" /> | <img width="356" height="703" alt="image" src="https://github.com/user-attachments/assets/76dc79cb-57b4-4653-a7b3-b8027331ad93" /> |

## 📋 4. 파일 변경 목록

| 파일 경로 | 변경 내용 |
| :--- | :--- |
| `apps/web/src/api/stock.ts` | 호가창 REST 스냅샷 조회를 위한 `getOrderbook()` fetcher 함수 추가 및 응답 타입 정의 (교체) |
| `apps/web/src/hooks/stock-detail/use-orderbook.ts` | 초기 REST 선호출 로직, `wsReceivedRef` 기반 데이터 역전 방지 및 `data: null` 처리 반영 (교체) |

## 💬 5. 리뷰 포인트
- **데이터 역전 방지 검증**: `use-orderbook.ts`에서 웹소켓 수신 이후 도착한 REST 응답을 `wsReceivedRef.current` 조건문으로 정확히 차단 및 무시하고 있는지 코드 검토 부탁드립니다.
- **스켈레톤 분기 및 렌더링**: 스크린샷과 같이 초기 데이터가 비어있거나 `null`인 엣지 케이스에서 UI 깨짐 없이 스켈레톤 상태가 매끄럽게 유지되는지 확인해 주세요.
- **데이터 유지 유효성**: 웹소켓 이벤트 연결 해제 및 재연결 트리거 시, 기존에 캐싱된 REST 데이터가 상태 변수에서 초기화되지 않고 화면에 계속 남아있는지 로직 확인이 필요합니다.