### PR TITLE
[QA] 통합 QA 및 문서화

### DIFF
--- a/apps/web/src/components/stock-detail/category-modal.tsx
+++ b/apps/web/src/components/stock-detail/category-modal.tsx
@@ -108,7 +108,7 @@ export const CategoryModal = ({ isOpen, onClose, categoryName, categorySubtitle 
 
 	return (
 		<div onClick={onClose} style={{ position: 'fixed', inset: 0, zIndex: 100, backgroundColor: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-			<div onClick={(e) => e.stopPropagation()} style={{ width: 'min(600px, calc(100vw - 32px))', maxHeight: '90dvh', backgroundColor: PANEL_BG, borderRadius: '16px', overflow: 'hidden', display: 'flex', flexDirection: 'column', position: 'relative' }}>
+			<div onClick={(e) => e.stopPropagation()} style={{ width: 'min(600px, calc(100vw - 32px))', maxHeight: '90dvh', backgroundColor: PANEL_BG, borderRadius: '16px', overflow: 'clip', display: 'flex', flexDirection: 'column', position: 'relative' }}>
 				<button onClick={onClose} style={{ position: 'absolute', top: '16px', right: '16px', zIndex: 10, width: '32px', height: '32px', borderRadius: '50%', backgroundColor: 'rgba(0,0,0,0.3)', border: 'none', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
 					<svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M1 1L13 13M13 1L1 13" stroke="#FFFFFF" strokeWidth="2" strokeLinecap="round"/></svg>
 				</button>


### PR DESCRIPTION
# [QA] 통합 QA 및 문서화

## 📌 1. PR 요약
스프린트 12에서 구현된 REST 스냅샷 전환 로직, 카테고리 모달, 광고 패널에 대해 데스크톱, 태블릿, 모바일 환경의 3단 뷰포트 교차 검증을 진행했습니다. 검증 중 발견된 `CategoryModal` 내부의 스크롤 단절 결함을 수정하고, 스프린트 12 회고 및 문서화를 완료했습니다.

## 🛠 2. 작업 내용
### 3단 뷰포트 검증 및 모바일 모달 스크롤 버그 수정
- **레이아웃 결함 조치**: `CategoryModal` 내부에 많은 데이터가 주입되어 기기 높이를 초과했음에도 불구하고, 모달 내부 영역의 세로 스크롤이 동작하지 않아 하단 콘텐츠(차트 뷰 등)에 접근할 수 없는 현상을 확인했습니다.
- **원인 분석 및 해결**: 모달 내부 스크롤 컨테이너에 `overflowY: 'auto'`가 정상 선언되어 있었으나, 부모 컨테이너에 적용된 `overflow: 'hidden'` 속성이 강력한 스크롤 컨텍스트 차단막으로 작용하여 하위 스크롤 이벤트를 억제하고 있었습니다.
- **스타일 제어 최적화**: `category-modal.tsx` 부모 레이아웃의 속성을 `overflow: 'hidden'`에서 `overflow: 'clip'`으로 변경했습니다. `clip` 속성은 `hidden`과 동일하게 부모 영역 외부로 나가는 콘텐츠를 시각적으로 잘라내지만, 하위 요소의 내부 스크롤 격리 컨텍스트를 방해하지 않으므로 자식 컨테이너의 `overflowY: 'auto'`가 의도대로 정상 작동합니다.

## 📋 3. 파일 변경 목록

| 파일 경로 | 변경 내용 |
| :--- | :--- |
| `apps/web/src/components/stock-detail/category-modal.tsx` | 부모 컨테이너 스타일의 `overflow: 'hidden'` 속성을 내부 스크롤을 보존하는 `overflow: 'clip'`으로 변경 (교체) |

## 💬 4. 리뷰 포인트
- **모달 내부 스크롤 정상화**: 수정된 모달 코드가 콘텐츠가 가득 찬 상황에서 우측에 세로 스크롤바가 정상 노출되며 최하단 차트 영역까지 끊김 없이 탐색이 가능한지 확인 부탁드립니다.
- **부모 뷰포트 영역 제한**: `overflow: 'clip'` 적용 이후에도 모달 창 외부 영역으로 레이아웃이 삐져나가거나 깨지는 현상 없이 `hidden`과 동일하게 박스 모델이 잘 유지되고 있는지 검토해 주세요.