### PR TITLE
[Infra] 외부 메시지 브로커 및 다중 서버 로드밸런서 환경 구축

### DIFF
--- a/apps/docker-compose.yml
+++ b/apps/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - app-stock-server-2
     restart: always
 
-  # Stock 서버 1
+  # Stock 서버 1 (수집, 서빙)
   app-stock-server-1:
     build: ./server-stock
     container_name: assetmind-stock-server-1
@@ -25,9 +25,10 @@ services:
     environment:
       - SERVER_PORT=9090
       - SPRING_PROFILES_ACTIVE=local
+      - KIS_WEBSOCKET_ENABLED=true
     restart: always
 
-  # Stock 서버 2
+  # Stock 서버 2 (서빙)
   app-stock-server-2:
     build: ./server-stock
     container_name: assetmind-stock-server-2
@@ -36,6 +37,7 @@ services:
     environment:
       - SERVER_PORT=9090
       - SPRING_PROFILES_ACTIVE=local
+      - KIS_WEBSOCKET_ENABLED=false
     restart: always
     
   # PostgreSQL 컨테이너

--- a/apps/docker-compose.yml
+++ b/apps/docker-compose.yml
@@ -12,18 +12,42 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
       - prometheus
+      - app-stock-server-1
+      - app-stock-server-2
+    restart: always
+
+  # Stock 서버 1
+  app-stock-server-1:
+    build: ./server-stock
+    container_name: assetmind-stock-server-1
+    env_file:
+      - ./server-stock/.env
+    environment:
+      - SERVER_PORT=9090
+      - SPRING_PROFILES_ACTIVE=local
+    restart: always
+
+  # Stock 서버 2
+  app-stock-server-2:
+    build: ./server-stock
+    container_name: assetmind-stock-server-2
+    env_file:
+      - ./server-stock/.env
+    environment:
+      - SERVER_PORT=9090
+      - SPRING_PROFILES_ACTIVE=local
     restart: always
     
   # PostgreSQL 컨테이너
   postgres:
     image: postgres:16-alpine
     container_name: assetmind-postgres
+    env_file:
+      - ./server-stock/.env
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      - POSTGRES_DB=assetmind
     volumes:
       - ./db/postgres_data:/var/lib/postgresql/data
     restart: always

--- a/apps/docker-compose.yml
+++ b/apps/docker-compose.yml
@@ -2,6 +2,18 @@
 version: '3.8'
 
 services:
+  # Nginx 컨테이너
+  nginx:
+    image: nginx:latest
+    container_name: assetmind-nginx
+    ports:
+      - "80:80" # 외부 k6 테스트 진입점
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - prometheus
+    restart: always
+    
   # PostgreSQL 컨테이너
   postgres:
     image: postgres:16-alpine

--- a/apps/docker-compose.yml
+++ b/apps/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     image: prom/prometheus:latest
     container_name: assetmind-prometheus
     ports:
-      - "9092:9090"
+      - "9093:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     command:

--- a/apps/nginx.conf
+++ b/apps/nginx.conf
@@ -1,0 +1,29 @@
+events { worker_connections 1024; }
+
+http {
+    upstream stock_servers {
+        server host.docker.internal:9091;
+        server host.docker.internal:9092;
+    }
+
+    server {
+        listen 80; # 외부에서 접근할 로드밸런서 포트
+
+        # REST API 요청 분산
+        location /api/ {
+            proxy_pass http://stock_servers;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        # 웹소켓 프로토콜 전환 및 연결 분산
+        location /ws-stock/ {
+            proxy_pass http://stock_servers;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+        }
+    }
+}

--- a/apps/nginx.conf
+++ b/apps/nginx.conf
@@ -2,8 +2,8 @@ events { worker_connections 1024; }
 
 http {
     upstream stock_servers {
-        server host.docker.internal:9091;
-        server host.docker.internal:9092;
+        server app-stock-server-1:9090;
+        server app-stock-server-2:9090;
     }
 
     server {

--- a/apps/prometheus.yml
+++ b/apps/prometheus.yml
@@ -1,5 +1,6 @@
 global:
-  scrape_interval: 10m
+  scrape_interval: 5s
+  evaluation_interval: 5s
 
 scrape_configs:
   # Auth 서버 수집 설정

--- a/apps/server-auth/build.gradle
+++ b/apps/server-auth/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:postgresql'
 
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+
 	testImplementation 'org.springframework.security:spring-security-test'
 
 	runtimeOnly 'com.h2database:h2'

--- a/apps/server-auth/src/test/java/com/assetmind/server_auth/support/IntegrationTestSupport.java
+++ b/apps/server-auth/src/test/java/com/assetmind/server_auth/support/IntegrationTestSupport.java
@@ -2,6 +2,7 @@ package com.assetmind.server_auth.support;
 
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -9,52 +10,22 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-/**
- * TestContainer를 통해서 도커 컨테이너를 띄우고 스프링에 포트를 알려주는 추상 클래스
- */
 @SpringBootTest // 통합 테스트
 @ActiveProfiles("test") // application-test.yml
-@Testcontainers // 컨테이너 관리 활성화
 @AutoConfigureMockMvc
 public abstract class IntegrationTestSupport {
 
-    /**
-     * PostgreSQL 컨테이너 정의
-     */
-    static final PostgreSQLContainer<?> POSTGRES_CONTAINER = new PostgreSQLContainer<>("postgres:16-alpine")
-            .withDatabaseName("testdb")
-            .withUsername("test")
-            .withPassword("test");
+    @ServiceConnection(name = "postgres")
+    static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>("postgres:16-alpine");
 
-    /**
-     * Redis 컨테이너 정의
-     * TestContainer 라이브러리에 Redis 컨테이너가 없다.
-     * 하지만, Redis 컨테이너를 위한 라이브러리를 따로 추가하지 않고
-     * GenericContainer에 이미지를 명시하여서 Redis 이미지를 컨테이너로 띄움
-     */
     static final int REDIS_PORT = 6379;
+
+    @ServiceConnection(name = "redis")
     static final GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>("redis:alpine")
             .withExposedPorts(REDIS_PORT);
 
     static {
-        POSTGRES_CONTAINER.start();
+        POSTGRE_SQL_CONTAINER.start();
         REDIS_CONTAINER.start();
-    }
-
-    /**
-     * TestContainer가 스프링에게 랜덤으로 할당한 컨테이너 포트를
-     * application-test.yml 값에 매핑
-     * @param registry
-     */
-    @DynamicPropertySource
-    static void overrideProps(DynamicPropertyRegistry registry) {
-        // PostgreSQL 설정
-        registry.add("spring.datasource.url", POSTGRES_CONTAINER::getJdbcUrl);
-        registry.add("spring.datasource.username", POSTGRES_CONTAINER::getUsername);
-        registry.add("spring.datasource.password", POSTGRES_CONTAINER::getPassword);
-
-        // Redis 설정
-        registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
-        registry.add("spring.data.redis.port", () -> REDIS_CONTAINER.getMappedPort(REDIS_PORT));
     }
 }

--- a/apps/server-stock/Dockerfile
+++ b/apps/server-stock/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:21-jre-alpine
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/application/MarketAccessService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/application/MarketAccessService.java
@@ -7,6 +7,7 @@ import com.assetmind.server_stock.market_access.domain.exception.MarketAccessFai
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "kis.websocket.enabled", havingValue = "true")
 public class MarketAccessService {
     private final MarketTokenProvider marketTokenProvider;
 

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/application/RealTimeMarketService.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/application/RealTimeMarketService.java
@@ -7,6 +7,7 @@ import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "kis.websocket.enabled", havingValue = "true")
 public class RealTimeMarketService {
 
     private final RealTimeStockDataPort realTimeStockDataPort; // 연결 담당

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisRealTimeStockDataAdapter.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/kis/websocket/KisRealTimeStockDataAdapter.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.TaskScheduler;
@@ -31,6 +32,7 @@ import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "kis.websocket.enabled", havingValue = "true")
 public class KisRealTimeStockDataAdapter implements RealTimeStockDataPort {
 
     private final KisProperties kisProperties;

--- a/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/scheduler/DailyMarketLifecycleScheduler.java
+++ b/apps/server-stock/src/main/java/com/assetmind/server_stock/market_access/infrastructure/scheduler/DailyMarketLifecycleScheduler.java
@@ -5,6 +5,7 @@ import com.assetmind.server_stock.stock.application.provider.StockMetadataProvid
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 @Component
+@ConditionalOnProperty(name = "kis.websocket.enabled", havingValue = "true")
 public class DailyMarketLifecycleScheduler {
     private final RealTimeStockDataPort realTimeStockDataPort;
 
@@ -34,10 +36,10 @@ public class DailyMarketLifecycleScheduler {
 
             Thread.sleep(1000);
 
-            // KOSPI 80 개의 종목 조회
+            // KOSPI 60 개의 종목 조회
             List<String> targetStocks = stockMetadataProvider.getAllStockCodes();
 
-            // 종목 구독 요청(Adapter 내부에서 40개씩 청킹하여 구독)
+            // 종목 구독 요청(Adapter 내부에서 30개씩 청킹하여 구독)
             realTimeStockDataPort.subscribe(targetStocks);
         } catch (Exception e) {
             log.error("[DailyMarketLifecycleScheduler] 체결 데이터 수집 파이프라인 연결 중 에러 발생", e);

--- a/apps/tests/load/load-test-chart.js
+++ b/apps/tests/load/load-test-chart.js
@@ -16,7 +16,7 @@ export const options = {
   },
 };
 
-const STOCK_SERVER_BASE_URL = 'http://127.0.0.1:9090'; // Stock 서버 주소
+const STOCK_SERVER_BASE_URL = 'http://localhost'; // Stock 서버 주소
 
 const TARGET_STOCKS = ['005930', '000660', '035420', '035720', '005380', '000270'];
 


### PR DESCRIPTION
## 📌 작업 내용
- **Nginx 기반의 리버스 프록시 및 로드밸런서 인프라 구축:** 포트 80을 단일 진입점(Single Entry Point)으로 설정하고, Upstream 설정을 통해 외부 트래픽을 다중 스프링 부트 컨테이너 서버들로 균등하게 분산(Round-Robin)하는 라우팅 환경 세팅.
- **마스터 스위치를 활용한 수집/서빙 레이어 격리(Isolation):** 스케일아웃(Scale-out) 시 발생하는 외부 증권사(KIS) API의 중복 로그인 차단 및 REST 토큰 발급 유량 제한(Rate Limit) 문제를 해결하기 위해, 환경 변수 기반 조건부 빈 생성 메커니즘을 구성하여 서버별 역할 분리 수행.
- **단일 진입점 기반 부하 테스트 및 실시간 분산 검증:** 기존 k6 부하 테스트 스크립트의 타깃 포트를 Nginx 프록시 레이어로 전면 수정하고, 복수 노드의 실시간 로그 통합 스트림을 모니터링하여 병목 없는 지그재그(교차) 트래픽 인젝션 거동을 최종 검증.

---

## 🏗️ 기술적 의사결정 및 아키텍처 설계

### 1. 마스터 스위치(`@ConditionalOnProperty`)를 통한 중복 연결 원천 차단
> **문제 정의:** 동일한 코드를 가진 서버를 단순히 2대로 늘릴 경우, 두 서버가 동시에 KIS 웹소켓 및 REST API 토큰 발급을 요청하게 되어 **[앱키당 일일 토큰 발급 유량 제한 초과]** 및 **[웹소켓 중복 로그인 동시 끊김 폭탄]** 장애가 발생함.
- **해결 방안:** 수집 관련 인프라/애플리케이션 레이어 대장 클래스인 `RealTimeMarketService`, `KisRealTimeStockDataAdapter`, `MarketAccessService` 상단에 `@ConditionalOnProperty(name = "kis.websocket.enabled")` 마스터 스위치를 적용.
- **결과:** 1호기는 수집+서빙 역할을 동시에 수행하고, 2호기는 외부 KIS API 통신 및 스케줄러를 완벽히 잠재운 채 **'순수 레디스 구독 및 STOMP 서빙 전용 레플리카'**로 동작하도록 물리적 역할을 격리함.

### 2. 도커 내부 네트워크를 활용한 포트 충돌 방지 및 Nginx 라우팅
> **문제 정의:** 로컬 호스트 PC 환경에서 두 대의 스프링 부트 서버를 띄우기 위해 9090, 9091 포트로 각각 포트 포워딩을 수행할 경우, 코드 내 환경 설정 분리 복잡도가 증가하고 외부 k6 스크립트 유지보수가 까다로워짐.
- **해결 방안:** 두 서버 모두 도커 내부 포트는 `9090`으로 통일하되, 호스트 포트 포워딩을 지워 외부 노출을 차단함. 대신 앞단에 **Nginx(포트 80)**를 배치하여 외부 진입점을 단일화하고, Nginx Upstream 설정을 통해 내부 도커 가상 네트워크 이름(`app-stock-server-1`, `app-stock-server-2`)으로 트래픽을 라우팅함.

---

## ✅ 주요 변경점 (Key Changes)

- **Backend (Spring Boot):**
  - `RealTimeMarketService.java`: `@ConditionalOnProperty` 마스터 스위치 어노테이션 추가
  - `KisRealTimeStockDataAdapter.java`: `@ConditionalOnProperty` 마스터 스위치 어노테이션 추가
  - `MarketAccessService.java`: `@ConditionalOnProperty` 마스터 스위치 어노테이션 추가 (2호기의 불필요한 REST 토큰 중복 발급 및 Rate Limit 차단)

- **Infrastructure (Docker / Nginx):**
  - `docker-compose.yml`: 
    - `app-stock-server-1` (수집 ON, 환경변수 `true`), `app-stock-server-2` (수집 OFF, 환경변수 `false`) 분리 구축
    - 외부 메시지 브로커 및 캐싱용 `Redis` 컨테이너 인프라 추가
    - 리버스 프록시 및 로드밸런싱용 `Nginx` 컨테이너 인프라 추가
  - `nginx.conf`: `upstream backend` 블록 설정을 통한 라운드로빈(Round-Robin) 로드밸런싱 룰 수립

- **Test:**
  - `load-test.js`: k6 차트 조회 부하 테스트 스크립트의 타깃 엔드포인트를 도커 다이렉트 포트(9090)에서 **단일 진입점 로드밸런서(localhost:80)**로 전면 수정

---

## 🖥️ 완료 조건 검증 결과 (Definition of Done)

### 1. 컨테이너 가동 및 서버별 역할 격리 검증
- `docker-compose up` 구동 시 Nginx, Redis 및 2대의 스프링 서버가 정상 에러 없이 기동됨을 확인.
- **1호기 로그:** 부팅 시점 `>>> Market Access 모듈 초기화: 최초 토큰 발급 시도` 정상 호출 및 KIS 실시간 멀티 세션 웹소켓 연결 수립 완료.
- **2호기 로그:** KIS 토큰 발급 및 웹소켓 핸들러 생성이 **단 1바이트의 메모리 풋프린트 없이 완벽히 비활성화(침묵)**된 것을 대조 검증함.

### 2. k6 부하 테스트를 통한 라운드로빈 트래픽 분산 검증
- 수정된 차트 조회 k6 스크립트를 통해 로드밸런서(Port 80)로 대량의 트래픽을 인젝션함.
- `docker compose logs -f` 모니터링 결과, Nginx 문지기를 거친 트래픽이 1호기(노란색)와 2호기(하늘색)로 정확하게 지그재그(교차) 분산 처리되는 것을 멀티 라인 로그 스트림으로 확인 및 최종 합격판정.

```text
assetmind-stock-server-1 | 2026-06-21 ... [http-nio-9090-exec-2] INFO  c.a.s.m.a.c.StockChartController - 차트 조회 요청 진입
assetmind-stock-server-2 | 2026-06-21 ... [http-nio-9090-exec-7] INFO  c.a.s.m.a.c.StockChartController - 차트 조회 요청 진입
assetmind-stock-server-1 | 2026-06-21 ... [http-nio-9090-exec-7] INFO  c.a.s.m.a.c.StockChartController - 차트 조회 요청 진입
assetmind-stock-server-2 | 2026-06-21 ... [http-nio-9090-exec-4] INFO  c.a.s.m.a.c.StockChartController - 차트 조회 요청 진입